### PR TITLE
feat: show account pnl and clean position layout

### DIFF
--- a/src/features/dashboard/Dashboard.jsx
+++ b/src/features/dashboard/Dashboard.jsx
@@ -7,6 +7,7 @@ import { useAccounts } from "../../hooks/useAccounts";
 import { useMarketPrice } from "../../hooks/useMarketPrice";
 import { useOrders } from "../../hooks/useOrders";
 import { usePositions } from "../../hooks/usePositions";
+import { useAccountPnl } from "../../hooks/useAccountPnl";
 import LockoutAllButton from "../lockout/LockoutAllButton";
 import LockoutAccountButton from "../lockout/LockoutAccountButton";
 
@@ -49,6 +50,10 @@ export default function Dashboard() {
     pollMs: 3000,
   });
   const { positions, loading: posLoading, close, partialClose } = usePositions({
+    accountId: selectedAccount,
+    pollMs: 5000,
+  });
+  const { unrealized, realized } = useAccountPnl({
     accountId: selectedAccount,
     pollMs: 5000,
   });
@@ -181,6 +186,8 @@ export default function Dashboard() {
           <PositionsCard
             positions={positions}
             loading={posLoading}
+            unrealizedPnl={unrealized}
+            realizedPnl={realized}
             onClose={(cid) =>
               close(cid)
                 .then(() => log(`Closed position ${cid}`))

--- a/src/features/trade/PositionsCard.jsx
+++ b/src/features/trade/PositionsCard.jsx
@@ -1,13 +1,25 @@
 import Card from "../../components/ui/Card";
 import Button from "../../components/ui/Button";
-import Label from "../../components/ui/Label";
+import { fmtUSD } from "../../lib/format";
 
-export default function PositionsCard({ positions, onClose, onPartial, loading }) {
+export default function PositionsCard({
+  positions,
+  onClose,
+  onPartial,
+  loading,
+  unrealizedPnl = 0,
+  realizedPnl = 0,
+}) {
   return (
     <Card className="p-5">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm font-semibold tracking-wide">Open Positions</h2>
         <span className="text-xs text-zinc-400">{loading ? "Loading…" : `${positions.length} open`}</span>
+      </div>
+
+      <div className="flex items-center justify-between mb-3 text-xs text-zinc-400">
+        <span>Unrealized: {fmtUSD(unrealizedPnl)}</span>
+        <span>Realized (today): {fmtUSD(realizedPnl)}</span>
       </div>
 
       <div className="space-y-3">
@@ -20,7 +32,7 @@ export default function PositionsCard({ positions, onClose, onPartial, loading }
             key={p.id}
             className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 flex items-center justify-between"
           >
-            <div className="text-sm flex-1 min-w-0">
+            <div className="text-sm flex-1 min-w-0 flex items-baseline gap-2">
               <div className="font-medium truncate">{p.contractId}</div>
               <div className="text-zinc-400">
                 Size: {p.size} • Avg: {p.averagePrice != null ? p.averagePrice : "—"}

--- a/src/hooks/useAccountPnl.js
+++ b/src/hooks/useAccountPnl.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+import { getAccountPnl } from '../services/pnl';
+
+export function useAccountPnl({ accountId, pollMs = 5000 } = {}) {
+  const [unrealized, setUnrealized] = useState(0);
+  const [realized, setRealized] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const t = useRef(null);
+
+  async function refresh() {
+    if (!accountId) return;
+    setLoading(true);
+    try {
+      const res = await getAccountPnl({ accountId: Number(accountId) });
+      setUnrealized(res.unrealizedPnl);
+      setRealized(res.realizedPnl);
+      setError(null);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!accountId) return;
+    refresh();
+    if (pollMs > 0) {
+      t.current = setInterval(refresh, pollMs);
+      return () => clearInterval(t.current);
+    }
+  }, [accountId, pollMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { unrealized, realized, loading, error, refresh };
+}

--- a/src/services/pnl.js
+++ b/src/services/pnl.js
@@ -1,0 +1,16 @@
+import { apiPost } from './http';
+
+/**
+ * Fetch account PnL summary.
+ * @param {{accountId:number, signal?:AbortSignal}} p
+ * @returns {Promise<{unrealizedPnl:number, realizedPnl:number}>}
+ */
+export async function getAccountPnl({ accountId, signal } = {}) {
+  if (!accountId) throw new Error('accountId is required');
+  const data = await apiPost('/api/Account/getPnl', { accountId }, { signal });
+  if (!data?.success) throw new Error(data?.errorMessage || `PnL fetch failed (code ${data?.errorCode})`);
+  return {
+    unrealizedPnl: data.unrealizedPnl ?? 0,
+    realizedPnl: data.realizedPnl ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary
- display unrealized and daily realized PnL on positions card
- keep contract and size details on one line
- add service & hook to fetch account PnL

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c10002b3d0832b874852d6146d6610