### PR TITLE
Add backend-authoritative automatic candle repair

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -185,10 +185,9 @@ from .services.bot_service import (
     list_market_candles,
     list_bot_configs,
     market_candle_cache_covers_request,
+    market_candle_cache_integrity_report,
     market_candle_cache_needs_refresh,
     market_candle_rows_are_stale,
-    next_market_candle_fetch_start,
-    prune_market_candle_cache_range,
     resolve_market_contract,
     serialize_bot_config,
     serialize_bot_decision,
@@ -1122,11 +1121,11 @@ def get_projectx_market_candles(
     repair: bool = False,
     db: Session = Depends(get_db),
 ):
-    """Serve candles from the per-user cache, fetching from ProjectX when needed.
+    """Serve backend-validated candles, repairing the per-user cache as needed.
 
-    `refresh` forces a full re-fetch and prunes cached rows the provider no longer
-    returns. `repair` also forces a full-window fetch (so interior holes in the
-    cache get backfilled) but merges with existing cache instead of pruning.
+    Integrity repair is automatic. ``repair`` remains a compatibility flag that
+    forces a full-window audit/fetch, while ``refresh`` additionally treats the
+    provider's non-empty response as authoritative for pruning that window.
     """
     user_id = get_authenticated_user_id()
     end_utc = _as_utc(end) if end is not None else datetime.now(timezone.utc)
@@ -1146,11 +1145,21 @@ def get_projectx_market_candles(
             unit=unit,
             unit_number=unit_number,
             limit=limit,
-            include_partial_bar=include_partial_bar,
+            include_partial_bar=True,
         )
-        fallback_candles = cached_candles
-        cached_covers_request = market_candle_cache_covers_request(
+        cached_integrity = market_candle_cache_integrity_report(
             cached_candles,
+            start=start_utc,
+            end=end_utc,
+            unit=unit,
+            unit_number=unit_number,
+            limit=limit,
+            include_partial_bar=include_partial_bar,
+            symbol=requested_symbol,
+        )
+        fallback_candles = list(cached_integrity.valid_rows)
+        cached_covers_request = market_candle_cache_covers_request(
+            list(cached_integrity.valid_rows),
             start=start_utc,
             unit=unit,
             unit_number=unit_number,
@@ -1161,15 +1170,16 @@ def get_projectx_market_candles(
             and not refresh
             and not repair
             and cached_covers_request
+            and cached_integrity.is_complete
             and not market_candle_cache_needs_refresh(
-                cached_candles,
+                list(cached_integrity.valid_rows),
                 end=end_utc,
                 unit=unit,
                 unit_number=unit_number,
                 include_partial_bar=include_partial_bar,
             )
         ):
-            return [serialize_market_candle(row) for row in cached_candles]
+            return [serialize_market_candle(row) for row in cached_integrity.valid_rows]
 
         client = _projectx_client_for_user(db, user_id=user_id)
         resolved_contract_id, resolved_symbol = resolve_market_contract(
@@ -1189,12 +1199,22 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 limit=limit,
-                include_partial_bar=include_partial_bar,
+                include_partial_bar=True,
             )
-            if cached_candles:
-                fallback_candles = cached_candles
-            cached_covers_request = market_candle_cache_covers_request(
+            cached_integrity = market_candle_cache_integrity_report(
                 cached_candles,
+                start=start_utc,
+                end=end_utc,
+                unit=unit,
+                unit_number=unit_number,
+                limit=limit,
+                include_partial_bar=include_partial_bar,
+                symbol=resolved_symbol or requested_symbol,
+            )
+            if cached_integrity.valid_rows:
+                fallback_candles = list(cached_integrity.valid_rows)
+            cached_covers_request = market_candle_cache_covers_request(
+                list(cached_integrity.valid_rows),
                 start=start_utc,
                 unit=unit,
                 unit_number=unit_number,
@@ -1205,28 +1225,18 @@ def get_projectx_market_candles(
                 and not refresh
                 and not repair
                 and cached_covers_request
+                and cached_integrity.is_complete
                 and not market_candle_cache_needs_refresh(
-                    cached_candles,
+                    list(cached_integrity.valid_rows),
                     end=end_utc,
                     unit=unit,
                     unit_number=unit_number,
                     include_partial_bar=include_partial_bar,
                 )
             ):
-                return [serialize_market_candle(row) for row in cached_candles]
+                return [serialize_market_candle(row) for row in cached_integrity.valid_rows]
 
         fetch_start_utc = start_utc
-        # A repair request always fetches the full window so interior cache holes
-        # are refilled; the normal path only extends the cached tail.
-        if cached_candles and not refresh and not repair and cached_covers_request:
-            fetch_start_utc = next_market_candle_fetch_start(
-                cached_candles,
-                start=start_utc,
-                unit=unit,
-                unit_number=unit_number,
-            )
-            if fetch_start_utc > end_utc:
-                return [serialize_market_candle(row) for row in cached_candles]
 
         active_lookup_symbol = requested_symbol or resolved_symbol
         active_contract_fallback_attempted = False
@@ -1259,6 +1269,8 @@ def get_projectx_market_candles(
                 unit_number=unit_number,
                 limit=limit,
                 include_partial_bar=include_partial_bar,
+                force_refresh=refresh,
+                force_full_repair=repair,
             )
 
         if not candles:
@@ -1276,6 +1288,8 @@ def get_projectx_market_candles(
                     unit_number=unit_number,
                     limit=limit,
                     include_partial_bar=include_partial_bar,
+                    force_refresh=refresh,
+                    force_full_repair=repair,
                 )
             except ProjectXClientError:
                 active_contract_fallback_attempted = True
@@ -1294,6 +1308,8 @@ def get_projectx_market_candles(
                         unit_number=unit_number,
                         limit=limit,
                         include_partial_bar=include_partial_bar,
+                        force_refresh=refresh,
+                        force_full_repair=repair,
                     )
                 if not active_candles:
                     raise
@@ -1325,40 +1341,13 @@ def get_projectx_market_candles(
                 unit_number=unit_number,
                 limit=limit,
                 include_partial_bar=include_partial_bar,
+                force_refresh=refresh,
+                force_full_repair=repair,
             )
             if _market_candle_rows_have_newer_tail(active_candles, candles):
                 candles = active_candles
 
-        response_contract_id = str(candles[-1].contract_id) if candles else resolved_contract_id
-        if refresh and not include_partial_bar:
-            prune_contract_id = response_contract_id
-            prune_market_candle_cache_range(
-                db,
-                user_id=user_id,
-                contract_id=prune_contract_id,
-                live=live,
-                start=start_utc,
-                end=end_utc,
-                unit=unit,
-                unit_number=unit_number,
-                keep_timestamps=[row.candle_timestamp for row in candles],
-            )
         db.commit()
-        if cached_candles and not refresh:
-            combined_candles = list_market_candles(
-                db,
-                user_id=user_id,
-                contract_id=response_contract_id,
-                live=live,
-                start=start_utc,
-                end=end_utc,
-                unit=unit,
-                unit_number=unit_number,
-                limit=limit,
-                include_partial_bar=include_partial_bar,
-            )
-            if combined_candles:
-                return [serialize_market_candle(row) for row in combined_candles]
     except ProjectXClientError as exc:
         db.rollback()
         if fallback_candles:
@@ -1403,6 +1392,8 @@ def _fetch_active_symbol_market_candles(
     unit_number: int,
     limit: int,
     include_partial_bar: bool,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
 ) -> list[ProjectXMarketCandle]:
     normalized_symbol = str(lookup_symbol or "").strip()
     if not normalized_symbol or not _looks_like_projectx_contract_id(current_contract_id):
@@ -1441,6 +1432,8 @@ def _fetch_active_symbol_market_candles(
         unit_number=unit_number,
         limit=limit,
         include_partial_bar=include_partial_bar,
+        force_refresh=force_refresh,
+        force_full_repair=force_full_repair,
     )
 
 
@@ -1631,17 +1624,26 @@ def create_trading_bot_backtest(
     payload: BotBacktestIn,
     db: Session = Depends(get_db),
 ):
-    """Replay stored candles without fetching data or invoking any order path."""
+    """Repair stored candles when possible, then replay without any order path."""
 
     user_id = get_authenticated_user_id()
     if bot_config_id <= 0:
         raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
     try:
+        client: ProjectXClient | None = None
+        try:
+            client = _projectx_client_for_user(db, user_id=user_id)
+        except Exception as exc:
+            # A complete local snapshot remains replayable when credentials are
+            # temporarily unavailable. The replay validators still reject bad
+            # or insufficient cached data.
+            logger.warning("Backtest candle repair unavailable; using vetted cache: %s", exc)
         row = create_bot_backtest(
             db,
             user_id=user_id,
             bot_config_id=bot_config_id,
             payload=payload,
+            client=client,
         )
         db.commit()
     except LookupError as exc:
@@ -1656,6 +1658,9 @@ def create_trading_bot_backtest(
     except BacktestError as exc:
         db.rollback()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
     except Exception:
         db.rollback()
         raise

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -36,7 +36,12 @@ from .bot_strategy_registry import (
     BACKTEST_SUPPORTED_STRATEGY_IDENTIFIERS,
     get_strategy_definition,
 )
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    is_expected_futures_candle,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
 BACKTEST_ENGINE_VERSION = "1.1.0"
@@ -1293,11 +1298,11 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            gaps = 0
-            for previous, current in zip(self.execution_candles, self.execution_candles[1:]):
-                delta = (_as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)).total_seconds()
-                if delta > expected_seconds * 1.5:
-                    gaps += 1
+            gaps = _count_futures_session_gaps(
+                self.execution_candles,
+                expected_seconds=expected_seconds,
+                symbol=self.config.symbol,
+            )
             if gaps:
                 self.warnings.append(
                     f"Detected {gaps} candle gap(s); the engine used the next available bar without interpolation."
@@ -1334,14 +1339,10 @@ class BacktestEngine:
                     if _as_utc(row.candle_timestamp) >= self.settings.start
                     and _candle_close_time(row) <= self.settings.end
                 ]
-                gaps = sum(
-                    1
-                    for previous, current in zip(execution_rows, execution_rows[1:])
-                    if (
-                        _as_utc(current.candle_timestamp)
-                        - _as_utc(previous.candle_timestamp)
-                    ).total_seconds()
-                    > expected * 1.5
+                gaps = _count_futures_session_gaps(
+                    execution_rows,
+                    expected_seconds=expected,
+                    symbol=spec.symbol or self.config.symbol,
                 )
                 if gaps:
                     self.warnings.append(
@@ -1899,12 +1900,160 @@ def run_backtest(
     ).run()
 
 
+def _ensure_backtest_candle_integrity(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: Any,
+    start: datetime,
+    end: datetime,
+    primary_warmup_bars: int,
+) -> None:
+    """Repair every stored stream before the pure replay reads its snapshot."""
+
+    primary_unit = str(config.timeframe_unit)
+    primary_unit_number = int(config.timeframe_unit_number)
+    primary_start = _cached_backtest_repair_start(
+        db,
+        user_id=user_id,
+        contract_id=str(config.contract_id),
+        symbol=config.symbol,
+        unit=primary_unit,
+        unit_number=primary_unit_number,
+        start=start,
+        warmup_bars=primary_warmup_bars,
+        minimum_warmup_bars=max(
+            0,
+            _strategy_history_bars(config, hard_minimum=True) - 1,
+        ),
+    )
+    try:
+        bot_service_module.ensure_market_candles(
+            db,
+            user_id=user_id,
+            client=client,
+            contract_id=str(config.contract_id),
+            symbol=config.symbol,
+            live=False,
+            start=primary_start,
+            end=end,
+            unit=primary_unit,
+            unit_number=primary_unit_number,
+            limit=MAX_BACKTEST_BARS,
+            include_partial_bar=False,
+            strict_integrity=True,
+        )
+
+        if str(config.strategy_type) != _TOPBOT_STRATEGY:
+            return
+        primary_key = _topbot_asset_stream_key(primary_unit, primary_unit_number)
+        for key, stream_spec in _topbot_stream_specs(config).items():
+            if key == primary_key:
+                continue
+            identifier = stream_spec.contract_id or stream_spec.symbol
+            if identifier is None:
+                raise InsufficientBacktestDataError(
+                    f"candle_integrity_unresolved:{key}: missing contract or symbol"
+                )
+            stream_start = _cached_backtest_repair_start(
+                db,
+                user_id=user_id,
+                contract_id=stream_spec.contract_id,
+                symbol=stream_spec.symbol,
+                unit=stream_spec.unit,
+                unit_number=stream_spec.unit_number,
+                start=start,
+                warmup_bars=stream_spec.warmup_bars,
+                minimum_warmup_bars=stream_spec.warmup_bars,
+            )
+            bot_service_module.ensure_market_candles(
+                db,
+                user_id=user_id,
+                client=client,
+                contract_id=identifier,
+                symbol=stream_spec.symbol,
+                live=False,
+                start=stream_start,
+                end=end,
+                unit=stream_spec.unit,
+                unit_number=stream_spec.unit_number,
+                limit=min(MAX_TOPBOT_REPLAY_STREAM_BARS, MAX_BACKTEST_BARS),
+                include_partial_bar=False,
+                strict_integrity=True,
+            )
+    except bot_service_module.CandleIntegrityError as exc:
+        raise InsufficientBacktestDataError(str(exc)) from exc
+
+
+def _backtest_repair_start(
+    start: datetime,
+    *,
+    unit: str,
+    unit_number: int,
+    warmup_bars: int,
+) -> datetime:
+    seconds = _timeframe_seconds(unit, unit_number)
+    if seconds is None:
+        seconds = 31 * 24 * 60 * 60 * max(1, int(unit_number))
+    lookback = timedelta(seconds=seconds * max(1, int(warmup_bars)) * 3)
+    if unit in {"second", "minute", "hour"}:
+        lookback = max(lookback, timedelta(days=7))
+    return _as_utc(start) - lookback
+
+
+def _cached_backtest_repair_start(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str | None,
+    symbol: str | None,
+    unit: str,
+    unit_number: int,
+    start: datetime,
+    warmup_bars: int,
+    minimum_warmup_bars: int,
+) -> datetime:
+    query = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.candle_timestamp < start)
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+    )
+    if contract_id is not None:
+        query = query.filter(ProjectXMarketCandle.contract_id == contract_id)
+    elif symbol is not None:
+        query = query.filter(
+            or_(
+                ProjectXMarketCandle.contract_id == symbol,
+                ProjectXMarketCandle.symbol == symbol,
+            )
+        )
+    cached = (
+        query.order_by(ProjectXMarketCandle.candle_timestamp.desc())
+        .limit(max(1, int(warmup_bars)))
+        .all()
+    )
+    if len(cached) >= max(0, int(minimum_warmup_bars)) and cached:
+        return min(_as_utc(row.candle_timestamp) for row in cached)
+    return _backtest_repair_start(
+        start,
+        unit=unit,
+        unit_number=unit_number,
+        warmup_bars=warmup_bars,
+    )
+
+
 def create_bot_backtest(
     db: Session,
     *,
     user_id: str,
     bot_config_id: int,
     payload: Any,
+    client: Any | None = None,
 ) -> BotBacktest:
     config = (
         db.query(BotConfig)
@@ -1933,26 +2082,6 @@ def create_bot_backtest(
             f"instrument_metadata_missing:{symbol_key or config.contract_id}"
         )
 
-    execution_query = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .limit(MAX_BACKTEST_BARS + 1)
-    )
-    execution_rows = execution_query.all()
-    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-    if len(execution_rows) > MAX_BACKTEST_BARS:
-        raise BacktestConfigurationError(
-            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
-        )
-
     rolling_warmup_limit = min(
         MAX_BACKTEST_BARS,
         max(
@@ -1974,6 +2103,38 @@ def create_bot_backtest(
         config,
         rolling_limit=rolling_warmup_limit,
     )
+
+    if client is not None:
+        _ensure_backtest_candle_integrity(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=start,
+            end=end,
+            primary_warmup_bars=warmup_limit,
+        )
+
+    execution_query = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .limit(MAX_BACKTEST_BARS + 1)
+    )
+    execution_rows = execution_query.all()
+    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
+    if len(execution_rows) > MAX_BACKTEST_BARS:
+        raise BacktestConfigurationError(
+            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
+        )
+
     warmup_rows = (
         db.query(ProjectXMarketCandle)
         .filter(ProjectXMarketCandle.user_id == user_id)
@@ -2632,7 +2793,7 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
         "slippage_rule": "configured_ticks_are_applied_adversely_to_every_entry_and_exit_fill",
         "pnl_rule": "price_delta_divided_by_tick_size_times_tick_value_times_quantity",
         "metric_basis": "profit_factor_expectancy_average_win_and_average_loss_use_net_trade_pnl",
-        "market_data": "stored_user_scoped_non_live_closed_candles_only; no_provider_fetch",
+        "market_data": "backend_repaired_user_scoped_non_live_closed_candles; replay_has_no_provider_access",
         "live_order_routing": "disabled_by_architecture",
         "timezone": str(getattr(TRADING_TZ, "key", "America/New_York")),
         "commission_per_contract": _clean(settings.commission_per_contract),
@@ -2647,6 +2808,41 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
 def _timeframe_seconds(unit: str, unit_number: int) -> int | None:
     seconds = _UNIT_SECONDS.get(unit)
     return seconds * unit_number if seconds is not None else None
+
+
+def _range_contains_expected_futures_gap(
+    previous_timestamp: datetime,
+    current_timestamp: datetime,
+    *,
+    expected_seconds: int,
+    symbol: str | None,
+) -> bool:
+    interval = timedelta(seconds=max(1, int(expected_seconds)))
+    missing_start = _as_utc(previous_timestamp) + interval
+    missing_end = _as_utc(current_timestamp)
+    return missing_start < missing_end and is_expected_futures_candle(
+        missing_start,
+        missing_end,
+        symbol=symbol,
+    )
+
+
+def _count_futures_session_gaps(
+    candles: list[ProjectXMarketCandle],
+    *,
+    expected_seconds: int,
+    symbol: str | None,
+) -> int:
+    return sum(
+        1
+        for previous, current in zip(candles, candles[1:])
+        if _range_contains_expected_futures_gap(
+            _as_utc(previous.candle_timestamp),
+            _as_utc(current.candle_timestamp),
+            expected_seconds=expected_seconds,
+            symbol=symbol or getattr(previous, "symbol", None),
+        )
+    )
 
 
 def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
@@ -2711,7 +2907,12 @@ def _require_complete_session_prefix(
         delta = (
             _as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)
         ).total_seconds()
-        if delta != expected_interval_seconds:
+        if delta != expected_interval_seconds and _range_contains_expected_futures_gap(
+            _as_utc(previous.candle_timestamp),
+            _as_utc(current.candle_timestamp),
+            expected_seconds=expected_interval_seconds,
+            symbol=getattr(previous, "symbol", None),
+        ):
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: incomplete_session_history: "
                 f"{strategy_type} has a missing session candle after "

--- a/backend/app/services/bot_candle_acquisition.py
+++ b/backend/app/services/bot_candle_acquisition.py
@@ -46,6 +46,44 @@ def _service() -> Any:
     return import_module(".bot_service", package=__package__)
 
 
+def _canonical_candles(service: Any, candles: list[Any]) -> list[Any]:
+    """Defense-in-depth before any strategy consumes an acquired stream."""
+
+    # Registry adapter tests intentionally use opaque sentinels to assert
+    # argument identity. Real acquisition rows are always candle models.
+    if candles and all(not hasattr(row, "candle_timestamp") for row in candles):
+        return candles
+    closed = [row for row in candles if not bool(getattr(row, "is_partial", False))]
+    closed.sort(key=lambda row: service._as_utc(row.candle_timestamp))
+    seen: set[Any] = set()
+    previous_close = None
+    for row in closed:
+        timestamp = service._as_utc(row.candle_timestamp)
+        if timestamp in seen:
+            raise service.CandleIntegrityError(
+                f"duplicate_candle_timestamp:{timestamp.isoformat()}"
+            )
+        seen.add(timestamp)
+        if service.validate_candle_ohlcv(row) is not None:
+            raise service.CandleIntegrityError(
+                f"invalid_candle_ohlc:{timestamp.isoformat()}"
+            )
+        if previous_close is not None and timestamp < previous_close:
+            raise service.CandleIntegrityError(
+                f"overlapping_candles:{timestamp.isoformat()}"
+            )
+        previous_close = service.integrity_candle_close_time(
+            timestamp,
+            unit=str(row.unit),
+            unit_number=int(row.unit_number),
+        )
+    return closed
+
+
+def _canonical_candle_sets(service: Any, candle_sets: dict[str, list[Any]]) -> dict[str, list[Any]]:
+    return {key: _canonical_candles(service, rows) for key, rows in candle_sets.items()}
+
+
 def acquire_and_evaluate_strategy(
     db: Any,
     *,
@@ -74,6 +112,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         candles = candle_sets.get("1m", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -91,6 +130,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -110,6 +150,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -126,6 +167,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         return candles, service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -141,6 +183,7 @@ def acquire_and_evaluate_strategy(
             strategy_type=strategy_type,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         signal_candles = candle_sets.get("1H", [])
         evaluator_args: dict[str, Any] = {
             "higher_timeframe_candles": candle_sets.get("4H", []),
@@ -163,6 +206,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         signal_candles = candle_sets.get("signal", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -180,6 +224,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         structure_candles = candle_sets.get("structure", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -190,7 +235,10 @@ def acquire_and_evaluate_strategy(
         return structure_candles, signal
 
     if strategy_type == "atr_adjusted_relative_strength":
-        candles = service.fetch_and_store_candles(db, user_id=user_id, config=config, client=client)
+        candles = _canonical_candles(
+            service,
+            service.fetch_and_store_candles(db, user_id=user_id, config=config, client=client),
+        )
         benchmark_candles = service.fetch_and_store_relative_strength_benchmark_candles(
             db,
             user_id=user_id,
@@ -198,6 +246,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        benchmark_candles = _canonical_candles(service, benchmark_candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -215,6 +264,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         asset_candles = candle_sets.get("5m", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -238,6 +288,7 @@ def acquire_and_evaluate_strategy(
         client=client,
         minimum_lookback_bars=minimum_lookback_bars,
     )
+    candles = _canonical_candles(service, candles)
 
     if strategy_type == "donchian_breakout":
         latest_candle = candles[-1] if candles else None
@@ -289,6 +340,7 @@ def _acquire_and_evaluate_topbot(
         client=client,
         minimum_lookback_bars=300,
     )
+    main_candles = _canonical_candles(service, main_candles)
     source_overrides = strategy_params.get("source_strategy_params") or {}
     source_results: list[dict[str, Any]] = []
 

--- a/backend/app/services/bot_market_analysis.py
+++ b/backend/app/services/bot_market_analysis.py
@@ -5,6 +5,8 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Iterable, Sequence
 from zoneinfo import ZoneInfo
 
+from .trading_day import is_expected_futures_candle
+
 
 ANALYSIS_VERSION = "market_analysis_v2"
 PROBABILITY_METHOD = "heuristic_scenario_weight"
@@ -523,7 +525,10 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
         missing = sum(
             1
             for index in range(1, raw_missing + 1)
-            if _is_futures_session_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
+            if is_expected_futures_candle(
+                previous["timestamp"] + timedelta(seconds=interval_seconds * index),
+                previous["timestamp"] + timedelta(seconds=interval_seconds * (index + 1)),
+            )
         )
         if missing <= 0:
             continue
@@ -535,22 +540,6 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
             }
         )
     return gaps[:20]
-
-
-def _is_futures_session_open(timestamp: datetime) -> bool:
-    local = timestamp.astimezone(_NEW_YORK)
-    weekday = local.weekday()
-    local_time = local.time()
-    if weekday == 5:
-        return False
-    if weekday == 6 and local_time < time(18, 0):
-        return False
-    if weekday == 4 and local_time >= time(17, 0):
-        return False
-    if time(17, 0) <= local_time < time(18, 0):
-        return False
-    return True
-
 
 def _true_ranges(rows: list[dict[str, Any]]) -> list[float]:
     output: list[float] = []

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, time, timedelta, timezone
 from numbers import Number
 from typing import Any, Iterable
 
-from sqlalchemy import func, or_
+from sqlalchemy import case, func, or_
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -41,6 +41,19 @@ from .bot_execution_safety import (
 )
 from .projectx_accounts import get_projectx_account_row
 from .projectx_client import ProjectXClient, ProjectXClientError
+from .candle_integrity import (
+    CandleIntegrityReport,
+    CandleRepairRange,
+    audit_candle_rows,
+    candle_close_time as integrity_candle_close_time,
+    candle_interval,
+    clear_failed_repair,
+    normalize_provider_bars,
+    note_failed_repair,
+    repair_request_in_cooldown,
+    retrieve_bars_singleflight,
+    validate_candle_ohlcv,
+)
 from .bot_strategy_registry import (
     SUPPORTED_STRATEGY_IDENTIFIERS,
     dispatch_strategy_evaluator,
@@ -72,6 +85,8 @@ _UNIT_SECONDS_BY_NAME = {
 }
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
+_MARKET_CANDLE_PROVIDER_LIMIT = 20_000
+_MARKET_CANDLE_INTEGRITY_QUERY_PADDING = 64
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -505,6 +520,10 @@ class BotRunEvaluationError(RuntimeError):
         self.cause = cause
         self.run = run
         self.correlation_id = correlation_id
+
+
+class CandleIntegrityError(RuntimeError):
+    """A strict consumer could not obtain a complete authoritative candle stream."""
 
 
 def list_bot_configs(
@@ -1326,25 +1345,20 @@ def fetch_and_store_fvg_sweep_mss_candles(
         unit_seconds = _UNIT_SECONDS_BY_NAME[unit]
         lookback_seconds = unit_seconds * unit_number * limit * 3
         start = now - timedelta(seconds=max(lookback_seconds, unit_seconds * unit_number * 25))
-        bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME[unit],
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=False,
-        )
-        candle_sets[key] = store_market_candles(
+        candle_sets[key] = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=start,
+            end=now,
             unit=unit,
             unit_number=unit_number,
-            bars=bars,
+            limit=limit,
+            include_partial_bar=False,
+            preserve_cached_history=True,
         )
 
     return candle_sets
@@ -1519,25 +1533,20 @@ def fetch_and_store_support_resistance_candles(
         unit_seconds = _UNIT_SECONDS_BY_NAME[unit]
         lookback_seconds = unit_seconds * unit_number * bars_per_timeframe * 3
         start = now - timedelta(seconds=lookback_seconds)
-        bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME[unit],
-            unit_number=unit_number,
-            limit=bars_per_timeframe,
-            include_partial_bar=False,
-        )
-        candle_sets[label] = store_market_candles(
+        candle_sets[label] = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=start,
+            end=now,
             unit=unit,
             unit_number=unit_number,
-            bars=bars,
+            limit=bars_per_timeframe,
+            include_partial_bar=False,
+            preserve_cached_history=True,
         )
 
     return candle_sets
@@ -1567,51 +1576,43 @@ def fetch_and_store_supertrend_pivot_candles(
     signal_unit_seconds = _UNIT_SECONDS_BY_NAME[signal_unit]
     signal_lookback_seconds = signal_unit_seconds * signal_unit_number * lookback_bars * 3
     signal_start = now - timedelta(seconds=signal_lookback_seconds)
-    signal_bars = client.retrieve_bars(
+    signal_candles = fetch_and_store_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
         contract_id=contract_id,
+        symbol=symbol,
         live=False,
         start=signal_start,
         end=now,
-        unit=_PROJECTX_UNIT_BY_NAME[signal_unit],
+        unit=signal_unit,
         unit_number=signal_unit_number,
         limit=lookback_bars,
         include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
     daily_lookback_seconds = _UNIT_SECONDS_BY_NAME["day"] * daily_bars * 3
     daily_start = now - timedelta(seconds=daily_lookback_seconds)
-    daily_bars_payload = client.retrieve_bars(
+    daily_candles = fetch_and_store_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
         contract_id=contract_id,
+        symbol=symbol,
         live=False,
         start=daily_start,
         end=now,
-        unit=_PROJECTX_UNIT_BY_NAME["day"],
+        unit="day",
         unit_number=1,
         limit=daily_bars,
         include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
     return {
-        "signal": store_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=contract_id,
-            symbol=symbol,
-            live=False,
-            unit=signal_unit,
-            unit_number=signal_unit_number,
-            bars=signal_bars,
-        ),
-        "1D": store_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=contract_id,
-            symbol=symbol,
-            live=False,
-            unit="day",
-            unit_number=1,
-            bars=daily_bars_payload,
-        ),
+        "signal": signal_candles,
+        "1D": daily_candles,
     }
 
 
@@ -1634,32 +1635,28 @@ def fetch_and_store_delayed_orb_candles(
         symbol=config.symbol,
         live=False,
     )
-    intraday_bars: list[dict[str, Any]] = []
+    intraday_candles: list[ProjectXMarketCandle] = []
     if session_start <= now:
         minimum_required_bars = opening_range_minutes + confirmation_minutes + 5
         minutes_since_session_start = max(0, int((now - session_start).total_seconds() // 60) + 1)
         limit = max(minimum_required_bars, minutes_since_session_start + 5)
-        intraday_bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=session_start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME["minute"],
-            unit_number=1,
-            limit=limit,
-            include_partial_bar=False,
-        )
-    return {
-        "1m": store_market_candles(
+        intraday_candles = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=session_start,
+            end=now,
             unit="minute",
             unit_number=1,
-            bars=intraday_bars,
-        ),
+            limit=limit,
+            include_partial_bar=False,
+            preserve_cached_history=True,
+        )
+    return {
+        "1m": intraday_candles,
         "1D": [],
     }
 
@@ -1693,25 +1690,20 @@ def fetch_and_store_orb_fibonacci_candles(
         symbol=config.symbol,
         live=False,
     )
-    bars = client.retrieve_bars(
-        contract_id=contract_id,
-        live=False,
-        start=session_start,
-        end=now,
-        unit=_PROJECTX_UNIT_BY_NAME["minute"],
-        unit_number=unit_number,
-        limit=limit,
-        include_partial_bar=False,
-    )
-    return store_market_candles(
+    return fetch_and_store_market_candles(
         db,
         user_id=user_id,
+        client=client,
         contract_id=contract_id,
         symbol=symbol,
         live=False,
+        start=session_start,
+        end=now,
         unit="minute",
         unit_number=unit_number,
-        bars=bars,
+        limit=limit,
+        include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
 
@@ -1731,12 +1723,65 @@ def fetch_and_store_market_candles(
     include_partial_bar: bool = False,
     prefer_current_contract: bool = False,
     preserve_cached_history: bool = False,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
+    strict_integrity: bool = False,
 ) -> list[ProjectXMarketCandle]:
+    return ensure_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
+        contract_id=contract_id,
+        symbol=symbol,
+        live=live,
+        start=start,
+        end=end,
+        unit=unit,
+        unit_number=unit_number,
+        limit=limit,
+        include_partial_bar=include_partial_bar,
+        prefer_current_contract=prefer_current_contract,
+        force_refresh=force_refresh,
+        force_full_repair=force_full_repair,
+        strict_integrity=strict_integrity,
+    )
+
+
+def ensure_market_candles(
+    db: Session,
+    *,
+    user_id: str,
+    client: ProjectXClient,
+    contract_id: str,
+    symbol: str | None,
+    live: bool,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool = False,
+    prefer_current_contract: bool = False,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
+    strict_integrity: bool = False,
+) -> list[ProjectXMarketCandle]:
+    """Return canonical cached candles after one bounded authoritative repair pass.
+
+    Provider bars are the only source of replacements. Missing slots are never
+    synthesized, and a usable vetted cache remains available when ProjectX is
+    temporarily unavailable.
+    """
+
     normalized_unit = str(unit).strip().lower()
     if normalized_unit not in _PROJECTX_UNIT_BY_NAME:
         raise ValueError("unsupported candle unit")
-    if start > end:
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if start_utc > end_utc:
         raise ValueError("start must be before end")
+    normalized_unit_number = max(1, int(unit_number))
+    normalized_limit = max(1, min(int(limit), _MARKET_CANDLE_PROVIDER_LIMIT))
     resolver = resolve_current_market_contract if prefer_current_contract else resolve_market_contract
     resolved_contract_id, resolved_symbol = resolver(
         client,
@@ -1744,69 +1789,385 @@ def fetch_and_store_market_candles(
         symbol=symbol,
         live=live,
     )
-    cached = (
-        list_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=resolved_contract_id,
-            live=live,
-            start=start,
-            end=end,
-            unit=normalized_unit,
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=include_partial_bar,
-        )
-        if preserve_cached_history
-        else []
-    )
-    try:
-        bars = client.retrieve_bars(
-            contract_id=resolved_contract_id,
-            live=live,
-            start=start,
-            end=end,
-            unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=include_partial_bar,
-        )
-    except ProjectXClientError:
-        if cached:
-            return cached
-        raise
-    stored = store_market_candles(
-        db,
-        user_id=user_id,
-        contract_id=resolved_contract_id,
-        symbol=resolved_symbol,
-        live=live,
-        unit=normalized_unit,
-        unit_number=unit_number,
-        bars=bars,
-    )
-    if not preserve_cached_history:
-        return stored
 
-    combined = list_market_candles(
+    cached = _list_market_candles_for_integrity(
         db,
         user_id=user_id,
         contract_id=resolved_contract_id,
         live=live,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+    )
+    report = audit_candle_rows(
+        cached,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+        include_partial_bar=include_partial_bar,
+        symbol=resolved_symbol or symbol,
+    )
+
+    if force_refresh or force_full_repair or not cached:
+        repair_ranges = [
+            CandleRepairRange(
+                start=start_utc,
+                end=end_utc,
+                reasons=("refresh" if force_refresh else "full_repair",),
+            )
+        ]
+    else:
+        repair_ranges = list(report.repair_ranges)
+        interval = candle_interval(unit=normalized_unit, unit_number=normalized_unit_number)
+        near_live_tail = interval is not None and end_utc >= datetime.now(timezone.utc) - interval * 2
+        if (
+            not repair_ranges
+            and near_live_tail
+            and report.valid_rows
+            and _market_candle_tail_revalidation_due(list(report.valid_rows))
+        ):
+            fetch_start = next_market_candle_fetch_start(
+                list(report.valid_rows),
+                start=start_utc,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+            )
+            repair_ranges = [
+                CandleRepairRange(
+                    start=fetch_start,
+                    end=end_utc,
+                    reasons=("tail_revalidation",),
+                )
+            ]
+
+    repair_ranges = _pad_and_coalesce_market_repair_ranges(
+        repair_ranges,
+        start=start_utc,
+        end=end_utc,
+        interval=candle_interval(unit=normalized_unit, unit_number=normalized_unit_number),
+    )
+
+    last_provider_error: ProjectXClientError | None = None
+    for repair_range in repair_ranges:
+        request_limit = _market_candle_repair_limit(
+            repair_range,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            requested_limit=normalized_limit,
+            full_window=repair_range.start == start_utc and repair_range.end == end_utc,
+        )
+        request_key = _market_candle_request_key(
+            user_id=user_id,
+            client=client,
+            contract_id=resolved_contract_id,
+            live=live,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            start=repair_range.start,
+            end=repair_range.end,
+            limit=request_limit,
+            include_partial_bar=include_partial_bar,
+        )
+        if repair_request_in_cooldown(request_key):
+            continue
+
+        try:
+            raw_bars = retrieve_bars_singleflight(
+                key=request_key,
+                retrieve=lambda repair_range=repair_range, request_limit=request_limit: client.retrieve_bars(
+                    contract_id=resolved_contract_id,
+                    live=live,
+                    start=repair_range.start,
+                    end=repair_range.end,
+                    unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
+                    unit_number=normalized_unit_number,
+                    limit=request_limit,
+                    include_partial_bar=include_partial_bar,
+                ),
+            )
+        except ProjectXClientError as exc:
+            last_provider_error = exc
+            note_failed_repair(request_key)
+            continue
+
+        normalized_bars = normalize_provider_bars(
+            raw_bars,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            request_start=repair_range.start,
+            request_end=repair_range.end,
+            include_partial_bar=include_partial_bar,
+        )
+        if raw_bars and not normalized_bars:
+            note_failed_repair(request_key)
+            continue
+
+        authoritative_timestamps = {
+            _as_utc(bar["timestamp"])
+            for bar in normalized_bars
+        }
+        _delete_repaired_duplicate_candle_rows(
+            db,
+            report=report,
+            repair_range=repair_range,
+        )
+        db.flush()
+        if normalized_bars:
+            store_market_candles(
+                db,
+                user_id=user_id,
+                contract_id=resolved_contract_id,
+                symbol=resolved_symbol,
+                live=live,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+                bars=normalized_bars,
+            )
+            clear_failed_repair(request_key)
+        else:
+            note_failed_repair(request_key)
+
+        _delete_repaired_bad_candle_rows(
+            db,
+            report=report,
+            repair_range=repair_range,
+            authoritative_timestamps=authoritative_timestamps,
+        )
+        if force_refresh and normalized_bars:
+            prune_market_candle_cache_range(
+                db,
+                user_id=user_id,
+                contract_id=resolved_contract_id,
+                live=live,
+                start=repair_range.start,
+                end=repair_range.end,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+                keep_timestamps=authoritative_timestamps,
+            )
+
+    db.flush()
+    final_rows = _list_market_candles_for_integrity(
+        db,
+        user_id=user_id,
+        contract_id=resolved_contract_id,
+        live=live,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+    )
+    final_report = audit_candle_rows(
+        final_rows,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+        include_partial_bar=include_partial_bar,
+        symbol=resolved_symbol or symbol,
+    )
+    vetted_rows = list(final_report.valid_rows)
+    if strict_integrity and not final_report.is_complete:
+        raise CandleIntegrityError(
+            "candle_integrity_unresolved:" + ",".join(final_report.issue_codes)
+        )
+    if not vetted_rows and last_provider_error is not None:
+        raise last_provider_error
+    return vetted_rows
+
+
+def market_candle_cache_integrity_report(
+    cached_candles: list[ProjectXMarketCandle],
+    *,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool = False,
+    symbol: str | None = None,
+) -> CandleIntegrityReport:
+    return audit_candle_rows(
+        cached_candles,
         start=start,
         end=end,
-        unit=normalized_unit,
+        unit=unit,
         unit_number=unit_number,
         limit=limit,
         include_partial_bar=include_partial_bar,
+        symbol=symbol,
     )
-    by_timestamp = {
-        _as_utc(row.candle_timestamp): row
-        for row in [*cached, *combined, *stored]
-        if include_partial_bar or not bool(row.is_partial)
+
+
+def _list_market_candles_for_integrity(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    live: bool,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+) -> list[ProjectXMarketCandle]:
+    audit_limit = min(
+        _MARKET_CANDLE_PROVIDER_LIMIT,
+        max(limit + _MARKET_CANDLE_INTEGRITY_QUERY_PADDING, limit * 2),
+    )
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == contract_id)
+        .filter(ProjectXMarketCandle.live == bool(live))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.desc())
+        .limit(audit_limit)
+        .all()
+    )
+    rows.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    return rows
+
+
+def _market_candle_repair_limit(
+    repair_range: CandleRepairRange,
+    *,
+    unit: str,
+    unit_number: int,
+    requested_limit: int,
+    full_window: bool,
+) -> int:
+    if full_window:
+        return max(1, min(requested_limit, _MARKET_CANDLE_PROVIDER_LIMIT))
+    interval = candle_interval(unit=unit, unit_number=unit_number)
+    if interval is None:
+        return max(1, min(requested_limit, _MARKET_CANDLE_PROVIDER_LIMIT))
+    slots = max(1, math.ceil((repair_range.end - repair_range.start) / interval))
+    return min(_MARKET_CANDLE_PROVIDER_LIMIT, max(5, slots + 2))
+
+
+def _market_candle_request_key(
+    *,
+    user_id: str,
+    client: ProjectXClient,
+    contract_id: str,
+    live: bool,
+    unit: str,
+    unit_number: int,
+    start: datetime,
+    end: datetime,
+    limit: int,
+    include_partial_bar: bool,
+) -> tuple[Any, ...]:
+    return (
+        "projectx_market_candles",
+        str(user_id),
+        _market_candle_client_identity(client),
+        str(contract_id),
+        bool(live),
+        str(unit),
+        int(unit_number),
+        _as_utc(start).isoformat(),
+        _as_utc(end).isoformat(),
+        int(limit),
+        bool(include_partial_bar),
+    )
+
+
+def _market_candle_client_identity(client: ProjectXClient) -> tuple[str, str]:
+    base_url = str(getattr(client, "base_url", "") or "")
+    username = str(getattr(client, "username", "") or "")
+    if base_url or username:
+        return base_url, username
+    client_type = type(client)
+    return client_type.__module__, client_type.__qualname__
+
+
+def _pad_and_coalesce_market_repair_ranges(
+    ranges: list[CandleRepairRange],
+    *,
+    start: datetime,
+    end: datetime,
+    interval: timedelta | None,
+) -> list[CandleRepairRange]:
+    if not ranges:
+        return []
+    padding = (interval * _MARKET_CANDLE_TAIL_REVALIDATION_BARS) if interval else timedelta(0)
+    padded = [
+        CandleRepairRange(
+            start=max(start, item.start - padding),
+            end=min(end, item.end + padding),
+            reasons=item.reasons,
+        )
+        for item in ranges
+    ]
+    merged: list[CandleRepairRange] = []
+    for item in sorted(padded, key=lambda value: (value.start, value.end)):
+        if not merged or item.start > merged[-1].end:
+            merged.append(item)
+            continue
+        previous = merged[-1]
+        merged[-1] = CandleRepairRange(
+            start=previous.start,
+            end=max(previous.end, item.end),
+            reasons=tuple(sorted(set((*previous.reasons, *item.reasons)))),
+        )
+    return merged
+
+
+def _delete_repaired_bad_candle_rows(
+    db: Session,
+    *,
+    report: CandleIntegrityReport,
+    repair_range: CandleRepairRange,
+    authoritative_timestamps: set[datetime],
+) -> None:
+    deleted_ids: set[int] = set()
+    duplicate_ids = {
+        int(row.id)
+        for row in report.duplicate_rows
+        if getattr(row, "id", None) is not None
     }
-    ordered = [by_timestamp[timestamp] for timestamp in sorted(by_timestamp)]
-    return ordered[-max(1, int(limit)):]
+    for row in report.bad_rows:
+        row_id = getattr(row, "id", None)
+        timestamp = getattr(row, "candle_timestamp", None)
+        if row_id is None or not isinstance(timestamp, datetime):
+            continue
+        if int(row_id) in duplicate_ids:
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if not (repair_range.start <= timestamp_utc <= repair_range.end):
+            continue
+        if int(row_id) in deleted_ids:
+            continue
+        if timestamp_utc in authoritative_timestamps:
+            continue
+        deleted_ids.add(int(row_id))
+        db.delete(row)
+
+
+def _delete_repaired_duplicate_candle_rows(
+    db: Session,
+    *,
+    report: CandleIntegrityReport,
+    repair_range: CandleRepairRange,
+) -> None:
+    for row in report.duplicate_rows:
+        timestamp = getattr(row, "candle_timestamp", None)
+        if getattr(row, "id", None) is None or not isinstance(timestamp, datetime):
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if repair_range.start <= timestamp_utc <= repair_range.end:
+            db.delete(row)
 
 
 def list_market_candles(
@@ -2141,12 +2502,17 @@ def store_market_candles(
                 candle_timestamp=timestamp,
             )
             db.add(row)
+        elif not bool(row.is_partial) and bool(bar.get("is_partial")):
+            # A late or racing partial response can never regress a bar that
+            # has already been observed as authoritatively closed.
+            output.append(row)
+            continue
         row.symbol = symbol
-        row.open_price = float(bar.get("open") or 0.0)
-        row.high_price = float(bar.get("high") or 0.0)
-        row.low_price = float(bar.get("low") or 0.0)
-        row.close_price = float(bar.get("close") or 0.0)
-        row.volume = float(bar.get("volume") or 0.0)
+        row.open_price = float(bar["open"])
+        row.high_price = float(bar["high"])
+        row.low_price = float(bar["low"])
+        row.close_price = float(bar["close"])
+        row.volume = float(bar["volume"])
         row.is_partial = bool(bar.get("is_partial") or False)
         row.raw_payload = bar.get("raw_payload")
         row.fetched_at = fetched_at
@@ -2166,8 +2532,29 @@ def _dedupe_market_candle_bars(bars: Iterable[dict[str, Any]]) -> list[dict[str,
         if not isinstance(timestamp, datetime):
             continue
         timestamp_utc = _as_utc(timestamp)
-        by_timestamp[timestamp_utc] = {**bar, "timestamp": timestamp_utc}
+        candidate = {
+            **bar,
+            "timestamp": timestamp_utc,
+            "volume": bar.get("volume", 0.0),
+            "is_partial": bool(bar.get("is_partial")),
+        }
+        if validate_candle_ohlcv(candidate) is not None:
+            continue
+        existing = by_timestamp.get(timestamp_utc)
+        if existing is None or _provider_candle_rank(candidate) >= _provider_candle_rank(existing):
+            by_timestamp[timestamp_utc] = candidate
     return [by_timestamp[timestamp] for timestamp in sorted(by_timestamp)]
+
+
+def _provider_candle_rank(bar: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        int(not bool(bar.get("is_partial"))),
+        float(bar["open"]),
+        float(bar["high"]),
+        float(bar["low"]),
+        float(bar["close"]),
+        float(bar["volume"]),
+    )
 
 
 def _session_dialect_name(db: Session) -> str:
@@ -2194,11 +2581,11 @@ def _market_candle_insert_values(
         "unit": unit,
         "unit_number": unit_number,
         "candle_timestamp": bar["timestamp"],
-        "open_price": float(bar.get("open") or 0.0),
-        "high_price": float(bar.get("high") or 0.0),
-        "low_price": float(bar.get("low") or 0.0),
-        "close_price": float(bar.get("close") or 0.0),
-        "volume": float(bar.get("volume") or 0.0),
+        "open_price": float(bar["open"]),
+        "high_price": float(bar["high"]),
+        "low_price": float(bar["low"]),
+        "close_price": float(bar["close"]),
+        "volume": float(bar["volume"]),
         "is_partial": bool(bar.get("is_partial") or False),
         "raw_payload": bar.get("raw_payload"),
         "fetched_at": fetched_at,
@@ -2212,6 +2599,7 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
     table = ProjectXMarketCandle.__table__
     insert_stmt = postgresql_insert(table).values(values)
     excluded = insert_stmt.excluded
+    preserve_closed = table.c.is_partial.is_(False) & excluded.is_partial.is_(True)
     db.execute(
         insert_stmt.on_conflict_do_update(
             index_elements=[
@@ -2223,15 +2611,15 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
                 table.c.candle_timestamp,
             ],
             set_={
-                "symbol": excluded.symbol,
-                "open_price": excluded.open_price,
-                "high_price": excluded.high_price,
-                "low_price": excluded.low_price,
-                "close_price": excluded.close_price,
-                "volume": excluded.volume,
-                "is_partial": excluded.is_partial,
-                "raw_payload": excluded.raw_payload,
-                "fetched_at": excluded.fetched_at,
+                "symbol": case((preserve_closed, table.c.symbol), else_=excluded.symbol),
+                "open_price": case((preserve_closed, table.c.open_price), else_=excluded.open_price),
+                "high_price": case((preserve_closed, table.c.high_price), else_=excluded.high_price),
+                "low_price": case((preserve_closed, table.c.low_price), else_=excluded.low_price),
+                "close_price": case((preserve_closed, table.c.close_price), else_=excluded.close_price),
+                "volume": case((preserve_closed, table.c.volume), else_=excluded.volume),
+                "is_partial": case((preserve_closed, table.c.is_partial), else_=excluded.is_partial),
+                "raw_payload": case((preserve_closed, table.c.raw_payload), else_=excluded.raw_payload),
+                "fetched_at": case((preserve_closed, table.c.fetched_at), else_=excluded.fetched_at),
             },
         )
     )

--- a/backend/app/services/candle_integrity.py
+++ b/backend/app/services/candle_integrity.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import Event, Lock
+from typing import Any, Callable
+
+from .projectx_client import ProjectXClientError
+from .trading_day import is_expected_futures_candle
+
+
+_CANDLE_CLOSE_GRACE = timedelta(seconds=2)
+_MAX_AUDIT_SLOTS = 25_000
+_MAX_REPAIR_WINDOWS = 8
+_PROVIDER_ATTEMPTS = 3
+_PROVIDER_RETRY_DELAYS = (0.0, 0.05, 0.15)
+_SINGLEFLIGHT_WAIT_SECONDS = 30.0
+_FAILED_REPAIR_COOLDOWN = timedelta(seconds=5)
+
+_UNIT_SECONDS = {
+    "second": 1,
+    "minute": 60,
+    "hour": 60 * 60,
+    "day": 24 * 60 * 60,
+    "week": 7 * 24 * 60 * 60,
+}
+
+
+@dataclass(frozen=True)
+class CandleRepairRange:
+    start: datetime
+    end: datetime
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CandleIntegrityReport:
+    valid_rows: tuple[Any, ...]
+    invalid_rows: tuple[Any, ...]
+    stale_partial_rows: tuple[Any, ...]
+    current_partial_rows: tuple[Any, ...]
+    duplicate_rows: tuple[Any, ...]
+    overlapping_rows: tuple[Any, ...]
+    missing_ranges: tuple[CandleRepairRange, ...]
+    repair_ranges: tuple[CandleRepairRange, ...]
+    issue_codes: tuple[str, ...]
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.issue_codes
+
+    @property
+    def bad_rows(self) -> tuple[Any, ...]:
+        rows: list[Any] = []
+        seen: set[int] = set()
+        for row in (
+            *self.invalid_rows,
+            *self.stale_partial_rows,
+            *self.duplicate_rows,
+            *self.overlapping_rows,
+        ):
+            marker = id(row)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            rows.append(row)
+        return tuple(rows)
+
+
+@dataclass
+class _ProviderFlight:
+    event: Event
+    result: list[dict[str, Any]] | None = None
+    error: Exception | None = None
+
+
+_FLIGHT_GUARD = Lock()
+_ACTIVE_FLIGHTS: dict[tuple[Any, ...], _ProviderFlight] = {}
+_FAILED_REPAIR_UNTIL: dict[tuple[Any, ...], datetime] = {}
+
+
+def candle_interval(*, unit: str, unit_number: int) -> timedelta | None:
+    seconds = _UNIT_SECONDS.get(str(unit).strip().lower())
+    if seconds is None:
+        return None
+    return timedelta(seconds=seconds * max(1, int(unit_number)))
+
+
+def candle_close_time(timestamp: datetime, *, unit: str, unit_number: int) -> datetime:
+    value = _as_utc(timestamp)
+    normalized_unit = str(unit).strip().lower()
+    if normalized_unit == "month":
+        return _add_months(value, max(1, int(unit_number)))
+    interval = candle_interval(unit=normalized_unit, unit_number=unit_number)
+    if interval is None:
+        raise ValueError(f"unsupported candle unit: {unit}")
+    return value + interval
+
+
+def validate_candle_ohlcv(row: Any) -> str | None:
+    values: dict[str, float] = {}
+    for field in ("open", "high", "low", "close", "volume"):
+        raw_value = _row_value(row, field)
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError, OverflowError):
+            return f"invalid_{field}"
+        if not math.isfinite(value):
+            return f"non_finite_{field}"
+        values[field] = value
+
+    if min(values["open"], values["high"], values["low"], values["close"]) <= 0:
+        return "non_positive_ohlc"
+    if values["high"] < max(values["open"], values["close"], values["low"]):
+        return "invalid_candle_high"
+    if values["low"] > min(values["open"], values["close"], values["high"]):
+        return "invalid_candle_low"
+    if values["volume"] < 0:
+        return "negative_candle_volume"
+    return None
+
+
+def audit_candle_rows(
+    rows: Iterable[Any],
+    *,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool,
+    symbol: str | None = None,
+    as_of: datetime | None = None,
+) -> CandleIntegrityReport:
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc < start_utc:
+        raise ValueError("start must be before end")
+    now = _as_utc(as_of or datetime.now(timezone.utc))
+    interval = candle_interval(unit=unit, unit_number=unit_number)
+
+    timestamped: list[tuple[datetime, Any]] = []
+    invalid_rows: list[Any] = []
+    issue_codes: set[str] = set()
+    for row in rows:
+        timestamp = _row_timestamp(row)
+        if timestamp is None:
+            invalid_rows.append(row)
+            issue_codes.add("invalid_candle_timestamp")
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if timestamp_utc < start_utc or timestamp_utc > end_utc:
+            continue
+        timestamped.append((timestamp_utc, row))
+
+    grouped: dict[datetime, list[Any]] = {}
+    for timestamp, row in timestamped:
+        grouped.setdefault(timestamp, []).append(row)
+
+    canonical: list[tuple[datetime, Any]] = []
+    duplicate_rows: list[Any] = []
+    for timestamp in sorted(grouped):
+        candidates = grouped[timestamp]
+        winner = max(candidates, key=_canonical_row_rank)
+        canonical.append((timestamp, winner))
+        if len(candidates) > 1:
+            issue_codes.add("duplicate_candle_timestamp")
+            duplicate_rows.extend(row for row in candidates if row is not winner)
+
+    usable: list[tuple[datetime, Any, bool]] = []
+    stale_partial_rows: list[Any] = []
+    current_partial_rows: list[Any] = []
+    closed_through = min(end_utc, now - _CANDLE_CLOSE_GRACE)
+    for timestamp, row in canonical:
+        invalid_code = validate_candle_ohlcv(row)
+        if invalid_code is not None:
+            invalid_rows.append(row)
+            issue_codes.add(invalid_code)
+            continue
+        try:
+            close_time = candle_close_time(timestamp, unit=unit, unit_number=unit_number)
+        except ValueError:
+            invalid_rows.append(row)
+            issue_codes.add("unsupported_candle_unit")
+            continue
+
+        declared_partial = _row_is_partial(row)
+        effectively_partial = declared_partial and close_time > closed_through
+        if declared_partial and not effectively_partial:
+            stale_partial_rows.append(row)
+            issue_codes.add("stale_partial_candle")
+            continue
+        is_current_partial = declared_partial or effectively_partial
+        if is_current_partial:
+            current_partial_rows.append(row)
+            if not include_partial_bar:
+                continue
+        usable.append((timestamp, row, is_current_partial))
+
+    overlapping_rows: list[Any] = []
+    non_overlapping: list[tuple[datetime, Any, bool]] = []
+    for candidate in usable:
+        if not non_overlapping or interval is None:
+            non_overlapping.append(candidate)
+            continue
+        previous = non_overlapping[-1]
+        previous_close = candle_close_time(previous[0], unit=unit, unit_number=unit_number)
+        if candidate[0] >= previous_close:
+            non_overlapping.append(candidate)
+            continue
+
+        issue_codes.add("overlapping_candles")
+        preferred = max(
+            (previous, candidate),
+            key=lambda item: _overlap_rank(item[0], item[1], item[2], interval),
+        )
+        rejected = candidate if preferred is previous else previous
+        overlapping_rows.append(rejected[1])
+        if preferred is candidate:
+            non_overlapping[-1] = candidate
+
+    valid_rows = [item[1] for item in non_overlapping]
+    closed_rows = [item for item in non_overlapping if not item[2]]
+    missing_ranges: list[CandleRepairRange] = []
+    if interval is not None and str(unit).strip().lower() in {"second", "minute", "hour"}:
+        missing_ranges = _find_missing_ranges(
+            closed_rows,
+            start=start_utc,
+            end=end_utc,
+            closed_through=closed_through,
+            interval=interval,
+            limit=max(1, int(limit)),
+            symbol=symbol,
+        )
+        if missing_ranges:
+            issue_codes.add("missing_candle")
+
+    bad_ranges: list[CandleRepairRange] = []
+    for code, bad_rows in (
+        ("invalid_candle", invalid_rows),
+        ("stale_partial_candle", stale_partial_rows),
+        ("duplicate_candle_timestamp", duplicate_rows),
+        ("overlapping_candles", overlapping_rows),
+    ):
+        for row in bad_rows:
+            timestamp = _row_timestamp(row)
+            if timestamp is None:
+                continue
+            timestamp_utc = _as_utc(timestamp)
+            padding = interval or timedelta(days=1)
+            bad_ranges.append(
+                CandleRepairRange(
+                    start=max(start_utc, timestamp_utc - padding),
+                    end=min(end_utc, candle_close_time(timestamp_utc, unit=unit, unit_number=unit_number) + padding),
+                    reasons=(code,),
+                )
+            )
+
+    repair_ranges = _merge_repair_ranges([*missing_ranges, *bad_ranges], maximum=_MAX_REPAIR_WINDOWS)
+    valid_rows.sort(key=lambda row: _as_utc(_row_timestamp(row) or start_utc))
+    return CandleIntegrityReport(
+        valid_rows=tuple(valid_rows[-max(1, int(limit)) :]),
+        invalid_rows=tuple(invalid_rows),
+        stale_partial_rows=tuple(stale_partial_rows),
+        current_partial_rows=tuple(current_partial_rows),
+        duplicate_rows=tuple(duplicate_rows),
+        overlapping_rows=tuple(overlapping_rows),
+        missing_ranges=tuple(missing_ranges),
+        repair_ranges=tuple(repair_ranges),
+        issue_codes=tuple(sorted(issue_codes)),
+    )
+
+
+def normalize_provider_bars(
+    bars: Iterable[dict[str, Any]],
+    *,
+    unit: str,
+    unit_number: int,
+    request_start: datetime | None = None,
+    request_end: datetime,
+    include_partial_bar: bool,
+    as_of: datetime | None = None,
+) -> list[dict[str, Any]]:
+    now = _as_utc(as_of or datetime.now(timezone.utc))
+    request_start_utc = _as_utc(request_start) if request_start is not None else None
+    request_end_utc = _as_utc(request_end)
+    closed_through = min(request_end_utc, now - _CANDLE_CLOSE_GRACE)
+    candidates: list[dict[str, Any]] = []
+    for raw_bar in bars:
+        if not isinstance(raw_bar, dict):
+            continue
+        timestamp = raw_bar.get("timestamp")
+        if not isinstance(timestamp, datetime):
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if timestamp_utc > request_end_utc or (
+            request_start_utc is not None and timestamp_utc < request_start_utc
+        ):
+            continue
+        try:
+            close_time = candle_close_time(timestamp_utc, unit=unit, unit_number=unit_number)
+        except ValueError:
+            continue
+        normalized = {**raw_bar, "timestamp": timestamp_utc}
+        inferred_partial = (
+            bool(raw_bar.get("is_partial"))
+            or close_time > request_end_utc
+            or (include_partial_bar and close_time > closed_through)
+        )
+        normalized["is_partial"] = inferred_partial
+        if validate_candle_ohlcv(normalized) is not None:
+            continue
+        if inferred_partial and not include_partial_bar:
+            continue
+        candidates.append(normalized)
+
+    if not candidates:
+        return []
+    start = min(_as_utc(row["timestamp"]) for row in candidates)
+    end = max(candle_close_time(row["timestamp"], unit=unit, unit_number=unit_number) for row in candidates)
+    report = audit_candle_rows(
+        candidates,
+        start=start,
+        end=end,
+        unit=unit,
+        unit_number=unit_number,
+        limit=len(candidates),
+        include_partial_bar=include_partial_bar,
+        as_of=now,
+    )
+    return [dict(row) for row in report.valid_rows]
+
+
+def retrieve_bars_singleflight(
+    *,
+    key: tuple[Any, ...],
+    retrieve: Callable[[], list[dict[str, Any]]],
+    attempts: int = _PROVIDER_ATTEMPTS,
+) -> list[dict[str, Any]]:
+    owner = False
+    with _FLIGHT_GUARD:
+        flight = _ACTIVE_FLIGHTS.get(key)
+        if flight is None:
+            flight = _ProviderFlight(event=Event())
+            _ACTIVE_FLIGHTS[key] = flight
+            owner = True
+
+    if not owner:
+        if not flight.event.wait(timeout=_SINGLEFLIGHT_WAIT_SECONDS):
+            raise ProjectXClientError("Timed out waiting for an identical candle request.", status_code=504)
+        if flight.error is not None:
+            raise flight.error
+        return [dict(row) for row in (flight.result or [])]
+
+    try:
+        result = _retrieve_with_bounded_retries(retrieve, attempts=attempts)
+        flight.result = [dict(row) for row in result]
+        return [dict(row) for row in result]
+    except Exception as exc:
+        flight.error = exc
+        raise
+    finally:
+        flight.event.set()
+        with _FLIGHT_GUARD:
+            if _ACTIVE_FLIGHTS.get(key) is flight:
+                _ACTIVE_FLIGHTS.pop(key, None)
+
+
+def repair_request_in_cooldown(key: tuple[Any, ...], *, now: datetime | None = None) -> bool:
+    current = _as_utc(now or datetime.now(timezone.utc))
+    with _FLIGHT_GUARD:
+        expires_at = _FAILED_REPAIR_UNTIL.get(key)
+        if expires_at is None:
+            return False
+        if expires_at <= current:
+            _FAILED_REPAIR_UNTIL.pop(key, None)
+            return False
+        return True
+
+
+def note_failed_repair(key: tuple[Any, ...], *, now: datetime | None = None) -> None:
+    current = _as_utc(now or datetime.now(timezone.utc))
+    with _FLIGHT_GUARD:
+        _FAILED_REPAIR_UNTIL[key] = current + _FAILED_REPAIR_COOLDOWN
+
+
+def clear_failed_repair(key: tuple[Any, ...]) -> None:
+    with _FLIGHT_GUARD:
+        _FAILED_REPAIR_UNTIL.pop(key, None)
+
+
+def _reset_request_state_for_tests() -> None:
+    with _FLIGHT_GUARD:
+        _ACTIVE_FLIGHTS.clear()
+        _FAILED_REPAIR_UNTIL.clear()
+
+
+def _retrieve_with_bounded_retries(
+    retrieve: Callable[[], list[dict[str, Any]]],
+    *,
+    attempts: int,
+) -> list[dict[str, Any]]:
+    bounded_attempts = max(1, min(int(attempts), _PROVIDER_ATTEMPTS))
+    for attempt in range(bounded_attempts):
+        try:
+            return retrieve()
+        except ProjectXClientError as exc:
+            if attempt + 1 >= bounded_attempts or not _is_transient_provider_error(exc):
+                raise
+            delay = _PROVIDER_RETRY_DELAYS[min(attempt + 1, len(_PROVIDER_RETRY_DELAYS) - 1)]
+            if delay > 0:
+                time.sleep(delay)
+    return []
+
+
+def _is_transient_provider_error(exc: ProjectXClientError) -> bool:
+    status_code = exc.status_code
+    return status_code is None or status_code == 429 or status_code >= 500
+
+
+def _find_missing_ranges(
+    closed_rows: list[tuple[datetime, Any, bool]],
+    *,
+    start: datetime,
+    end: datetime,
+    closed_through: datetime,
+    interval: timedelta,
+    limit: int,
+    symbol: str | None,
+) -> list[CandleRepairRange]:
+    if closed_through < start:
+        return []
+    timestamps = [row[0] for row in closed_rows]
+    missing: list[datetime] = []
+    broad_ranges: list[CandleRepairRange] = []
+    scanned = 0
+
+    wall_slots = max(0, int((closed_through - start) // interval) + 1)
+    if wall_slots <= limit:
+        candidate = _ceil_timestamp(start, interval)
+        first = timestamps[0] if timestamps else None
+        while candidate < (first or closed_through + interval) and candidate + interval <= closed_through:
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if is_expected_futures_candle(candidate, candidate + interval, symbol=symbol):
+                missing.append(candidate)
+            candidate += interval
+
+    for left, right in zip(timestamps, timestamps[1:]):
+        candidate = left + interval
+        candidate_slots = max(0, math.ceil((right - candidate) / interval))
+        if scanned + candidate_slots > _MAX_AUDIT_SLOTS:
+            if candidate < right and is_expected_futures_candle(candidate, right, symbol=symbol):
+                broad_ranges.append(
+                    CandleRepairRange(
+                        start=candidate,
+                        end=right,
+                        reasons=("missing_candle",),
+                    )
+                )
+            scanned = _MAX_AUDIT_SLOTS + 1
+            break
+        while candidate < right:
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if candidate + interval <= closed_through and is_expected_futures_candle(
+                candidate,
+                candidate + interval,
+                symbol=symbol,
+            ):
+                missing.append(candidate)
+            candidate += interval
+        if scanned > _MAX_AUDIT_SLOTS:
+            break
+
+    if scanned <= _MAX_AUDIT_SLOTS:
+        candidate = (timestamps[-1] + interval) if timestamps else _ceil_timestamp(start, interval)
+        tail_slots = max(0, int((closed_through - candidate) // interval))
+        if scanned + tail_slots > _MAX_AUDIT_SLOTS:
+            if candidate < closed_through and is_expected_futures_candle(
+                candidate,
+                closed_through,
+                symbol=symbol,
+            ):
+                broad_ranges.append(
+                    CandleRepairRange(
+                        start=candidate,
+                        end=closed_through,
+                        reasons=("missing_candle",),
+                    )
+                )
+            scanned = _MAX_AUDIT_SLOTS + 1
+        while candidate + interval <= closed_through:
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if is_expected_futures_candle(candidate, candidate + interval, symbol=symbol):
+                missing.append(candidate)
+            candidate += interval
+    elif timestamps:
+        candidate = timestamps[-1] + interval
+        if candidate + interval <= closed_through and is_expected_futures_candle(
+            candidate,
+            closed_through,
+            symbol=symbol,
+        ):
+            broad_ranges.append(
+                CandleRepairRange(
+                    start=candidate,
+                    end=closed_through,
+                    reasons=("missing_candle",),
+                )
+            )
+
+    if not missing:
+        return broad_ranges
+    unique = sorted(set(missing))
+    ranges: list[CandleRepairRange] = []
+    range_start = unique[0]
+    previous = unique[0]
+    for timestamp in unique[1:]:
+        if timestamp == previous + interval:
+            previous = timestamp
+            continue
+        ranges.append(
+            CandleRepairRange(start=range_start, end=previous + interval, reasons=("missing_candle",))
+        )
+        range_start = timestamp
+        previous = timestamp
+    ranges.append(CandleRepairRange(start=range_start, end=previous + interval, reasons=("missing_candle",)))
+    return _merge_repair_ranges([*ranges, *broad_ranges], maximum=_MAX_REPAIR_WINDOWS)
+
+
+def _merge_repair_ranges(
+    ranges: Iterable[CandleRepairRange],
+    *,
+    maximum: int,
+) -> list[CandleRepairRange]:
+    ordered = sorted(ranges, key=lambda item: (item.start, item.end))
+    merged: list[CandleRepairRange] = []
+    for item in ordered:
+        if item.end <= item.start:
+            continue
+        if not merged or item.start > merged[-1].end:
+            merged.append(item)
+            continue
+        previous = merged[-1]
+        merged[-1] = CandleRepairRange(
+            start=previous.start,
+            end=max(previous.end, item.end),
+            reasons=tuple(sorted(set((*previous.reasons, *item.reasons)))),
+        )
+
+    maximum = max(1, int(maximum))
+    while len(merged) > maximum:
+        pair_index = min(
+            range(len(merged) - 1),
+            key=lambda index: merged[index + 1].start - merged[index].end,
+        )
+        left = merged[pair_index]
+        right = merged[pair_index + 1]
+        merged[pair_index : pair_index + 2] = [
+            CandleRepairRange(
+                start=left.start,
+                end=right.end,
+                reasons=tuple(sorted(set((*left.reasons, *right.reasons)))),
+            )
+        ]
+    return merged
+
+
+def _canonical_row_rank(row: Any) -> tuple[Any, ...]:
+    valid = validate_candle_ohlcv(row) is None
+    partial = _row_is_partial(row)
+    fetched_at = _row_fetched_at(row)
+    fetched_epoch = fetched_at.timestamp() if fetched_at is not None else 0.0
+    numeric: list[float] = []
+    for field in ("open", "high", "low", "close", "volume"):
+        try:
+            numeric.append(float(_row_value(row, field)))
+        except (TypeError, ValueError, OverflowError):
+            numeric.append(float("-inf"))
+    return (int(valid), int(not partial), fetched_epoch, *numeric)
+
+
+def _overlap_rank(
+    timestamp: datetime,
+    row: Any,
+    is_partial: bool,
+    interval: timedelta,
+) -> tuple[Any, ...]:
+    aligned = _floor_timestamp(timestamp, interval) == timestamp
+    fetched_at = _row_fetched_at(row)
+    return (
+        int(not is_partial),
+        int(aligned),
+        fetched_at.timestamp() if fetched_at is not None else 0.0,
+        -timestamp.timestamp(),
+    )
+
+
+def _row_timestamp(row: Any) -> datetime | None:
+    value = row.get("timestamp") if isinstance(row, Mapping) else getattr(row, "candle_timestamp", None)
+    return value if isinstance(value, datetime) else None
+
+
+def _row_value(row: Any, field: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(field)
+    return getattr(row, f"{field}_price" if field != "volume" else "volume", None)
+
+
+def _row_is_partial(row: Any) -> bool:
+    if isinstance(row, Mapping):
+        return bool(row.get("is_partial"))
+    return bool(getattr(row, "is_partial", False))
+
+
+def _row_fetched_at(row: Any) -> datetime | None:
+    value = row.get("fetched_at") if isinstance(row, Mapping) else getattr(row, "fetched_at", None)
+    return _as_utc(value) if isinstance(value, datetime) else None
+
+
+def _floor_timestamp(value: datetime, interval: timedelta) -> datetime:
+    value_utc = _as_utc(value)
+    seconds = max(1, int(interval.total_seconds()))
+    epoch = int(value_utc.timestamp())
+    return datetime.fromtimestamp(epoch - epoch % seconds, tz=timezone.utc)
+
+
+def _ceil_timestamp(value: datetime, interval: timedelta) -> datetime:
+    floor = _floor_timestamp(value, interval)
+    return floor if floor >= _as_utc(value) else floor + interval
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _add_months(value: datetime, months: int) -> datetime:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    if month == 12:
+        next_month = datetime(year + 1, 1, 1, tzinfo=value.tzinfo)
+    else:
+        next_month = datetime(year, month + 1, 1, tzinfo=value.tzinfo)
+    month_start = datetime(year, month, 1, tzinfo=value.tzinfo)
+    last_day = (next_month - month_start).days
+    return value.replace(year=year, month=month, day=min(value.day, last_day))

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -1,10 +1,82 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
+from functools import lru_cache
 from zoneinfo import ZoneInfo
 
 TRADING_TZ = ZoneInfo("America/New_York")
 TRADING_DAY_ROLLOVER_HOUR = 18
+
+_REGULAR_SESSION_OPEN = time(hour=18)
+_REGULAR_SESSION_CLOSE = time(hour=17)
+_EQUITY_HALT_START = time(hour=16, minute=15)
+_EQUITY_HALT_END = time(hour=16, minute=30)
+_EARLY_CLOSE = time(hour=13)
+_EARLY_CLOSE_OLD = time(hour=11, minute=30)
+_EARLY_CLOSE_1215_CT = time(hour=13, minute=15)
+_GOOD_FRIDAY_CLOSE = time(hour=9, minute=15)
+
+# ProjectX symbols can be short roots (``MNQ``), provider symbols
+# (``F.US.MNQ``), or full contract ids (``CON.F.US.MNQ.M26``).  Unknown
+# symbols use the equity schedule because that is TopSignal's primary market;
+# known non-equity roots retain the common Globex week and maintenance break
+# without incorrectly borrowing equity-specific holiday close times.
+_CME_EQUITY_ROOTS = frozenset(
+    {
+        "ES",
+        "MES",
+        "NQ",
+        "MNQ",
+        "YM",
+        "MYM",
+        "RTY",
+        "M2K",
+        "EMD",
+        "MME",
+        "NKD",
+        "NIY",
+    }
+)
+_KNOWN_NON_EQUITY_ROOTS = frozenset(
+    {
+        "CL",
+        "MCL",
+        "NG",
+        "QG",
+        "GC",
+        "MGC",
+        "SI",
+        "SIL",
+        "HG",
+        "MHG",
+        "ZB",
+        "ZN",
+        "ZF",
+        "ZT",
+        "6A",
+        "6B",
+        "6C",
+        "6E",
+        "6J",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FuturesHolidaySchedule:
+    """A deterministic CME equity holiday exception for one trading date.
+
+    ``full_close`` means the session that would normally start at 18:00 ET on
+    the prior calendar date never opens.  ``early_close`` is an ET wall-clock
+    close on ``trading_date``; the next trading date can still open at 18:00 ET.
+    """
+
+    name: str
+    trading_date: date
+    full_close: bool = False
+    early_close: time | None = None
 
 
 def as_utc(value: datetime) -> datetime:
@@ -34,3 +106,279 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     )
     end_local = start_local + timedelta(days=1) - timedelta(microseconds=1)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def futures_holiday_schedule(
+    value: date,
+    *,
+    symbol: str | None = None,
+) -> FuturesHolidaySchedule | None:
+    """Return the CME equity holiday exception for a trading date, if any.
+
+    Holiday hours are product-family specific.  The equity calendar is used for
+    CME equity roots and when no root is available.  Known non-equity roots use
+    only the common Globex weekly schedule until a dedicated product calendar is
+    added, avoiding false claims about their special close times.
+    """
+
+    if not _uses_cme_equity_schedule(symbol):
+        return None
+    return _cme_equity_holiday_schedule(value)
+
+
+def futures_session_intervals_utc(
+    value: date,
+    *,
+    symbol: str | None = None,
+) -> tuple[tuple[datetime, datetime], ...]:
+    """Return authoritative open intervals for one futures trading date.
+
+    Intervals are half-open UTC ranges.  A normal CME equity trading date has
+    two ranges because the 16:15-16:30 ET equity halt is excluded.  Weekends,
+    full holidays, the daily 17:00-18:00 maintenance period, and holiday hours
+    therefore never appear as expected candle time.
+    """
+
+    return _futures_session_intervals_utc_cached(value, _uses_cme_equity_schedule(symbol))
+
+
+def is_futures_market_open(at: datetime, *, symbol: str | None = None) -> bool:
+    """Return whether ``at`` is inside a scheduled CME futures session."""
+
+    instant = as_utc(at)
+    session_date = trading_day_date(instant)
+    return any(
+        session_open <= instant < session_close
+        for session_open, session_close in futures_session_intervals_utc(
+            session_date,
+            symbol=symbol,
+        )
+    )
+
+
+def is_expected_futures_candle(
+    timestamp: datetime,
+    close_time: datetime,
+    *,
+    symbol: str | None = None,
+) -> bool:
+    """Return whether a candle bucket overlaps scheduled trading time.
+
+    The bucket is treated as ``[timestamp, close_time)``.  This interval-based
+    test handles larger bars that straddle a scheduled halt without inventing a
+    candle for a bucket wholly contained in a weekend, holiday, or maintenance
+    period.  It only describes whether a bar may be expected; it never creates
+    or interpolates market data.
+    """
+
+    start_utc = as_utc(timestamp)
+    end_utc = as_utc(close_time)
+    if end_utc <= start_utc:
+        return False
+
+    start_local_date = start_utc.astimezone(TRADING_TZ).date()
+    end_local_date = end_utc.astimezone(TRADING_TZ).date()
+    # A session beginning after 18:00 belongs to the following trading date, so
+    # inspect one date beyond the local end.  API/backtest ranges are bounded;
+    # iterating dates avoids scanning every missing second across a weekend.
+    final_session_date = _add_date_safely(end_local_date, days=1)
+    session_date = start_local_date
+    while session_date <= final_session_date:
+        for session_open, session_close in futures_session_intervals_utc(
+            session_date,
+            symbol=symbol,
+        ):
+            if session_open < end_utc and session_close > start_utc:
+                return True
+        if session_date == date.max:
+            break
+        session_date += timedelta(days=1)
+    return False
+
+
+@lru_cache(maxsize=8_192)
+def _futures_session_intervals_utc_cached(
+    value: date,
+    equity_schedule: bool,
+) -> tuple[tuple[datetime, datetime], ...]:
+    if value.weekday() >= 5:
+        return ()
+
+    holiday = _cme_equity_holiday_schedule(value) if equity_schedule else None
+    if holiday is not None and holiday.full_close:
+        return ()
+
+    open_local = datetime.combine(
+        value - timedelta(days=1),
+        _REGULAR_SESSION_OPEN,
+        tzinfo=TRADING_TZ,
+    )
+    close_at = (
+        holiday.early_close
+        if holiday is not None and holiday.early_close is not None
+        else _REGULAR_SESSION_CLOSE
+    )
+    close_local = datetime.combine(value, close_at, tzinfo=TRADING_TZ)
+    if close_local <= open_local:
+        return ()
+
+    local_intervals: list[tuple[datetime, datetime]] = []
+    if equity_schedule:
+        halt_start = datetime.combine(value, _EQUITY_HALT_START, tzinfo=TRADING_TZ)
+        halt_end = datetime.combine(value, _EQUITY_HALT_END, tzinfo=TRADING_TZ)
+        first_close = min(close_local, halt_start)
+        if open_local < first_close:
+            local_intervals.append((open_local, first_close))
+        if halt_end < close_local:
+            local_intervals.append((halt_end, close_local))
+    else:
+        local_intervals.append((open_local, close_local))
+
+    return tuple(
+        (interval_open.astimezone(timezone.utc), interval_close.astimezone(timezone.utc))
+        for interval_open, interval_close in local_intervals
+    )
+
+
+@lru_cache(maxsize=1_024)
+def _cme_equity_holiday_schedule(value: date) -> FuturesHolidaySchedule | None:
+    """Contemporary CME Globex equity holiday rules in Eastern time.
+
+    CME publishes product-specific schedules annually.  These deterministic
+    rules encode the recurring equity-index schedule and its documented regime
+    changes; unusual exchange notices can be added as explicit date overrides
+    without changing gap-detection behavior elsewhere.
+    """
+
+    year = value.year
+
+    new_year = date(year, 1, 1)
+    observed_new_year = new_year + timedelta(days=1) if new_year.weekday() == 6 else new_year
+    if value == observed_new_year:
+        return FuturesHolidaySchedule("New Year's Day", value, full_close=True)
+
+    christmas = _nearest_weekday(date(year, 12, 25))
+    if value == christmas:
+        return FuturesHolidaySchedule("Christmas", value, full_close=True)
+
+    good_friday = _easter_sunday(year) - timedelta(days=2)
+    if value == good_friday:
+        if year == 2022 or (year < 2021 and year not in {2010, 2012, 2015}):
+            return FuturesHolidaySchedule("Good Friday", value, full_close=True)
+        return FuturesHolidaySchedule(
+            "Good Friday",
+            value,
+            early_close=_GOOD_FRIDAY_CLOSE,
+        )
+
+    early_close_name: str | None = None
+    early_close_at: time | None = None
+
+    if year >= 1998 and value == _nth_weekday(year, 1, weekday=0, occurrence=3):
+        early_close_name = "Martin Luther King Jr. Day"
+        early_close_at = _EARLY_CLOSE if year >= 2015 else _EARLY_CLOSE_OLD
+    elif value == _nth_weekday(year, 2, weekday=0, occurrence=3):
+        early_close_name = "Presidents Day"
+        early_close_at = _EARLY_CLOSE if year >= 2015 else _EARLY_CLOSE_OLD
+    elif value == _last_weekday(year, 5, weekday=0):
+        early_close_name = "Memorial Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    elif year >= 2022 and value == _nearest_weekday(date(year, 6, 19)):
+        early_close_name = "Juneteenth"
+        early_close_at = _EARLY_CLOSE
+    elif value == _nearest_weekday(date(year, 7, 4)):
+        early_close_name = "Independence Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    elif value == _pre_independence_early_close(year):
+        early_close_name = "Independence Day Eve"
+        early_close_at = _EARLY_CLOSE_1215_CT
+    elif value == _nth_weekday(year, 9, weekday=0, occurrence=1):
+        early_close_name = "Labor Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    else:
+        thanksgiving = _nth_weekday(year, 11, weekday=3, occurrence=4)
+        if value == thanksgiving:
+            early_close_name = "Thanksgiving Day"
+            early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+        elif value == thanksgiving + timedelta(days=1):
+            early_close_name = "Day After Thanksgiving"
+            early_close_at = _EARLY_CLOSE_1215_CT
+        elif year >= 1993 and value == date(year, 12, 24) and value.weekday() < 5:
+            early_close_name = "Christmas Eve"
+            early_close_at = _EARLY_CLOSE_1215_CT
+
+    if early_close_name is None or early_close_at is None:
+        return None
+    return FuturesHolidaySchedule(
+        early_close_name,
+        value,
+        early_close=early_close_at,
+    )
+
+
+def _uses_cme_equity_schedule(symbol: str | None) -> bool:
+    if symbol is None or not str(symbol).strip():
+        return True
+    tokens = {token for token in re.split(r"[^A-Z0-9]+", str(symbol).upper()) if token}
+    if tokens & _CME_EQUITY_ROOTS:
+        return True
+    if tokens & _KNOWN_NON_EQUITY_ROOTS:
+        return False
+    return True
+
+
+def _nth_weekday(year: int, month: int, *, weekday: int, occurrence: int) -> date:
+    first = date(year, month, 1)
+    offset = (weekday - first.weekday()) % 7
+    return first + timedelta(days=offset + 7 * (occurrence - 1))
+
+
+def _last_weekday(year: int, month: int, *, weekday: int) -> date:
+    if month == 12:
+        next_month = date(year + 1, 1, 1)
+    else:
+        next_month = date(year, month + 1, 1)
+    last = next_month - timedelta(days=1)
+    return last - timedelta(days=(last.weekday() - weekday) % 7)
+
+
+def _nearest_weekday(value: date) -> date:
+    if value.weekday() == 5:
+        return value - timedelta(days=1)
+    if value.weekday() == 6:
+        return value + timedelta(days=1)
+    return value
+
+
+def _pre_independence_early_close(year: int) -> date | None:
+    independence_day = date(year, 7, 4)
+    if independence_day.weekday() not in {1, 2, 3, 4}:
+        return None
+    return independence_day - timedelta(days=1)
+
+
+def _easter_sunday(year: int) -> date:
+    """Gregorian Easter (Meeus/Jones/Butcher), used to derive Good Friday."""
+
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    ell = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * ell) // 451
+    month = (h + ell - 7 * m + 114) // 31
+    day = ((h + ell - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
+
+
+def _add_date_safely(value: date, *, days: int) -> date:
+    try:
+        return value + timedelta(days=days)
+    except OverflowError:
+        return date.max if days >= 0 else date.min

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -767,6 +767,29 @@ def test_malformed_candle_streams_are_rejected(bars, error_fragment: str):
         _run(bars, evaluator=_hold)
 
 
+def test_backtest_gap_detection_ignores_futures_weekend_and_maintenance():
+    friday_close = datetime(2026, 4, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 4, 12, 22, 0, tzinfo=timezone.utc)
+    maintenance_close = datetime(2026, 4, 13, 20, 55, tzinfo=timezone.utc)
+    maintenance_reopen = datetime(2026, 4, 13, 22, 0, tzinfo=timezone.utc)
+
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(friday_close), _candle(sunday_open)],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(maintenance_close), _candle(maintenance_reopen)],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=10))],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 1
+
+
 def test_unsupported_strategy_fails_explicitly_without_approximation():
     bars = [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))]
 
@@ -1036,6 +1059,151 @@ def test_orb_rejects_an_incompatible_non_minute_timeframe():
             evaluator=_hold,
             end=BASE_TIME + timedelta(hours=2),
         )
+
+
+def test_backtest_route_repairs_missing_execution_bar_before_replay(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    timestamps = [
+        BASE_TIME - timedelta(minutes=10),
+        BASE_TIME - timedelta(minutes=5),
+        BASE_TIME,
+        BASE_TIME + timedelta(minutes=10),
+        BASE_TIME + timedelta(minutes=15),
+    ]
+    db_session.add_all(
+        [_candle(timestamp, close_price=100 + index) for index, timestamp in enumerate(timestamps)]
+    )
+    db_session.commit()
+
+    authoritative_timestamps = [
+        BASE_TIME - timedelta(minutes=10),
+        BASE_TIME - timedelta(minutes=5),
+        BASE_TIME,
+        BASE_TIME + timedelta(minutes=5),
+        BASE_TIME + timedelta(minutes=10),
+        BASE_TIME + timedelta(minutes=15),
+    ]
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return [
+                {
+                    "timestamp": timestamp,
+                    "open": 100 + index,
+                    "high": 101 + index,
+                    "low": 99 + index,
+                    "close": 100 + index,
+                    "volume": 10,
+                }
+                for index, timestamp in enumerate(authoritative_timestamps)
+                if kwargs["start"] <= timestamp <= kwargs["end"]
+            ]
+
+    client = StubClient()
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
+
+    response = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        db=db_session,
+    )
+
+    assert len(client.calls) == 1
+    assert response["range"]["bar_count"] == 4
+    repaired = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.candle_timestamp == BASE_TIME + timedelta(minutes=5))
+        .one()
+    )
+    assert float(repaired.close_price) == 103.0
+    assert db_session.query(BotBacktest).count() == 1
+
+
+def test_backtest_route_does_not_persist_when_integrity_remains_unresolved(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(BASE_TIME - timedelta(minutes=10)),
+            _candle(BASE_TIME - timedelta(minutes=5)),
+            _candle(BASE_TIME, high_price=99, low_price=98, close_price=100),
+            _candle(BASE_TIME + timedelta(minutes=5)),
+        ]
+    )
+    db_session.commit()
+
+    class EmptyClient:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            return []
+
+    client = EmptyClient()
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main_module.create_trading_bot_backtest(
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=10),
+            ),
+            db=db_session,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "candle_integrity_unresolved" in str(exc_info.value.detail)
+    assert client.calls == 1
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_topbot_backtest_preflight_repairs_every_required_stream(db_session, monkeypatch):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": ["support_resistance"],
+            "minimum_directional_votes": 1,
+            "minimum_score": 70,
+            "minimum_reward_risk": 1.5,
+        },
+    )
+    observed: list[tuple[str, int]] = []
+
+    def record_ensure(*_args, **kwargs):
+        observed.append((kwargs["unit"], kwargs["unit_number"]))
+        assert kwargs["strict_integrity"] is True
+        return []
+
+    monkeypatch.setattr(backtesting_module.bot_service_module, "ensure_market_candles", record_ensure)
+
+    backtesting_module._ensure_backtest_candle_integrity(
+        db_session,
+        user_id=OWNER_ID,
+        config=config,
+        client=object(),
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=20),
+        primary_warmup_bars=25,
+    )
+
+    assert observed == [("minute", 5), ("hour", 4), ("hour", 1)]
 
 
 def test_authenticated_route_reuses_real_strategy_and_never_routes_orders(

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -3242,7 +3242,12 @@ def test_candles_endpoint_returns_local_cache_without_provider_call(monkeypatch)
     )
 
     try:
-        db.add(_make_candle(datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc), 10))
+        db.add_all(
+            [
+                _make_candle(datetime(2026, 4, 1, 9, 55, tzinfo=timezone.utc), 9),
+                _make_candle(datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc), 10),
+            ]
+        )
         db.commit()
 
         payload = main_module.get_projectx_market_candles(
@@ -3256,8 +3261,7 @@ def test_candles_endpoint_returns_local_cache_without_provider_call(monkeypatch)
             db=db,
         )
 
-        assert len(payload) == 1
-        assert payload[0]["close"] == 10.0
+        assert [row["close"] for row in payload] == [9.0, 10.0]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
@@ -3513,7 +3517,7 @@ def test_candles_endpoint_resolves_legacy_symbol_to_cached_contract(monkeypatch)
         payload = main_module.get_projectx_market_candles(
             contract_id="MNQ",
             symbol="MNQ",
-            start=datetime(2026, 4, 1, 9, 55, tzinfo=timezone.utc),
+            start=datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc),
             end=datetime(2026, 4, 1, 10, 5, tzinfo=timezone.utc),
             unit="minute",
             unit_number=5,
@@ -3727,7 +3731,7 @@ def test_candles_endpoint_tries_active_symbol_contract_when_saved_contract_histo
             if kwargs["contract_id"] == "CON.F.US.MNQ.U26":
                 return [
                     {
-                        "timestamp": datetime(2026, 6, 25, 14, 0, tzinfo=timezone.utc),
+                        "timestamp": datetime(2026, 5, 13, 14, 0, tzinfo=timezone.utc),
                         "open": 20,
                         "high": 21,
                         "low": 19,
@@ -3889,7 +3893,7 @@ def test_candles_endpoint_refresh_replaces_cached_window(monkeypatch):
         engine.dispose()
 
 
-def test_candles_endpoint_partial_refresh_does_not_prune_closed_cache(monkeypatch):
+def test_candles_endpoint_rejects_stale_partial_without_pruning_closed_cache(monkeypatch):
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -3954,7 +3958,6 @@ def test_candles_endpoint_partial_refresh_does_not_prune_closed_cache(monkeypatc
         assert [_as_test_utc(row.candle_timestamp) for row in cached_rows] == [
             datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc),
             datetime(2026, 4, 1, 10, 1, tzinfo=timezone.utc),
-            datetime(2026, 4, 1, 10, 2, tzinfo=timezone.utc),
         ]
     finally:
         db.close()
@@ -4046,11 +4049,12 @@ def test_dry_run_evaluation_logs_order_attempt_without_submitting():
         place_order_called = False
 
         def retrieve_bars(self, **_kwargs):
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4146,7 +4150,7 @@ def test_macd_support_resistance_evaluation_serializes_trailing_stop_plan_into_o
     SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     db = SessionLocal()
 
-    base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    base = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0) - timedelta(hours=20)
     higher_timeframe = [
         _make_hour_candle(base + timedelta(hours=index * 4), close=120 + index, low=118 + index, high=122 + index, unit_number=4)
         for index in range(5)
@@ -4267,7 +4271,7 @@ def test_donchian_reversal_uses_double_size_to_flip_position_without_risk_block(
 
     class StubClient:
         def retrieve_bars(self, **_kwargs):
-            base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=105)
             rows = [
                 {"timestamp": base + timedelta(minutes=index * 5), "open": 100, "high": 102, "low": 98, "close": 100, "volume": 1}
                 for index in range(20)
@@ -4384,11 +4388,12 @@ def test_live_evaluation_is_blocked_without_explicit_confirmation():
 
     class StubClient:
         def retrieve_bars(self, **_kwargs):
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4500,11 +4505,12 @@ def test_evaluation_uses_resolved_contract_for_decision_and_order_attempt():
 
         def retrieve_bars(self, **kwargs):
             assert kwargs["contract_id"] == "CON.F.US.MNQ.M26"
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4670,7 +4676,7 @@ def test_stop_without_active_run_links_lifecycle_decision_to_created_run():
         engine.dispose()
 
 
-def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypatch):
+def test_candles_endpoint_automatically_repairs_interior_gap(monkeypatch):
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -4682,15 +4688,38 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
 
     user_id = "00000000-0000-0000-0000-000000000000"
     monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: user_id)
-    monkeypatch.setattr(
-        main_module,
-        "_projectx_client_for_user",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("provider should not be called")),
-    )
+    base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return [
+                {
+                    "timestamp": base + timedelta(minutes=10),
+                    "open": 11.5,
+                    "high": 11.8,
+                    "low": 11.2,
+                    "close": 11.6,
+                    "volume": 5,
+                },
+                {
+                    "timestamp": base + timedelta(minutes=15),
+                    "open": 11.6,
+                    "high": 12.0,
+                    "low": 11.4,
+                    "close": 11.9,
+                    "volume": 6,
+                },
+            ]
+
+    client = StubClient()
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
 
     try:
         fetched_at = datetime.now(timezone.utc)
-        base = fetched_at.replace(second=0, microsecond=0) - timedelta(minutes=30)
         # Interior hole: base+10m and base+15m are missing.
         for offset, close in ((0, 10), (5, 11), (20, 12), (25, 13)):
             db.add(_make_candle(base + timedelta(minutes=offset), close, fetched_at=fetched_at))
@@ -4707,9 +4736,8 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
             db=db,
         )
 
-        # Documents the fast path: a covering, fresh cache is returned as-is even
-        # when it has interior holes. Backfill requires repair=True.
-        assert len(payload) == 4
+        assert len(client.calls) == 1
+        assert [row["close"] for row in payload] == [10.0, 11.0, 11.6, 11.9, 12.0, 13.0]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])

--- a/backend/tests/test_candle_integrity.py
+++ b/backend/tests/test_candle_integrity.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+from app.db import Base
+from app.models import ProjectXMarketCandle
+from app.services.bot_service import ensure_market_candles, store_market_candles
+from app.services.candle_integrity import (
+    _reset_request_state_for_tests,
+    audit_candle_rows,
+    normalize_provider_bars,
+    retrieve_bars_singleflight,
+)
+from app.services.projectx_client import ProjectXClientError
+
+
+USER_ID = "00000000-0000-0000-0000-000000000000"
+CONTRACT_ID = "CON.F.US.MNQ.M26"
+BASE = datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def reset_request_state():
+    _reset_request_state_for_tests()
+    yield
+    _reset_request_state_for_tests()
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def _bar(timestamp: datetime, close: float = 100.0, **overrides):
+    bar = {
+        "timestamp": timestamp,
+        "open": close - 0.25,
+        "high": close + 0.5,
+        "low": close - 0.5,
+        "close": close,
+        "volume": 10.0,
+        "is_partial": False,
+    }
+    bar.update(overrides)
+    return bar
+
+
+def _row(timestamp: datetime, close: float = 100.0, **overrides):
+    values = {
+        "user_id": USER_ID,
+        "contract_id": CONTRACT_ID,
+        "symbol": "MNQ",
+        "live": False,
+        "unit": "minute",
+        "unit_number": 5,
+        "candle_timestamp": timestamp,
+        "open_price": close - 0.25,
+        "high_price": close + 0.5,
+        "low_price": close - 0.5,
+        "close_price": close,
+        "volume": 10.0,
+        "is_partial": False,
+    }
+    values.update(overrides)
+    return ProjectXMarketCandle(**values)
+
+
+def _audit(rows, *, start=BASE, end=BASE + timedelta(minutes=15), include_partial=False):
+    return audit_candle_rows(
+        rows,
+        start=start,
+        end=end,
+        unit="minute",
+        unit_number=5,
+        limit=100,
+        include_partial_bar=include_partial,
+        symbol="MNQ",
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_duplicate_timestamp_prefers_closed_valid_bar_independent_of_order(reverse):
+    closed = _bar(BASE, close=101.0)
+    partial = _bar(BASE, close=999.0, is_partial=True)
+    rows = [partial, closed] if reverse else [closed, partial]
+
+    report = _audit(rows, end=BASE + timedelta(minutes=5), include_partial=True)
+
+    assert report.issue_codes == ("duplicate_candle_timestamp",)
+    assert len(report.valid_rows) == 1
+    assert report.valid_rows[0]["close"] == 101.0
+
+
+@pytest.mark.parametrize(
+    ("overrides", "issue"),
+    [
+        ({"high": 99.0}, "invalid_candle_high"),
+        ({"low": 100.25}, "invalid_candle_low"),
+        ({"open": 0.0}, "non_positive_ohlc"),
+        ({"close": float("nan")}, "non_finite_close"),
+        ({"volume": -1.0}, "negative_candle_volume"),
+    ],
+)
+def test_invalid_ohlcv_is_excluded_and_scheduled_for_repair(overrides, issue):
+    bar = _bar(BASE)
+    bar.update(overrides)
+    report = _audit([bar], end=BASE + timedelta(minutes=5))
+
+    assert issue in report.issue_codes
+    assert report.valid_rows == ()
+    assert report.repair_ranges
+
+
+def test_overlap_is_detected_and_only_one_bar_survives():
+    report = _audit(
+        [_bar(BASE), _bar(BASE + timedelta(minutes=1), close=101)],
+        end=BASE + timedelta(minutes=10),
+    )
+
+    assert "overlapping_candles" in report.issue_codes
+    assert len(report.valid_rows) == 1
+    assert report.valid_rows[0]["timestamp"] == BASE
+
+
+def test_open_session_gap_and_incomplete_tail_are_detected():
+    report = _audit(
+        [_bar(BASE), _bar(BASE + timedelta(minutes=10))],
+        end=BASE + timedelta(minutes=20),
+    )
+
+    assert "missing_candle" in report.issue_codes
+    assert [(item.start, item.end) for item in report.missing_ranges] == [
+        (BASE + timedelta(minutes=5), BASE + timedelta(minutes=10)),
+        (BASE + timedelta(minutes=15), BASE + timedelta(minutes=20)),
+    ]
+
+
+def test_large_second_gap_uses_bounded_broad_repair_window():
+    end = BASE + timedelta(hours=8)
+    report = audit_candle_rows(
+        [_bar(BASE), _bar(end)],
+        start=BASE,
+        end=end + timedelta(seconds=1),
+        unit="second",
+        unit_number=1,
+        limit=50_000,
+        include_partial_bar=False,
+        symbol="MNQ",
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert "missing_candle" in report.issue_codes
+    assert report.repair_ranges
+    assert len(report.repair_ranges) <= 8
+
+
+def test_daily_maintenance_gap_is_not_repaired():
+    # 2026-04-01 is EDT: 17:00-18:00 ET is 21:00-22:00 UTC.
+    before_close = datetime(2026, 4, 1, 20, 55, tzinfo=timezone.utc)
+    reopen = datetime(2026, 4, 1, 22, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(before_close), _bar(reopen)],
+        start=before_close,
+        end=reopen + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_weekend_gap_is_not_repaired():
+    friday_close = datetime(2026, 4, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 4, 12, 22, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(friday_close), _bar(sunday_open)],
+        start=friday_close,
+        end=sunday_open + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_holiday_early_close_gap_is_not_repaired():
+    # MLK Day 2026 closes at 13:00 ET (18:00 UTC) and reopens at 18:00 ET.
+    before_close = datetime(2026, 1, 19, 17, 55, tzinfo=timezone.utc)
+    reopen = datetime(2026, 1, 19, 23, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(before_close), _bar(reopen)],
+        start=before_close,
+        end=reopen + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_stale_partial_is_excluded_and_scheduled_for_authoritative_replacement():
+    report = _audit(
+        [_bar(BASE, is_partial=True)],
+        end=BASE + timedelta(minutes=5),
+        include_partial=True,
+    )
+
+    assert report.valid_rows == ()
+    assert report.stale_partial_rows
+    assert "stale_partial_candle" in report.issue_codes
+
+
+def test_current_partial_is_allowed_until_its_bucket_closes():
+    report = audit_candle_rows(
+        [_bar(BASE, is_partial=True)],
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        include_partial_bar=True,
+        symbol="MNQ",
+        as_of=BASE + timedelta(minutes=2),
+    )
+
+    assert report.is_complete
+    assert len(report.valid_rows) == 1
+    assert len(report.current_partial_rows) == 1
+
+
+def test_provider_duplicate_normalization_prefers_closed_bar():
+    normalized = normalize_provider_bars(
+        [_bar(BASE, close=999, is_partial=True), _bar(BASE, close=101)],
+        unit="minute",
+        unit_number=5,
+        request_end=BASE + timedelta(minutes=5),
+        include_partial_bar=True,
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert len(normalized) == 1
+    assert normalized[0]["close"] == 101
+    assert normalized[0]["is_partial"] is False
+
+
+def test_provider_normalization_rejects_bars_outside_requested_closed_window():
+    normalized = normalize_provider_bars(
+        [
+            _bar(BASE - timedelta(minutes=5)),
+            _bar(BASE),
+            _bar(BASE + timedelta(minutes=5)),
+        ],
+        unit="minute",
+        unit_number=5,
+        request_start=BASE,
+        request_end=BASE + timedelta(minutes=5),
+        include_partial_bar=False,
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert [row["timestamp"] for row in normalized] == [BASE]
+
+
+def test_singleflight_deduplicates_concurrent_provider_requests():
+    call_count = 0
+    guard = Lock()
+
+    def retrieve():
+        nonlocal call_count
+        with guard:
+            call_count += 1
+        time.sleep(0.1)
+        return [_bar(BASE)]
+
+    def invoke():
+        return retrieve_bars_singleflight(key=("same",), retrieve=retrieve)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(lambda _index: invoke(), range(4)))
+
+    assert call_count == 1
+    assert [result[0]["timestamp"] for result in results] == [BASE] * 4
+
+
+def test_transient_retries_are_capped_and_nontransient_errors_are_not_retried():
+    transient_calls = 0
+
+    def transient():
+        nonlocal transient_calls
+        transient_calls += 1
+        raise ProjectXClientError("timeout", status_code=504)
+
+    with pytest.raises(ProjectXClientError):
+        retrieve_bars_singleflight(key=("transient",), retrieve=transient)
+    assert transient_calls == 3
+
+    permanent_calls = 0
+
+    def permanent():
+        nonlocal permanent_calls
+        permanent_calls += 1
+        raise ProjectXClientError("bad request", status_code=400)
+
+    with pytest.raises(ProjectXClientError):
+        retrieve_bars_singleflight(key=("permanent",), retrieve=permanent)
+    assert permanent_calls == 1
+
+
+def test_closed_database_row_cannot_be_downgraded_by_partial(db_session):
+    store_market_candles(
+        db_session,
+        user_id=USER_ID,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        unit="minute",
+        unit_number=5,
+        bars=[_bar(BASE, close=101)],
+    )
+    db_session.flush()
+    store_market_candles(
+        db_session,
+        user_id=USER_ID,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        unit="minute",
+        unit_number=5,
+        bars=[_bar(BASE, close=999, is_partial=True)],
+    )
+    db_session.flush()
+
+    row = db_session.query(ProjectXMarketCandle).one()
+    assert row.is_partial is False
+    assert float(row.close_price) == 101.0
+
+
+def test_stale_partial_is_replaced_in_place_by_closed_provider_bar(db_session):
+    db_session.add(_row(BASE, close=100, is_partial=True))
+    db_session.flush()
+
+    class Client:
+        def retrieve_bars(self, **_kwargs):
+            return [_bar(BASE, close=102, is_partial=False)]
+
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=Client(),
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+
+    assert len(rows) == 1
+    assert db_session.query(ProjectXMarketCandle).count() == 1
+    assert rows[0].is_partial is False
+    assert float(rows[0].close_price) == 102.0
+
+
+def test_empty_provider_response_never_creates_synthetic_gap_bar(db_session):
+    db_session.add_all([_row(BASE), _row(BASE + timedelta(minutes=10), close=102)])
+    db_session.flush()
+
+    class Client:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            return []
+
+    client = Client()
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=15),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+    repeated_rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=15),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+
+    assert client.calls == 1
+    assert [
+        row.candle_timestamp.replace(tzinfo=row.candle_timestamp.tzinfo or timezone.utc)
+        for row in rows
+    ] == [BASE, BASE + timedelta(minutes=10)]
+    assert len(repeated_rows) == 2
+    assert db_session.query(ProjectXMarketCandle).count() == 2
+
+
+def test_provider_failure_uses_vetted_cache_after_exact_retry_cap(db_session):
+    db_session.add(_row(BASE, close=101))
+    db_session.flush()
+
+    class Client:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            raise ProjectXClientError("timeout", status_code=504)
+
+    client = Client()
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        force_refresh=True,
+    )
+
+    assert client.calls == 3
+    assert len(rows) == 1
+    assert float(rows[0].close_price) == 101.0
+
+
+def test_invalid_provider_bar_cannot_overwrite_good_cache(db_session):
+    db_session.add(_row(BASE, close=101))
+    db_session.flush()
+
+    class Client:
+        def retrieve_bars(self, **_kwargs):
+            return [_bar(BASE, close=999, high=998)]
+
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=Client(),
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        force_refresh=True,
+    )
+
+    assert len(rows) == 1
+    assert float(rows[0].close_price) == 101.0

--- a/backend/tests/test_trading_day.py
+++ b/backend/tests/test_trading_day.py
@@ -1,6 +1,12 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 
-from app.services.trading_day import trading_day_key
+from app.services.trading_day import (
+    futures_holiday_schedule,
+    futures_session_intervals_utc,
+    is_expected_futures_candle,
+    is_futures_market_open,
+    trading_day_key,
+)
 
 
 def test_trading_day_key_keeps_559pm_et_on_same_day():
@@ -16,3 +22,129 @@ def test_trading_day_key_rolls_600pm_et_to_next_day():
 def test_trading_day_key_rolls_monday_609pm_et_to_tuesday():
     # Reported case: Monday 2026-03-02 18:09 ET should bucket as Tuesday.
     assert trading_day_key(datetime(2026, 3, 2, 23, 9, tzinfo=timezone.utc)) == "2026-03-03"
+
+
+def test_cme_equity_session_excludes_daily_halt_and_maintenance():
+    symbol = "F.US.MNQ"
+
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 14, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 20, 29, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 21, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 22, 0, tzinfo=timezone.utc), symbol=symbol)
+
+
+def test_cme_equity_session_excludes_weekend():
+    symbol = "CON.F.US.MNQ.M26"
+
+    assert is_futures_market_open(datetime(2026, 6, 5, 20, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 5, 21, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 6, 15, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 7, 21, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 7, 22, 0, tzinfo=timezone.utc), symbol=symbol)
+
+
+def test_cme_equity_sunday_open_is_dst_safe():
+    # March 1 is EST (18:00 ET == 23:00 UTC); March 8 is EDT
+    # (18:00 ET == 22:00 UTC) after the spring transition.
+    assert not is_futures_market_open(datetime(2026, 3, 1, 22, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 3, 1, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 3, 8, 21, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 3, 8, 22, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+    # The November 1 fall transition returns the Sunday open to 23:00 UTC.
+    assert not is_futures_market_open(datetime(2026, 11, 1, 22, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 11, 1, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+
+def test_cme_equity_recurring_holiday_rules_report_full_and_early_closes():
+    mlk = futures_holiday_schedule(date(2026, 1, 19), symbol="MNQ")
+    good_friday = futures_holiday_schedule(date(2026, 4, 3), symbol="MNQ")
+    independence_eve = futures_holiday_schedule(date(2024, 7, 3), symbol="MNQ")
+    independence_day = futures_holiday_schedule(date(2024, 7, 4), symbol="MNQ")
+    thanksgiving = futures_holiday_schedule(date(2026, 11, 26), symbol="MNQ")
+    thanksgiving_friday = futures_holiday_schedule(date(2026, 11, 27), symbol="MNQ")
+    christmas_eve = futures_holiday_schedule(date(2026, 12, 24), symbol="MNQ")
+    christmas = futures_holiday_schedule(date(2026, 12, 25), symbol="MNQ")
+
+    assert mlk is not None and mlk.early_close == time(13, 0) and not mlk.full_close
+    assert good_friday is not None and good_friday.early_close == time(9, 15)
+    assert independence_eve is not None and independence_eve.early_close == time(13, 15)
+    assert independence_day is not None and independence_day.early_close == time(13, 0)
+    assert thanksgiving is not None and thanksgiving.early_close == time(13, 0)
+    assert thanksgiving_friday is not None and thanksgiving_friday.early_close == time(13, 15)
+    assert christmas_eve is not None and christmas_eve.early_close == time(13, 15)
+    assert christmas is not None and christmas.full_close and christmas.early_close is None
+
+
+def test_cme_equity_holiday_closes_are_applied_to_market_open_checks():
+    # MLK Day closes at 13:00 ET and the next trading date opens at 18:00 ET.
+    assert is_futures_market_open(datetime(2026, 1, 19, 17, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 1, 19, 18, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 1, 19, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+    # Good Friday closes at 09:15 ET in the contemporary schedule.
+    assert is_futures_market_open(datetime(2026, 4, 3, 13, 14, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 4, 3, 13, 15, tzinfo=timezone.utc), symbol="MNQ")
+
+    # Christmas is a full close: the prior-evening session never opens.
+    assert not is_futures_market_open(datetime(2026, 12, 24, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 12, 25, 16, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+
+def test_cme_equity_session_intervals_are_half_open_and_exclude_halt():
+    assert futures_session_intervals_utc(date(2026, 6, 9), symbol="MNQ") == (
+        (
+            datetime(2026, 6, 8, 22, 0, tzinfo=timezone.utc),
+            datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc),
+            datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc),
+        ),
+    )
+    assert futures_session_intervals_utc(date(2026, 12, 25), symbol="MNQ") == ()
+
+
+def test_expected_candle_requires_bucket_to_overlap_open_session_time():
+    def expected(start: datetime, end: datetime) -> bool:
+        return is_expected_futures_candle(start, end, symbol="MNQ")
+
+    # A bucket wholly inside the equity halt or maintenance break is scheduled empty.
+    assert not expected(
+        datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc),
+    )
+    assert not expected(
+        datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 22, 0, tzinfo=timezone.utc),
+    )
+
+    # A larger candle that has any actual session time remains expected.
+    assert expected(
+        datetime(2026, 6, 9, 20, 10, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 20, 20, tzinfo=timezone.utc),
+    )
+    assert expected(
+        datetime(2026, 6, 9, 21, 55, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 22, 5, tzinfo=timezone.utc),
+    )
+
+    assert not expected(
+        datetime(2026, 6, 6, 12, 0, tzinfo=timezone.utc),
+        datetime(2026, 6, 7, 18, 0, tzinfo=timezone.utc),
+    )
+    assert not expected(
+        datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc),
+    )
+
+
+def test_known_non_equity_symbol_does_not_inherit_equity_only_halt_or_holidays():
+    # Product-specific special schedules differ. Until a metals calendar is
+    # modeled, MGC gets only the common Globex week and 17:00-18:00 maintenance.
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 20, tzinfo=timezone.utc), symbol="F.US.MGC")
+    assert futures_holiday_schedule(date(2026, 1, 19), symbol="MGC") is None


### PR DESCRIPTION
## Summary

Adds a backend-authoritative candle integrity and automatic repair pipeline for candle requests, strategy evaluation, and backtests.

The backend now detects and repairs:

- missing session bars and incomplete tails
- stale partial bars after candle close
- duplicate timestamps and overlapping bars
- invalid or non-finite OHLC/volume values
- provider responses outside the requested range

Repairs only persist authoritative provider candles. The system never manufactures synthetic candles.

## Why

Candle completeness previously depended on explicit backfill/repair requests and several strategy paths could bypass the shared cache path. Gap checks also treated calendar time as trading time, which could incorrectly flag futures weekends, holidays, maintenance windows, or the equity-index trading halt.

That allowed incomplete or stale candle sets to reach charts and backtests and made manual Backfill necessary during normal operation.

## Implementation

- Added a central candle integrity audit and repair service.
- Made normal candle GET requests automatically validate and repair cached data.
- Replaced stale partial candles with authoritative closed bars after close.
- Added CME futures-session-aware gap detection, including weekends, holidays, daily maintenance, DST, and the equity-index halt.
- Added single-flight request deduplication, three-attempt bounded transient retries, failure cooldowns, and vetted-cache fallback.
- Prevented partial bars from downgrading already-closed database rows.
- Routed specialized bot candle acquisition through the canonical repair path.
- Added strict backtest preflight for execution candles and TopBot auxiliary streams.
- Made replay-time gap reporting session-aware.
- Retained the existing `repair` request flag for compatibility, while removing the need for normal manual backfills.

## Behavior and safety

- No synthetic candles are created.
- Invalid provider rows cannot overwrite valid cached rows.
- Provider failure falls back to valid cached data where possible.
- Backtests fail cleanly before persistence when authoritative data remains incomplete.
- Repair windows and retry counts are bounded to prevent infinite repair loops.

## Database impact

No migration was added. SQLite query-plan profiling confirmed that candle range lookups use the existing `idx_projectx_market_candles_contract_ts` composite index and the existing uniqueness constraint already supports canonical timestamp storage.

## Validation

- `489 passed in 6.18s`
- Python syntax compilation passed for the modified services and API module.
- Git staged-diff integrity check passed.

Tests cover duplicate precedence, invalid OHLC/volume, overlaps, missing bars, incomplete tails, stale/current partials, maintenance periods, weekends, holidays, early closes, DST, request deduplication, retry limits, provider fallback, non-downgrade persistence, automatic request repair, and strict backtest preflight.

## Chart-cache integration notes

- Cache candles by contract, live mode, unit, unit number, and timestamp.
- Treat backend closed bars as authoritative over partial chart-cache entries.
- Candle responses are sorted, unique, and integrity-vetted.
- Manual Backfill should remain a diagnostic/compatibility action rather than a normal chart workflow.
- Concurrent performance integration commit `74cc070` is intentionally separate and may require conflict reconciliation in overlapping backend files.
