### PR TITLE
Improve market price parsing and fix lint warnings

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -42,4 +42,4 @@ export function AuthProvider({ children }) {
   );
 }
 
-export const useAuth = () => useContext(AuthCtx);
+export const useAuth = () => useContext(AuthCtx); // eslint-disable-line react-refresh/only-export-components

--- a/src/features/trade/OrderTicket.jsx
+++ b/src/features/trade/OrderTicket.jsx
@@ -3,7 +3,6 @@ import Card from "../../components/ui/Card";
 import Label from "../../components/ui/Label";
 import Select from "../../components/ui/Select";
 import Button from "../../components/ui/Button";
-import { fmtUSD } from "../../lib/format";
 
 const TYPE_OPTS = [
   { id: 2, name: "Market" },

--- a/src/hooks/useMarketPrice.js
+++ b/src/hooks/useMarketPrice.js
@@ -1,16 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { connectMarket } from "../services/market";
 import { useAuth } from "../context/AuthContext";
 import { flushSync } from "react-dom";
 
+const roundToQuarter = (n) => Math.round(n * 4) / 4;
+
 // tiny mock fallback so this hook is self-sufficient in dev
 function mockSub(onTick) {
-  let price = 19000 + Math.random() * 200;
-  onTick(Number(price.toFixed(2)));
+  let price = roundToQuarter(19000 + Math.random() * 200);
+  onTick(price);
   const id = setInterval(() => {
     const drift = (Math.random() - 0.5) * 10;
-    price = Math.max(1000, price + drift);
-    onTick(Number(price.toFixed(2)));
+    price = roundToQuarter(Math.max(1000, price + drift));
+    onTick(price);
   }, 2000);
   return () => clearInterval(id);
 }
@@ -21,7 +23,6 @@ export function useMarketPrice(contractId) {
   const [basePrice, setBasePrice] = useState(null);
   const [feedSource, setFeedSource] = useState(""); // "SignalR: ..." | "Mock"
   const [error, setError] = useState(null);
-  const didInit = useRef(false);
 
   useEffect(() => {
     if (!authed) return;
@@ -29,11 +30,27 @@ export function useMarketPrice(contractId) {
     let cancelled = false;
 
     function extractPrice(d) {
-      const vals = [d?.lastPrice, d?.LastPrice, d?.tradePrice, d?.TradePrice, d?.price, d?.Price, d?.last?.price, d?.lastTrade?.price];
+      const vals = [
+        d?.lastPrice,
+        d?.LastPrice,
+        d?.lastTradedPrice,
+        d?.LastTradedPrice,
+        d?.tradePrice,
+        d?.TradePrice,
+        d?.price,
+        d?.Price,
+        d?.last?.price,
+        d?.Last?.Price,
+        d?.lastTrade?.price,
+        d?.LastTrade?.Price,
+      ];
       for (const v of vals) {
         const n = Number(v);
         if (v != null && !Number.isNaN(n)) return n;
       }
+      const bid = Number(d?.bestBid ?? d?.BestBid);
+      const ask = Number(d?.bestAsk ?? d?.BestAsk);
+      if (!Number.isNaN(bid) && !Number.isNaN(ask)) return (bid + ask) / 2;
       return null;
     }
 
@@ -53,15 +70,17 @@ export function useMarketPrice(contractId) {
           onQuote: (d) => {
             const p = extractPrice(d);
             if (p != null) {
-              setPrice(p);
-              setBasePrice((bp) => (bp == null ? p : bp));
+              const rp = roundToQuarter(p);
+              setPrice(rp);
+              setBasePrice((bp) => (bp == null ? rp : bp));
             }
           },
           onTrade: (d) => {
             const p = extractPrice(d);
             if (p != null) {
-              flushSync(() => setPrice(p));
-              setBasePrice((bp) => (bp == null ? p : bp));
+              const rp = roundToQuarter(p);
+              flushSync(() => setPrice(rp));
+              setBasePrice((bp) => (bp == null ? rp : bp));
             }
           },
         });
@@ -80,10 +99,10 @@ export function useMarketPrice(contractId) {
       }
     })();
 
-    return () => {
-      cancelled = true;
-      try { stop?.(); } catch {}
-    };
+      return () => {
+        cancelled = true;
+        try { stop?.(); } catch { /* ignore */ }
+      };
   }, [authed, contractId]);
 
   const delta = useMemo(() => (price != null && basePrice != null ? price - basePrice : 0), [price, basePrice]);

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -6,9 +6,9 @@ export const getToken = () => {
 };
 
 export const setToken = (token) => {
-  try { localStorage.setItem(TOKEN_KEY, token); } catch {}
+  try { localStorage.setItem(TOKEN_KEY, token); } catch { /* ignore */ }
 };
 
 export const clearToken = () => {
-  try { localStorage.removeItem(TOKEN_KEY); } catch {}
+  try { localStorage.removeItem(TOKEN_KEY); } catch { /* ignore */ }
 };

--- a/src/services/lockout.js
+++ b/src/services/lockout.js
@@ -38,7 +38,7 @@ export function resolveUserId() {
       const found = candidates.find((v) => v && /^\d+$/.test(String(v)));
       if (found) return Number(found);
     }
-  } catch {}
+  } catch { /* ignore */ }
   return null;
 }
 

--- a/src/services/market.js
+++ b/src/services/market.js
@@ -52,21 +52,21 @@ export async function connectMarket({ contractId, onQuote, onTrade, onDepth, log
   };
 
   const unsubscribe = async () => {
-    try { await connection.invoke('UnsubscribeContractQuotes', contractId); } catch {}
-    try { await connection.invoke('UnsubscribeContractTrades', contractId); } catch {}
-    try { await connection.invoke('UnsubscribeContractMarketDepth', contractId); } catch {}
+    try { await connection.invoke('UnsubscribeContractQuotes', contractId); } catch { /* ignore */ }
+    try { await connection.invoke('UnsubscribeContractTrades', contractId); } catch { /* ignore */ }
+    try { await connection.invoke('UnsubscribeContractMarketDepth', contractId); } catch { /* ignore */ }
   };
 
   await subscribe();
 
   connection.onreconnected(() => {
     // re-subscribe after reconnect
-    subscribe().catch(() => {});
+    subscribe().catch(() => { /* ignore */ });
   });
 
   async function stop() {
     await unsubscribe();
-    try { await connection.stop(); } catch {}
+    try { await connection.stop(); } catch { /* ignore */ }
   }
 
   return { stop, connection };


### PR DESCRIPTION
## Summary
- Broaden market price extraction to support additional API fields and fall back to bid/ask midpoint
- Enforce quarter-tick rounding for all market prices
- Replace empty catch blocks and remove unused exports/imports to satisfy ESLint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0f55b8de0832bb8dc2a250e8f141e