### PR TITLE
Speed up Signal Chart loading and candle repair

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,6 +207,7 @@ from .services.bot_backtesting import (
     MalformedBacktestDataError,
     UnsupportedBacktestStrategyError,
     create_bot_backtest,
+    prepare_bot_backtest_data,
     serialize_bot_backtest,
 )
 from .services.bot_serialization import serialize_supported_bot_configs
@@ -1615,6 +1616,45 @@ def delete_trading_bot(
     except LookupError as exc:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+    return Response(status_code=204)
+
+
+@app.post(
+    "/api/bots/{bot_config_id}/backtests/prepare",
+    status_code=204,
+)
+def prepare_trading_bot_backtest_data(
+    bot_config_id: int,
+    payload: BotBacktestIn,
+    db: Session = Depends(get_db),
+):
+    """Cache every historical stream required by a deterministic TopBot replay."""
+
+    user_id = get_authenticated_user_id()
+    if bot_config_id <= 0:
+        raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
+    try:
+        client = _projectx_client_for_user(db, user_id=user_id)
+        prepare_bot_backtest_data(
+            db,
+            user_id=user_id,
+            bot_config_id=bot_config_id,
+            payload=payload,
+            client=client,
+        )
+        db.commit()
+    except LookupError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
+    except BacktestError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
         db.rollback()
         raise

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -32,20 +32,27 @@ from .bot_service import (
     _session_window_utc_for_reference,
 )
 from .instruments import load_instrument_specs, normalize_symbol_key
+from .projectx_client import ProjectXClient
 from .bot_strategy_registry import (
     BACKTEST_SUPPORTED_STRATEGY_IDENTIFIERS,
     get_strategy_definition,
 )
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    futures_session_is_open,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
-BACKTEST_ENGINE_VERSION = "1.1.0"
+BACKTEST_ENGINE_VERSION = "1.2.0"
 MAX_BACKTEST_BARS = 20_000
 MAX_BACKTEST_RANGE_DAYS = 366
 MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
 MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
 MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
 MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
+MAX_PROVIDER_FETCH_BARS = 20_000
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -62,7 +69,7 @@ UNSUPPORTED_BACKTEST_STRATEGY_REASONS: dict[str, str] = {
     "supertrend_pivot": "requires synchronized signal-timeframe and closed daily candles",
     "fvg_sweep_mss": "requires synchronized FVG and lower-timeframe structure streams",
     "atr_adjusted_relative_strength": "requires an exactly aligned benchmark candle stream",
-    "relative_strength_spy": "requires an exactly aligned SPY candle stream",
+    "relative_strength_spy": "requires an exactly aligned MES benchmark candle stream",
     "vwap_gap_retrace": "requires fixed 1-minute data and alternative exit-path replay",
     "donchian_breakout": "requires stateful channel, trailing-stop, sizing, and entry-plan replay",
     "ema_scalping": "requires exact strong-opposite-candle exit replay",
@@ -202,13 +209,13 @@ class BacktestEngine:
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
+        self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
         auxiliary_excluded_partial = 0
-        missing_replay_streams: list[str] = []
+        deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
             (
                 self.topbot_streams,
                 auxiliary_excluded_partial,
-                missing_replay_streams,
             ) = _prepare_topbot_replay_streams(
                 config,
                 primary_candles=self.all_candles,
@@ -232,11 +239,35 @@ class BacktestEngine:
                 1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
             )
             if closed_by_first_event < hard_minimum:
-                raise InsufficientBacktestDataError(
-                    "insufficient_backtest_data: insufficient_strategy_warmup: "
-                    f"{self.strategy_type} requires at least {hard_minimum} bars closed by the "
-                    f"first replay event; found {closed_by_first_event}"
+                deferred_execution_bars = hard_minimum - closed_by_first_event
+                self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                if len(self.execution_candles) < MIN_EXECUTION_BARS:
+                    available_closed_bars = sum(
+                        1
+                        for candle in self.all_candles
+                        if _candle_close_time(candle) <= self.settings.end
+                    )
+                    raise InsufficientBacktestDataError(
+                        "insufficient_backtest_data: insufficient_strategy_warmup: "
+                        f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
+                        f"only {available_closed_bars} were available"
+                    )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            session_execution_candles = [
+                candle
+                for candle in self.execution_candles
+                if _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
                 )
+            ]
+            coverage_candles = session_execution_candles or self.execution_candles
+            self.topbot_unavailable_sources = _topbot_unavailable_sources(
+                config,
+                streams=self.topbot_streams,
+                first_event=_candle_close_time(coverage_candles[0]),
+                last_event=_candle_close_time(coverage_candles[-1]),
+            )
         if len(self.execution_candles) > MAX_BACKTEST_BARS:
             raise BacktestConfigurationError(
                 f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}; "
@@ -254,9 +285,16 @@ class BacktestEngine:
             rolling_limit=self.evaluator_history_limit,
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            signal_evaluation_bars = sum(
+                _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
+                )
+                for candle in self.execution_candles
+            )
             estimated_operations = _estimate_topbot_evaluator_operations(
                 config,
-                execution_bars=len(self.execution_candles),
+                execution_bars=signal_evaluation_bars,
             )
             operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
         else:
@@ -278,11 +316,20 @@ class BacktestEngine:
             self.warnings.append(
                 f"Excluded {auxiliary_excluded_partial} partial auxiliary candle(s); only closed bars were replayed."
             )
-        if missing_replay_streams:
+        if deferred_execution_bars:
             self.warnings.append(
-                "TopBot source data was unavailable for stored replay stream(s): "
-                + ", ".join(sorted(missing_replay_streams))
-                + ". Affected sources were recorded as failed for ensemble voting."
+                f"Deferred replay by {deferred_execution_bars} candle(s) so the strategy had "
+                "its required closed-bar warmup before the first evaluation."
+            )
+        if self.topbot_unavailable_sources:
+            excluded = "; ".join(
+                f"{source} ({', '.join(keys)})"
+                for source, keys in sorted(self.topbot_unavailable_sources.items())
+            )
+            self.warnings.append(
+                "TopBot excluded source(s) whose required stored replay data was unavailable: "
+                + excluded
+                + ". Vote thresholds were unchanged."
             )
         self._add_data_quality_warnings()
 
@@ -338,6 +385,15 @@ class BacktestEngine:
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
+            if (
+                self.strategy_type == _TOPBOT_STRATEGY
+                and not _event_timestamp_is_in_configured_session(
+                    self.config,
+                    candle_start,
+                )
+            ):
+                self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
+                continue
             signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
@@ -392,8 +448,8 @@ class BacktestEngine:
         )
         return {
             "range": {
-                "start": self.settings.start.isoformat(),
-                "end": self.settings.end.isoformat(),
+                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
+                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
             },
             "config_snapshot": _config_snapshot(self.config),
@@ -532,8 +588,11 @@ class BacktestEngine:
         )
         source_overrides = topbot_params.get("source_strategy_params") or {}
         source_results: list[dict[str, Any]] = []
+        event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
+            if source_strategy in self.topbot_unavailable_sources:
+                continue
             source_params = bot_service_module._normalize_strategy_params(
                 source_strategy,
                 source_overrides.get(source_strategy, {}),
@@ -542,6 +601,7 @@ class BacktestEngine:
                 source_strategy,
                 source_params=source_params,
                 event_time=event_time,
+                event_timestamp=event_timestamp,
             )
             cached = self._topbot_source_cache.get(source_strategy)
             if cached is not None and cached[0] == signature:
@@ -552,6 +612,7 @@ class BacktestEngine:
                     source_strategy,
                     source_params=source_params,
                     event_time=event_time,
+                    event_timestamp=event_timestamp,
                 )
             except Exception as exc:
                 result = {
@@ -577,6 +638,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
         for key in _topbot_source_stream_keys(
@@ -602,6 +664,11 @@ class BacktestEngine:
                         self.position.take_profit,
                     )
                 )
+        if source_strategy == "delayed_orb_confirmation":
+            # A one-minute stream must advance through every primary event.
+            # Including the event prevents a stale final minute from being
+            # cached and reused across the rest of a session or a later day.
+            signature.append(("primary_event", _as_utc(event_timestamp)))
         return tuple(signature)
 
     def _evaluate_topbot_source(
@@ -610,6 +677,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> dict[str, Any]:
         fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
             source_strategy,
@@ -706,67 +774,93 @@ class BacktestEngine:
                 base_order_size=float(self.config.order_size),
             )
         elif source_strategy == "delayed_orb_confirmation":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                _topbot_asset_stream_key("minute", 1),
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:delayed_orb_confirmation",
-                enforce=True,
-                expected_interval_seconds=60,
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                candles=source_candles,
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    _topbot_asset_stream_key("minute", 1),
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                    enforce=True,
+                    expected_interval_seconds=60,
+                )
+                _require_stream_current_through_event(
+                    source_candles,
+                    event_time=event_time,
+                    interval_seconds=60,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    candles=source_candles,
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                )
         elif source_strategy == "orb_fibonacci_pullback":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                primary_key,
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:orb_fibonacci_pullback",
-                enforce=True,
-                expected_interval_seconds=_timeframe_seconds(
-                    str(self.config.timeframe_unit),
-                    int(self.config.timeframe_unit_number),
-                ),
-            )
-            _require_complete_orb_opening_range(
-                source_candles,
-                config=source_config,
-                session_start=session_start,
-                latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                source_candles,
-                timeframe_unit=str(self.config.timeframe_unit),
-                timeframe_unit_number=int(self.config.timeframe_unit_number),
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-                session_end_time=str(self.config.trading_end_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    primary_key,
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:orb_fibonacci_pullback",
+                    enforce=True,
+                    expected_interval_seconds=_timeframe_seconds(
+                        str(self.config.timeframe_unit),
+                        int(self.config.timeframe_unit_number),
+                    ),
+                )
+                _require_complete_orb_opening_range(
+                    source_candles,
+                    config=source_config,
+                    session_start=session_start,
+                    latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    source_candles,
+                    timeframe_unit=str(self.config.timeframe_unit),
+                    timeframe_unit_number=int(self.config.timeframe_unit_number),
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                    session_end_time=str(self.config.trading_end_time),
+                )
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
@@ -1293,11 +1387,30 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            gaps = 0
-            for previous, current in zip(self.execution_candles, self.execution_candles[1:]):
-                delta = (_as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)).total_seconds()
-                if delta > expected_seconds * 1.5:
-                    gaps += 1
+            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
+            actual_end = _candle_close_time(self.execution_candles[-1])
+            if _has_open_futures_interval(
+                self.settings.start,
+                actual_start,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles began after the requested start; replay coverage begins at "
+                    f"{actual_start.isoformat()}."
+                )
+            if _has_open_futures_interval(
+                actual_end,
+                self.settings.end,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles ended before the requested end; replay coverage ends at "
+                    f"{actual_end.isoformat()}. The configured futures delivery may have expired or rolled."
+                )
+            gaps = _count_futures_session_gaps(
+                self.execution_candles,
+                interval_seconds=expected_seconds,
+            )
             if gaps:
                 self.warnings.append(
                     f"Detected {gaps} candle gap(s); the engine used the next available bar without interpolation."
@@ -1334,14 +1447,9 @@ class BacktestEngine:
                     if _as_utc(row.candle_timestamp) >= self.settings.start
                     and _candle_close_time(row) <= self.settings.end
                 ]
-                gaps = sum(
-                    1
-                    for previous, current in zip(execution_rows, execution_rows[1:])
-                    if (
-                        _as_utc(current.candle_timestamp)
-                        - _as_utc(previous.candle_timestamp)
-                    ).total_seconds()
-                    > expected * 1.5
+                gaps = _count_futures_session_gaps(
+                    execution_rows,
+                    interval_seconds=expected,
                 )
                 if gaps:
                     self.warnings.append(
@@ -1436,6 +1544,23 @@ def _relative_strength_spy_history_limit(
             50,
         ),
     )
+
+
+def _matching_benchmark_contract(
+    config: BotConfig,
+    source_params: Mapping[str, Any],
+) -> tuple[str | None, str]:
+    explicit_contract = source_params.get("benchmark_contract_id")
+    benchmark_symbol = str(source_params.get("benchmark_symbol") or "MES").strip().upper()
+    benchmark_root = benchmark_symbol.rsplit(".", 1)[-1]
+    canonical_symbol = f"F.US.{benchmark_root}"
+    if explicit_contract:
+        return str(explicit_contract), canonical_symbol
+
+    parts = str(config.contract_id).strip().split(".")
+    if len(parts) == 5 and parts[:3] == ["CON", "F", "US"]:
+        return ".".join([*parts[:3], benchmark_root, parts[4]]), canonical_symbol
+    return None, canonical_symbol
 
 
 def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec]:
@@ -1539,30 +1664,34 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
                 min(5000, max(fvg_limit * ratio, fvg_limit + 25)),
             )
         elif source_strategy == "atr_adjusted_relative_strength":
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit=primary_unit,
                 unit_number=primary_unit_number,
                 warmup_bars=max(25, int(config.lookback_bars)),
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
         elif source_strategy == "relative_strength_spy":
             limit = _relative_strength_spy_history_limit(config, source_params)
             add_asset("minute", 5, limit)
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit="minute",
                 unit_number=5,
                 warmup_bars=limit,
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
@@ -1617,7 +1746,7 @@ def _prepare_topbot_replay_streams(
     *,
     primary_candles: list[ProjectXMarketCandle],
     replay_streams: Mapping[str, list[ProjectXMarketCandle]] | None,
-) -> tuple[dict[str, _PreparedReplayStream], int, list[str]]:
+) -> tuple[dict[str, _PreparedReplayStream], int]:
     provided = dict(replay_streams or {})
     primary_key = _topbot_asset_stream_key(
         str(config.timeframe_unit),
@@ -1626,7 +1755,6 @@ def _prepare_topbot_replay_streams(
     provided[primary_key] = primary_candles
     prepared: dict[str, _PreparedReplayStream] = {}
     excluded_partial = 0
-    missing: list[str] = []
 
     for key, spec in _topbot_stream_specs(config).items():
         rows, excluded = _validate_topbot_replay_stream(
@@ -1635,14 +1763,12 @@ def _prepare_topbot_replay_streams(
             config=config,
         )
         excluded_partial += excluded
-        if not rows:
-            missing.append(key)
         prepared[key] = _PreparedReplayStream(
             candles=rows,
             start_times=[_as_utc(row.candle_timestamp) for row in rows],
             close_times=[_candle_close_time(row) for row in rows],
         )
-    return prepared, excluded_partial, missing
+    return prepared, excluded_partial
 
 
 def _validate_topbot_replay_stream(
@@ -1651,7 +1777,7 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -1723,6 +1849,71 @@ def _validate_topbot_replay_stream(
             f"ambiguous_benchmark_replay_stream:{spec.key}: configure benchmark_contract_id"
         )
     return closed, excluded_partial
+
+
+def _topbot_unavailable_sources(
+    config: BotConfig,
+    *,
+    streams: Mapping[str, _PreparedReplayStream],
+    first_event: datetime,
+    last_event: datetime,
+) -> dict[str, tuple[str, ...]]:
+    params = bot_service_module._normalize_strategy_params(
+        _TOPBOT_STRATEGY,
+        config.strategy_params,
+    )
+    overrides = params.get("source_strategy_params") or {}
+    specs = _topbot_stream_specs(config)
+    unavailable: dict[str, tuple[str, ...]] = {}
+    for source_strategy in params["source_strategies"]:
+        source_params = bot_service_module._normalize_strategy_params(
+            source_strategy,
+            overrides.get(source_strategy, {}),
+        )
+        missing = tuple(
+            key
+            for key in _topbot_source_stream_keys(
+                config,
+                source_strategy,
+                source_params=source_params,
+            )
+            if not _prepared_stream_covers_replay_window(
+                streams.get(key),
+                spec=specs.get(key),
+                first_event=first_event,
+                last_event=last_event,
+            )
+        )
+        if missing:
+            unavailable[source_strategy] = missing
+    return unavailable
+
+
+def _prepared_stream_covers_replay_window(
+    stream: _PreparedReplayStream | None,
+    *,
+    spec: _TopBotReplayStreamSpec | None,
+    first_event: datetime,
+    last_event: datetime,
+) -> bool:
+    if stream is None or not stream.candles or spec is None:
+        return False
+    interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+    if interval_seconds is None or interval_seconds <= 0:
+        return False
+    for event_time in (first_event, last_event):
+        event_utc = _as_utc(event_time)
+        closed_count = bisect_right(stream.close_times, event_utc)
+        if closed_count <= 0:
+            return False
+        latest_close = stream.close_times[closed_count - 1]
+        if _has_open_futures_interval(
+            latest_close,
+            event_utc,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: int) -> int:
@@ -1848,7 +2039,10 @@ def _load_topbot_replay_streams(
         warmup_rows = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars)))
+            # One candle can start before the requested range while closing
+            # after the first replay event. Overfetch it so the requested
+            # number of genuinely closed warmup bars remains available.
+            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
             .all()
         )
         warmup_rows.reverse()
@@ -1862,6 +2056,225 @@ def _load_topbot_replay_streams(
             )
 
     return streams
+
+
+def prepare_bot_backtest_data(
+    db: Session,
+    *,
+    user_id: str,
+    bot_config_id: int,
+    payload: Any,
+    client: ProjectXClient,
+) -> int:
+    """Populate TopBot's deterministic replay cache without running a replay."""
+
+    config = (
+        db.query(BotConfig)
+        .filter(BotConfig.user_id == user_id)
+        .filter(BotConfig.id == bot_config_id)
+        .one_or_none()
+    )
+    if config is None:
+        raise LookupError("bot_config_not_found")
+    if str(config.strategy_type) != _TOPBOT_STRATEGY:
+        return 0
+    _validate_replay_configuration(config)
+
+    start = _as_utc(payload.start)
+    end = _as_utc(payload.end)
+    if end <= start:
+        raise BacktestConfigurationError("backtest end must be after start")
+    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
+        raise BacktestConfigurationError(
+            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
+        )
+
+    fetch_end = min(end, datetime.now(timezone.utc))
+    requests: dict[tuple[str, str, int], tuple[str | None, datetime, int]] = {}
+    for spec in _topbot_stream_specs(config).values():
+        interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+        if interval_seconds is None or interval_seconds <= 0:
+            raise BacktestConfigurationError(
+                f"unsupported_topbot_replay_timeframe:{spec.unit}:{spec.unit_number}"
+            )
+        contract_id = spec.contract_id or spec.symbol
+        if not contract_id:
+            raise BacktestConfigurationError(f"topbot_replay_contract_missing:{spec.key}")
+        fetch_start = start - timedelta(
+            seconds=interval_seconds * max(25, int(spec.warmup_bars)) * 3
+        )
+        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
+        existing = requests.get(identity)
+        if existing is None or fetch_start < existing[1]:
+            requests[identity] = (spec.symbol, fetch_start, int(spec.warmup_bars))
+        elif int(spec.warmup_bars) > existing[2]:
+            requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
+
+    primary_identity = (
+        str(config.contract_id),
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
+    primary_execution_rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    primary_execution_rows = [
+        row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+    ]
+    first_event = (
+        _candle_close_time(primary_execution_rows[0])
+        if primary_execution_rows
+        else start
+    )
+    last_event = (
+        _candle_close_time(primary_execution_rows[-1])
+        if primary_execution_rows
+        else fetch_end
+    )
+
+    prepared_count = 0
+    for (contract_id, unit, unit_number), (symbol, fetch_start, warmup_bars) in requests.items():
+        interval_seconds = _timeframe_seconds(unit, unit_number)
+        assert interval_seconds is not None
+        identity = (contract_id, unit, unit_number)
+        primary_cache_is_clean = not any(
+            _cached_candle_was_fetched_before_nominal_close(row)
+            for row in primary_execution_rows
+        ) and not _candle_stream_has_overlaps(primary_execution_rows)
+        if (
+            identity == primary_identity
+            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
+            and primary_cache_is_clean
+        ):
+            continue
+        if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
+            db,
+            user_id=user_id,
+            contract_id=contract_id,
+            unit=unit,
+            unit_number=unit_number,
+            fetch_start=fetch_start,
+            requested_start=start,
+            first_event=first_event,
+            last_event=last_event,
+            warmup_bars=warmup_bars,
+        ):
+            continue
+        cursor = fetch_start
+        chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
+        while cursor < fetch_end:
+            chunk_end = min(fetch_end, cursor + chunk_span)
+            bot_service_module.fetch_and_store_market_candles(
+                db,
+                user_id=user_id,
+                client=client,
+                contract_id=contract_id,
+                symbol=symbol,
+                live=False,
+                start=cursor,
+                end=chunk_end,
+                unit=unit,
+                unit_number=unit_number,
+                limit=MAX_PROVIDER_FETCH_BARS,
+                include_partial_bar=False,
+                prefer_current_contract=False,
+                preserve_cached_history=True,
+                authoritative_refresh=True,
+            )
+            if chunk_end >= fetch_end:
+                break
+            cursor = chunk_end
+        prepared_count += 1
+
+        if identity == primary_identity:
+            primary_execution_rows = (
+                db.query(ProjectXMarketCandle)
+                .filter(ProjectXMarketCandle.user_id == user_id)
+                .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+                .filter(ProjectXMarketCandle.live.is_(False))
+                .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+                .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+                .filter(ProjectXMarketCandle.is_partial.is_(False))
+                .filter(ProjectXMarketCandle.candle_timestamp >= start)
+                .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+                .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+                .all()
+            )
+            primary_execution_rows = [
+                row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+            ]
+            if primary_execution_rows:
+                first_event = _candle_close_time(primary_execution_rows[0])
+                last_event = _candle_close_time(primary_execution_rows[-1])
+
+    return prepared_count
+
+
+def _cached_replay_stream_covers(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    unit: str,
+    unit_number: int,
+    fetch_start: datetime,
+    requested_start: datetime,
+    first_event: datetime,
+    last_event: datetime,
+    warmup_bars: int,
+) -> bool:
+    interval_seconds = _timeframe_seconds(unit, unit_number)
+    if interval_seconds is None:
+        return False
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == contract_id)
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
+        return False
+    if _candle_stream_has_overlaps(rows):
+        return False
+    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
+    warmup_count = sum(
+        _as_utc(row.candle_timestamp) < requested_start
+        for row in closed_by_first
+    )
+    if warmup_count < max(1, int(warmup_bars)):
+        return False
+
+    for event, candidates in (
+        (first_event, closed_by_first),
+        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+    ):
+        if not candidates:
+            return False
+        latest_close = _candle_close_time(candidates[-1])
+        if _has_open_futures_interval(
+            latest_close,
+            event,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def run_backtest(
@@ -2032,8 +2445,8 @@ def create_bot_backtest(
         timeframe_unit_number=int(config.timeframe_unit_number),
         requested_start=start,
         requested_end=end,
-        actual_start=_as_utc(execution_rows[0].candle_timestamp) if execution_rows else start,
-        actual_end=_candle_close_time(execution_rows[-1]) if execution_rows else end,
+        actual_start=_as_utc(datetime.fromisoformat(str(result["range"]["start"]))),
+        actual_end=_as_utc(datetime.fromisoformat(str(result["range"]["end"]))),
         starting_balance=float(payload.starting_balance),
         commission_per_contract=float(payload.commission_per_contract),
         slippage_ticks=float(payload.slippage_ticks),
@@ -2197,7 +2610,7 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -2254,6 +2667,36 @@ def _validate_and_sort_candles(
         if values["volume"] < 0:
             raise MalformedBacktestDataError(f"negative_candle_volume:{timestamp.isoformat()}")
     return closed, excluded_partial
+
+
+def _cached_candle_is_effectively_partial(candle: ProjectXMarketCandle) -> bool:
+    return bool(candle.is_partial) or _cached_candle_was_fetched_before_nominal_close(candle)
+
+
+def _cached_candle_was_fetched_before_nominal_close(
+    candle: ProjectXMarketCandle,
+) -> bool:
+    if str(candle.unit) not in {"second", "minute", "hour"}:
+        return False
+    fetched_at = candle.fetched_at
+    if fetched_at is None:
+        return False
+    raw_payload = candle.raw_payload
+    if isinstance(raw_payload, dict) and any(
+        key in raw_payload for key in ("isPartial", "is_partial", "partial")
+    ):
+        return False
+    return _as_utc(fetched_at) < _candle_close_time(candle)
+
+
+def _candle_stream_has_overlaps(candles: list[ProjectXMarketCandle]) -> bool:
+    previous_close_time: datetime | None = None
+    for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp)):
+        timestamp = _as_utc(row.candle_timestamp)
+        if previous_close_time is not None and timestamp < previous_close_time:
+            return True
+        previous_close_time = _candle_close_time(row)
+    return False
 
 
 def _candle_close_time(candle: ProjectXMarketCandle) -> datetime:
@@ -2625,7 +3068,9 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
             "oversized_entries_are_blocked_not_capped"
         ),
         "session_rule": (
-            "entries_obey_bot_session_after-loss_cooldown_daily-trade_and_daily-loss_limits; "
+            "TopBot signals are evaluated only during the configured session while resting "
+            "brackets are processed on every execution candle; entries obey bot session "
+            "after-loss cooldown, daily-trade, and daily-loss limits; "
             "counters_reset_at_requested_start_and_loss_uses_isolated_simulated_realized_net_pnl"
         ),
         "commission_rule": "commission_per_contract_is_charged_per_side",
@@ -2647,6 +3092,61 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
 def _timeframe_seconds(unit: str, unit_number: int) -> int | None:
     seconds = _UNIT_SECONDS.get(unit)
     return seconds * unit_number if seconds is not None else None
+
+
+def _count_futures_session_gaps(
+    candles: list[ProjectXMarketCandle],
+    *,
+    interval_seconds: int,
+) -> int:
+    gaps = 0
+    for previous, current in zip(candles, candles[1:]):
+        previous_timestamp = _as_utc(previous.candle_timestamp)
+        current_timestamp = _as_utc(current.candle_timestamp)
+        elapsed = int((current_timestamp - previous_timestamp).total_seconds())
+        missing_slots = max(0, int(round(elapsed / interval_seconds)) - 1)
+        if missing_slots and _contains_open_futures_timestamp(
+            previous_timestamp + timedelta(seconds=interval_seconds),
+            current_timestamp,
+            step_seconds=interval_seconds,
+        ):
+            gaps += 1
+    return gaps
+
+
+def _has_open_futures_interval(
+    start: datetime,
+    end: datetime,
+    *,
+    interval_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc - cursor <= timedelta(seconds=interval_seconds * 1.5):
+        return False
+    return _contains_open_futures_timestamp(
+        cursor + timedelta(seconds=interval_seconds),
+        end_utc,
+        step_seconds=interval_seconds,
+    )
+
+
+def _contains_open_futures_timestamp(
+    start: datetime,
+    end: datetime,
+    *,
+    step_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    # Session boundaries are minute-aligned, so sub-minute streams need not
+    # scan every second across a weekend closure.
+    step = timedelta(seconds=max(60, int(step_seconds)))
+    while cursor < end_utc:
+        if futures_session_is_open(cursor):
+            return True
+        cursor += step
+    return False
 
 
 def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
@@ -2687,6 +3187,57 @@ def _first_index_at_or_after(
         else:
             high = middle
     return low
+
+
+def _topbot_outside_session_signal(
+    strategy_type: str,
+    *,
+    event_timestamp: datetime,
+) -> SignalResult:
+    return SignalResult(
+        action="HOLD",
+        reason="Outside the configured trading session.",
+        candle_timestamp=_as_utc(event_timestamp),
+        price=None,
+        raw_payload={
+            "strategy_type": strategy_type,
+            "outside_configured_session": True,
+        },
+    )
+
+
+def _event_timestamp_is_in_configured_session(
+    config: BotConfig,
+    event_timestamp: datetime,
+) -> bool:
+    timestamp = _as_utc(event_timestamp)
+    if not futures_session_is_open(timestamp):
+        return False
+    session_start, session_end = _session_window_utc_for_reference(
+        timestamp,
+        start_text=str(config.trading_start_time),
+        end_text=str(config.trading_end_time),
+    )
+    return session_start <= timestamp <= session_end
+
+
+def _require_stream_current_through_event(
+    candles: list[ProjectXMarketCandle],
+    *,
+    event_time: datetime,
+    interval_seconds: int,
+    strategy_type: str,
+) -> None:
+    if not candles:
+        return
+    expected_latest_start = _as_utc(event_time) - timedelta(seconds=interval_seconds)
+    actual_latest_start = _as_utc(candles[-1].candle_timestamp)
+    if actual_latest_start != expected_latest_start:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: incomplete_session_history: "
+            f"{strategy_type} is missing the closed candle at "
+            f"{expected_latest_start.isoformat()}"
+        )
 
 
 def _require_complete_session_prefix(

--- a/backend/app/services/bot_candle_acquisition.py
+++ b/backend/app/services/bot_candle_acquisition.py
@@ -219,7 +219,7 @@ def acquire_and_evaluate_strategy(
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             asset_candles=asset_candles,
-            benchmark_candles=candle_sets.get("SPY", []),
+            benchmark_candles=candle_sets.get("benchmark", []),
             strategy_params=strategy_params,
         )
         return asset_candles, signal

--- a/backend/app/services/bot_market_analysis.py
+++ b/backend/app/services/bot_market_analysis.py
@@ -5,6 +5,8 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Iterable, Sequence
 from zoneinfo import ZoneInfo
 
+from .trading_day import futures_session_is_open
+
 
 ANALYSIS_VERSION = "market_analysis_v2"
 PROBABILITY_METHOD = "heuristic_scenario_weight"
@@ -523,7 +525,7 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
         missing = sum(
             1
             for index in range(1, raw_missing + 1)
-            if _is_futures_session_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
+            if futures_session_is_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
         )
         if missing <= 0:
             continue
@@ -535,21 +537,6 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
             }
         )
     return gaps[:20]
-
-
-def _is_futures_session_open(timestamp: datetime) -> bool:
-    local = timestamp.astimezone(_NEW_YORK)
-    weekday = local.weekday()
-    local_time = local.time()
-    if weekday == 5:
-        return False
-    if weekday == 6 and local_time < time(18, 0):
-        return False
-    if weekday == 4 and local_time >= time(17, 0):
-        return False
-    if time(17, 0) <= local_time < time(18, 0):
-        return False
-    return True
 
 
 def _true_ranges(rows: list[dict[str, Any]]) -> list[float]:

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -72,6 +72,7 @@ _UNIT_SECONDS_BY_NAME = {
 }
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
+_MARKET_CANDLE_UPSERT_BATCH_SIZE = 1_000
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -301,7 +302,7 @@ _FVG_SWEEP_MSS_DEFAULTS = {
     "target_mode": _FVG_TARGET_MODE_NEXT_LIQUIDITY,
 }
 _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "move_lookback_bars": 3,
     "atr_period": 14,
     "relative_volume_period": 20,
@@ -314,7 +315,7 @@ _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
     "take_profit_r_multiple": 2.0,
 }
 _RELATIVE_STRENGTH_SPY_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "comparison_bars": 12,
     "pullback_lookback_bars": 3,
     "relative_volume_period": 20,
@@ -1476,7 +1477,7 @@ def fetch_and_store_relative_strength_spy_candles(
             prefer_current_contract=True,
             preserve_cached_history=True,
         ),
-        "SPY": fetch_and_store_market_candles(
+        "benchmark": fetch_and_store_market_candles(
             db,
             user_id=user_id,
             client=client,
@@ -1731,6 +1732,7 @@ def fetch_and_store_market_candles(
     include_partial_bar: bool = False,
     prefer_current_contract: bool = False,
     preserve_cached_history: bool = False,
+    authoritative_refresh: bool = False,
 ) -> list[ProjectXMarketCandle]:
     normalized_unit = str(unit).strip().lower()
     if normalized_unit not in _PROJECTX_UNIT_BY_NAME:
@@ -1785,6 +1787,31 @@ def fetch_and_store_market_candles(
         unit_number=unit_number,
         bars=bars,
     )
+    if authoritative_refresh and stored:
+        provider_timestamps = [_as_utc(row.candle_timestamp) for row in stored]
+        provider_timestamp_set = set(provider_timestamps)
+        provider_start = min(provider_timestamps)
+        provider_end = max(provider_timestamps)
+        prune_market_candle_cache_range(
+            db,
+            user_id=user_id,
+            contract_id=resolved_contract_id,
+            live=live,
+            start=provider_start,
+            end=provider_end,
+            unit=normalized_unit,
+            unit_number=unit_number,
+            keep_timestamps=provider_timestamps,
+        )
+        cached = [
+            row
+            for row in cached
+            if (
+                _as_utc(row.candle_timestamp) < provider_start
+                or _as_utc(row.candle_timestamp) > provider_end
+                or _as_utc(row.candle_timestamp) in provider_timestamp_set
+            )
+        ]
     if not preserve_cached_history:
         return stored
 
@@ -2210,31 +2237,33 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
         return
 
     table = ProjectXMarketCandle.__table__
-    insert_stmt = postgresql_insert(table).values(values)
-    excluded = insert_stmt.excluded
-    db.execute(
-        insert_stmt.on_conflict_do_update(
-            index_elements=[
-                table.c.user_id,
-                table.c.contract_id,
-                table.c.live,
-                table.c.unit,
-                table.c.unit_number,
-                table.c.candle_timestamp,
-            ],
-            set_={
-                "symbol": excluded.symbol,
-                "open_price": excluded.open_price,
-                "high_price": excluded.high_price,
-                "low_price": excluded.low_price,
-                "close_price": excluded.close_price,
-                "volume": excluded.volume,
-                "is_partial": excluded.is_partial,
-                "raw_payload": excluded.raw_payload,
-                "fetched_at": excluded.fetched_at,
-            },
+    for offset in range(0, len(values), _MARKET_CANDLE_UPSERT_BATCH_SIZE):
+        batch = values[offset : offset + _MARKET_CANDLE_UPSERT_BATCH_SIZE]
+        insert_stmt = postgresql_insert(table).values(batch)
+        excluded = insert_stmt.excluded
+        db.execute(
+            insert_stmt.on_conflict_do_update(
+                index_elements=[
+                    table.c.user_id,
+                    table.c.contract_id,
+                    table.c.live,
+                    table.c.unit,
+                    table.c.unit_number,
+                    table.c.candle_timestamp,
+                ],
+                set_={
+                    "symbol": excluded.symbol,
+                    "open_price": excluded.open_price,
+                    "high_price": excluded.high_price,
+                    "low_price": excluded.low_price,
+                    "close_price": excluded.close_price,
+                    "volume": excluded.volume,
+                    "is_partial": excluded.is_partial,
+                    "raw_payload": excluded.raw_payload,
+                    "fetched_at": excluded.fetched_at,
+                },
+            )
         )
-    )
 
 
 def _query_market_candles_by_timestamps(
@@ -2628,6 +2657,7 @@ def evaluate_relative_strength_vs_spy(
     strategy_params: dict[str, Any] | None = None,
 ) -> SignalResult:
     params = _normalize_strategy_params(_STRATEGY_RELATIVE_STRENGTH_SPY, strategy_params)
+    benchmark_name = str(params["benchmark_symbol"])
     comparison_bars = int(params["comparison_bars"])
     pullback_lookback_bars = int(params["pullback_lookback_bars"])
     relative_volume_period = int(params["relative_volume_period"])
@@ -2661,7 +2691,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="HOLD",
             reason=(
-                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and SPY; "
+                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and {benchmark_name}; "
                 f"found {len(aligned_asset)}."
             ),
             candle_timestamp=latest_timestamp,
@@ -2750,7 +2780,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol outperformed SPY over {comparison_bars} candles, but SPY is not in a meaningful pullback "
+                    f"Symbol outperformed {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful pullback "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2760,7 +2791,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent <= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol outperformed SPY overall, but it did not hold up better during the latest SPY pullback.",
+                reason=(
+                    f"Symbol outperformed {benchmark_name} overall, but it did not hold up better "
+                    f"during the latest {benchmark_name} pullback."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2807,7 +2841,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="BUY",
             reason=(
-                f"BUY on relative strength vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"BUY on relative strength vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {long_entry[0]} "
                 f"{_format_strategy_price(long_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -2823,7 +2857,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol lagged SPY over {comparison_bars} candles, but SPY is not in a meaningful bounce "
+                    f"Symbol lagged {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful bounce "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2833,7 +2868,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent >= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol lagged SPY overall, but it bounced too much during the latest SPY rebound.",
+                reason=(
+                    f"Symbol lagged {benchmark_name} overall, but it bounced too much during the "
+                    f"latest {benchmark_name} rebound."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2880,7 +2918,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="SELL",
             reason=(
-                f"SELL on relative weakness vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"SELL on relative weakness vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {short_entry[0]} "
                 f"{_format_strategy_price(short_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -9633,6 +9671,8 @@ def _validate_strategy_configuration(
     slow_period: int,
 ) -> None:
     _validate_strategy_periods(fast_period, slow_period)
+    if strategy_type == _STRATEGY_TOPBOT_ADAPTIVE and str(timeframe_unit) == "month":
+        raise ValueError("TopBot Adaptive does not support month candles.")
     if strategy_type != _STRATEGY_EMA_SCALPING:
         return
     if str(timeframe_unit) != "minute" or int(timeframe_unit_number) not in _EMA_SCALPING_ALLOWED_MINUTE_BUCKETS:
@@ -9852,8 +9892,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_ATR_ADJUSTED_RELATIVE_STRENGTH:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         return {
@@ -9932,8 +9973,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_RELATIVE_STRENGTH_SPY:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         swing_window = _bounded_int_param(
@@ -10902,6 +10944,15 @@ def _validate_unique_bot_name(
 
 def _looks_like_projectx_contract_id(value: str) -> bool:
     return value.upper().startswith("CON.")
+
+
+def _normalize_projectx_benchmark_symbol(value: Any, *, default: str) -> str:
+    """Map the legacy SPY benchmark to the MES futures feed ProjectX supports."""
+
+    normalized = _normalized_optional_text(value) or str(default)
+    if normalized.strip().upper() in {"SPY", "F.US.SPY"}:
+        return "MES"
+    return normalized.strip().upper()
 
 
 def _pick_market_contract(rows: Iterable[dict[str, Any]]) -> dict[str, Any] | None:

--- a/backend/app/services/projectx_client.py
+++ b/backend/app/services/projectx_client.py
@@ -23,6 +23,8 @@ _TOKEN_CACHE_BY_KEY: dict[str, _TokenCache] = {}
 _TOKEN_SAFETY_WINDOW = timedelta(seconds=60)
 _PROJECTX_ORDER_TYPES = {1, 2, 4, 5, 6, 7}
 _PROJECTX_ORDER_SIDES = {0, 1}
+_PROJECTX_INTRADAY_UNIT_SECONDS = {1: 1, 2: 60, 3: 60 * 60}
+_PARTIAL_BAR_KEYS = ("isPartial", "is_partial", "partial")
 
 
 class ProjectXClientError(RuntimeError):
@@ -183,6 +185,15 @@ class ProjectXClient:
             timestamp = _parse_datetime(_first_value(row, ["t", "timestamp", "time"]))
             if timestamp is None:
                 continue
+            has_partial_marker = any(key in row for key in _PARTIAL_BAR_KEYS)
+            is_partial = _is_truthy(_first_value(row, list(_PARTIAL_BAR_KEYS)))
+            interval_seconds = _PROJECTX_INTRADAY_UNIT_SECONDS.get(int(unit))
+            if not has_partial_marker and interval_seconds is not None:
+                is_partial = timestamp + timedelta(
+                    seconds=interval_seconds * max(1, int(unit_number))
+                ) > _as_utc(end)
+            if is_partial and not include_partial_bar:
+                continue
 
             output.append(
                 {
@@ -192,7 +203,7 @@ class ProjectXClient:
                     "low": _safe_float(_first_value(row, ["l", "low"])),
                     "close": _safe_float(_first_value(row, ["c", "close"])),
                     "volume": _safe_float(_first_value(row, ["v", "volume"])),
-                    "is_partial": _is_truthy(_first_value(row, ["isPartial", "is_partial", "partial"])),
+                    "is_partial": is_partial,
                     "raw_payload": row,
                 }
             )

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -34,3 +34,20 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     )
     end_local = start_local + timedelta(days=1) - timedelta(microseconds=1)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def futures_session_is_open(value: datetime) -> bool:
+    """Return whether a timestamp falls inside the regular CME Globex week."""
+
+    local = as_utc(value).astimezone(TRADING_TZ)
+    weekday = local.weekday()
+    local_time = local.time()
+    if weekday == 5:
+        return False
+    if weekday == 6 and local_time < time(hour=18):
+        return False
+    if weekday == 4 and local_time >= time(hour=17):
+        return False
+    if time(hour=17) <= local_time < time(hour=18):
+        return False
+    return True

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -238,6 +238,55 @@ def test_signal_evaluation_receives_only_bars_closed_as_of_each_event():
     assert all(BASE_TIME + timedelta(minutes=15) not in call for call in observed)
 
 
+def test_topbot_defers_replay_when_requested_start_precedes_available_warmup():
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(30)
+    ]
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            strategy_params={"source_strategies": ["sma_cross"]},
+            lookback_bars=25,
+        ),
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=150),
+    )
+
+    assert result["range"]["start"] == (BASE_TIME + timedelta(minutes=120)).isoformat()
+    assert result["range"]["bar_count"] == 6
+    assert any("Deferred replay by 24 candle(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_only_evaluates_signals_inside_the_configured_session():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    bars = [
+        _candle(session_open + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-2, 2)
+    ]
+    evaluated: list[datetime] = []
+
+    def evaluator(candles):
+        evaluated.append(_utc(candles[-1].candle_timestamp))
+        return _hold(candles)
+
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            trading_start_time="09:30",
+            trading_end_time="15:45",
+        ),
+        evaluator=evaluator,
+        start=session_open - timedelta(minutes=10),
+        end=session_open + timedelta(minutes=10),
+    )
+
+    assert result["range"]["bar_count"] == 4
+    assert evaluated == [session_open, session_open + timedelta(minutes=5)]
+
+
 def test_orb_evaluator_keeps_the_true_session_open_beyond_configured_lookback():
     session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
     bars = [
@@ -948,7 +997,472 @@ def test_topbot_replay_records_missing_auxiliary_stream_as_source_failure():
 
     assert result["metrics"]["trade_count"] == 0
     assert any("asset:hour:1" in warning for warning in result["warnings"])
-    assert any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert not any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert any("TopBot excluded source(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_replay_excludes_a_benchmark_that_stops_before_the_replay_tail(
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": ["atr_adjusted_relative_strength"],
+            "minimum_directional_votes": 1,
+        },
+        lookback_bars=25,
+    )
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 4)
+    ]
+    benchmark = _candle(
+        BASE_TIME - timedelta(minutes=5),
+        contract_id="CON.F.US.MES.M26",
+        symbol="F.US.MES",
+    )
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"stale source {identifier} should have been excluded")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=20),
+        replay_streams={
+            backtesting_module._topbot_benchmark_stream_key(
+                "atr_adjusted_relative_strength"
+            ): [benchmark],
+        },
+    )
+
+    assert result["metrics"]["trade_count"] == 0
+    assert any(
+        "benchmark:atr_adjusted_relative_strength" in warning
+        and "TopBot excluded source(s)" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_benchmark_specs_use_mes_with_the_asset_delivery():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+            "source_strategy_params": {
+                "atr_adjusted_relative_strength": {"benchmark_symbol": "SPY"},
+                "relative_strength_spy": {"benchmark_symbol": "SPY"},
+            },
+        },
+        contract_id="CON.F.US.MNQ.M26",
+    )
+
+    specs = backtesting_module._topbot_stream_specs(config)
+
+    for source in ("atr_adjusted_relative_strength", "relative_strength_spy"):
+        spec = specs[backtesting_module._topbot_benchmark_stream_key(source)]
+        assert spec.contract_id == "CON.F.US.MES.M26"
+        assert spec.symbol == "F.US.MES"
+        assert spec.unit == "minute"
+        assert spec.unit_number == 5
+
+
+def test_topbot_cache_preparation_deduplicates_shared_mes_benchmark(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+
+    class StubClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("exact historical deliveries should not be re-resolved")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return []
+
+    client = StubClient()
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+        ),
+        client=client,
+    )
+
+    assert prepared == 2
+    assert {call["contract_id"] for call in client.calls} == {
+        CONTRACT_ID,
+        "CON.F.US.MES.M26",
+    }
+    assert sum(call["contract_id"] == "CON.F.US.MES.M26" for call in client.calls) == 1
+
+
+def test_topbot_cache_preparation_skips_streams_that_already_cover_the_replay(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+        lookback_bars=25,
+    )
+    db_session.add_all([_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))])
+    db_session.commit()
+
+    class UnexpectedClient:
+        def retrieve_bars(self, **_kwargs):
+            raise AssertionError("covered streams should not be fetched again")
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_cached_replay_stream_covers",
+        lambda *_args, **_kwargs: True,
+    )
+
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=10),
+        ),
+        client=UnexpectedClient(),
+    )
+
+    assert prepared == 0
+
+
+def test_topbot_cache_coverage_rejects_overlapping_candles(db_session):
+    canonical = [
+        _candle(
+            BASE_TIME - timedelta(hours=4 * index),
+            unit="hour",
+            unit_number=4,
+        )
+        for index in range(26, 0, -1)
+    ]
+    overlap = _candle(
+        BASE_TIME - timedelta(hours=6),
+        unit="hour",
+        unit_number=4,
+    )
+    db_session.add_all([*canonical, overlap])
+    db_session.commit()
+
+    assert not backtesting_module._cached_replay_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="hour",
+        unit_number=4,
+        fetch_start=BASE_TIME - timedelta(days=7),
+        requested_start=BASE_TIME,
+        first_event=BASE_TIME + timedelta(minutes=5),
+        last_event=BASE_TIME + timedelta(minutes=10),
+        warmup_bars=25,
+    )
+
+
+def test_topbot_replay_excludes_legacy_unmarked_four_hour_tail_snapshot():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+    )
+    fetched_after_close = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    canonical = [
+        _candle(
+            timestamp,
+            unit="hour",
+            unit_number=4,
+        )
+        for timestamp in (
+            datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        )
+    ]
+    for row in canonical:
+        row.fetched_at = fetched_after_close
+        row.raw_payload = {"t": row.candle_timestamp.isoformat()}
+    stale_tail = _candle(
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        unit="hour",
+        unit_number=4,
+    )
+    stale_tail.fetched_at = datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc)
+    stale_tail.raw_payload = {"t": stale_tail.candle_timestamp.isoformat()}
+    spec = backtesting_module._topbot_stream_specs(config)[
+        backtesting_module._topbot_asset_stream_key("hour", 4)
+    ]
+
+    rows, excluded = backtesting_module._validate_topbot_replay_stream(
+        [canonical[0], stale_tail, canonical[1]],
+        spec=spec,
+        config=config,
+    )
+
+    assert [_utc(row.candle_timestamp) for row in rows] == [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+    ]
+    assert excluded == 1
+
+
+def test_topbot_cache_preparation_rejects_monthly_primary_candles(db_session):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        timeframe_unit="month",
+        timeframe_unit_number=1,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="TopBot Adaptive does not support month candles",
+    ):
+        backtesting_module.prepare_bot_backtest_data(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(days=31),
+            ),
+            client=object(),
+        )
+
+
+@pytest.mark.parametrize(
+    "event_start",
+    [
+        datetime(2026, 7, 6, 13, 20, tzinfo=timezone.utc),  # Before 09:30 ET.
+        datetime(2026, 7, 6, 20, 0, tzinfo=timezone.utc),   # After 15:45 ET.
+        datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc),   # Sunday.
+    ],
+)
+def test_topbot_orb_skips_events_outside_the_configured_session(
+    event_start,
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert not any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_does_not_dispatch_during_a_sunday_closure(monkeypatch):
+    event_start = datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+    one_minute = [
+        _candle(
+            event_start + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(10)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_orb_still_reports_a_genuinely_missing_session_open():
+    event_start = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(event_start - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(event_start),
+        _candle(event_start + timedelta(minutes=5)),
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        and "requires the session-opening candle" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_excludes_a_truncated_one_minute_tail():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(session_open - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(session_open),
+        _candle(session_open + timedelta(minutes=5)),
+    ]
+    one_minute = [
+        _candle(
+            session_open + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(5)
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=session_open,
+        end=session_open + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert any(
+        "TopBot excluded source(s)" in warning
+        and "delayed_orb_confirmation (asset:minute:1)" in warning
+        for warning in result["warnings"]
+    )
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_futures_gap_detection_ignores_weekends_but_flags_open_session_holes():
+    friday_close = datetime(2026, 7, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)
+    weekend_rows = [_candle(friday_close), _candle(sunday_open)]
+    open_session_rows = [
+        _candle(BASE_TIME),
+        _candle(BASE_TIME + timedelta(minutes=10)),
+    ]
+
+    assert backtesting_module._count_futures_session_gaps(
+        weekend_rows,
+        interval_seconds=300,
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        open_session_rows,
+        interval_seconds=300,
+    ) == 1
+
+
+def test_backtest_range_reports_actual_stored_coverage():
+    bars = [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))]
+
+    result = _run(
+        bars,
+        evaluator=_hold,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(days=1),
+    )
+
+    assert result["range"]["start"] == BASE_TIME.isoformat()
+    assert result["range"]["end"] == (BASE_TIME + timedelta(minutes=10)).isoformat()
+    assert any("Stored candles ended before the requested end" in warning for warning in result["warnings"])
 
 
 def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
@@ -977,11 +1491,14 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             raw_payload={},
         )
 
-    benchmark = _candle(
-        BASE_TIME - timedelta(minutes=5),
-        contract_id="SPY",
-        symbol="SPY",
-    )
+    benchmark = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id="CON.F.US.MES.M26",
+            symbol="F.US.MES",
+        )
+        for index in range(-5, 3)
+    ]
     monkeypatch.setattr(backtesting_module.bot_service_module, "dispatch_strategy_evaluator", fake_dispatch)
 
     result = _run(
@@ -991,7 +1508,12 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
         end=BASE_TIME + timedelta(minutes=15),
         replay_streams={
             backtesting_module._topbot_asset_stream_key("minute", 1): [
-                _candle(BASE_TIME, unit="minute", unit_number=1)
+                _candle(
+                    BASE_TIME + timedelta(minutes=index),
+                    unit="minute",
+                    unit_number=1,
+                )
+                for index in range(15)
             ],
             backtesting_module._topbot_asset_stream_key("hour", 1): [
                 _candle(BASE_TIME - timedelta(hours=1), unit="hour", unit_number=1)
@@ -1004,10 +1526,10 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             ],
             backtesting_module._topbot_benchmark_stream_key(
                 "atr_adjusted_relative_strength"
-            ): [benchmark],
-            backtesting_module._topbot_benchmark_stream_key("relative_strength_spy"): [
-                benchmark
-            ],
+            ): benchmark,
+            backtesting_module._topbot_benchmark_stream_key(
+                "relative_strength_spy"
+            ): benchmark,
         },
     )
 
@@ -1174,7 +1696,7 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
     )
     first_validated = BotBacktestOut.model_validate(first)
 
-    assert first_validated.engine_version == "1.1.0"
+    assert first_validated.engine_version == "1.2.0"
     assert first_validated.metrics.trade_count == 1
     assert not any("strategy_not_supported" in warning for warning in first["warnings"])
 

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -2704,8 +2704,8 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2724,7 +2724,7 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
     )
 
     assert signal.action == "BUY"
-    assert "BUY on relative strength vs SPY" in signal.reason
+    assert "BUY on relative strength vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] > signal.price
     assert signal.raw_payload["stop_loss"] < signal.price
@@ -2763,8 +2763,8 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2783,13 +2783,13 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
     )
 
     assert signal.action == "SELL"
-    assert "SELL on relative weakness vs SPY" in signal.reason
+    assert "SELL on relative weakness vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] < signal.price
     assert signal.raw_payload["stop_loss"] > signal.price
 
 
-def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
+def test_relative_strength_vs_spy_fetches_symbol_and_mes_five_minute_candles():
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -2804,8 +2804,8 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             self.calls = []
 
         def search_contracts(self, *, search_text: str, live: bool = False):
-            if search_text == "SPY":
-                return [{"id": "CON.F.US.SPY.M26", "symbol_id": "SPY", "active_contract": True}]
+            if search_text == "MES":
+                return [{"id": "CON.F.US.MES.M26", "symbol_id": "F.US.MES", "active_contract": True}]
             return []
 
         def retrieve_bars(self, **kwargs):
@@ -2849,15 +2849,48 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             strategy_params={"benchmark_symbol": "SPY"},
         )
 
-        assert rows == {"5m": [], "SPY": []}
+        assert rows == {"5m": [], "benchmark": []}
         assert [(call["contract_id"], call["unit"], call["unit_number"], call["limit"]) for call in client.calls] == [
             ("CON.F.US.MNQ.M26", 2, 5, 50),
-            ("CON.F.US.SPY.M26", 2, 5, 50),
+            ("CON.F.US.MES.M26", 2, 5, 50),
         ]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
         engine.dispose()
+
+
+def test_postgres_market_candle_upserts_are_batched(monkeypatch):
+    batch_sizes: list[int] = []
+
+    class Excluded:
+        def __getattr__(self, name):
+            return name
+
+    class Insert:
+        excluded = Excluded()
+
+        def values(self, batch):
+            batch_sizes.append(len(batch))
+            return self
+
+        def on_conflict_do_update(self, **_kwargs):
+            return self
+
+    class StubDb:
+        def __init__(self):
+            self.execute_count = 0
+
+        def execute(self, _statement):
+            self.execute_count += 1
+
+    monkeypatch.setattr(bot_service_module, "postgresql_insert", lambda _table: Insert())
+    db = StubDb()
+
+    bot_service_module._upsert_market_candle_rows(db, values=[{} for _ in range(2_501)])
+
+    assert batch_sizes == [1_000, 1_000, 501]
+    assert db.execute_count == 3
 
 
 def test_fetch_market_candles_deduplicates_provider_timestamps():
@@ -2912,6 +2945,89 @@ def test_fetch_market_candles_deduplicates_provider_timestamps():
         assert rows[0].close_price == 13.0
         assert rows[0].volume == 2.0
         assert db.query(ProjectXMarketCandle).count() == 1
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def test_authoritative_market_candle_refresh_prunes_displaced_cached_bars():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    user_id = "00000000-0000-0000-0000-000000000000"
+    outside = datetime(2026, 4, 26, 18, 0, tzinfo=timezone.utc)
+    stale = [
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc),
+    ]
+    authoritative = [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 6, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 14, 0, tzinfo=timezone.utc),
+    ]
+
+    class StubClient:
+        def retrieve_bars(self, **_kwargs):
+            return [
+                {
+                    "timestamp": timestamp,
+                    "open": 100,
+                    "high": 102,
+                    "low": 99,
+                    "close": 101,
+                    "volume": 10,
+                    "is_partial": False,
+                }
+                for timestamp in authoritative
+            ]
+
+    try:
+        db.add_all(
+            [
+                _make_candle(
+                    timestamp,
+                    100,
+                    user_id=user_id,
+                    unit="hour",
+                    unit_number=4,
+                )
+                for timestamp in [outside, *stale]
+            ]
+        )
+        db.commit()
+
+        rows = fetch_and_store_market_candles(
+            db,
+            user_id=user_id,
+            client=StubClient(),
+            contract_id="CON.F.US.MNQ.M26",
+            symbol="MNQ",
+            live=False,
+            start=authoritative[0],
+            end=authoritative[-1] + timedelta(hours=4),
+            unit="hour",
+            unit_number=4,
+            limit=500,
+            preserve_cached_history=True,
+            authoritative_refresh=True,
+        )
+
+        assert [_as_test_utc(row.candle_timestamp) for row in rows] == authoritative
+        cached_timestamps = [
+            _as_test_utc(row.candle_timestamp)
+            for row in db.query(ProjectXMarketCandle)
+            .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+            .all()
+        ]
+        assert cached_timestamps == [outside, *authoritative]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
@@ -3037,6 +3153,47 @@ def test_create_bot_config_rejects_invalid_ema_scalping_timeframe():
         )
 
         with pytest.raises(ValueError, match="3-minute or 5-minute timeframe"):
+            create_bot_config(db, user_id=user_id, payload=payload)
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=tables)
+        engine.dispose()
+
+
+def test_create_bot_config_rejects_monthly_topbot_timeframe():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [Account.__table__, BotConfig.__table__]
+    Base.metadata.create_all(bind=engine, tables=tables)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user_id = "00000000-0000-0000-0000-000000000000"
+    try:
+        db.add(
+            Account(
+                user_id=user_id,
+                provider="projectx",
+                external_id="9001",
+                name="Practice 9001",
+                account_state="ACTIVE",
+                can_trade=True,
+                is_visible=True,
+            )
+        )
+        db.flush()
+        payload = _make_bot_create_payload(name="Monthly TopBot").model_copy(
+            update={
+                "strategy_type": "topbot_adaptive",
+                "timeframe_unit": "month",
+                "timeframe_unit_number": 1,
+            }
+        )
+
+        with pytest.raises(ValueError, match="does not support month candles"):
             create_bot_config(db, user_id=user_id, payload=payload)
     finally:
         db.close()

--- a/backend/tests/test_projectx_client.py
+++ b/backend/tests/test_projectx_client.py
@@ -276,6 +276,42 @@ def test_retrieve_bars_normalizes_and_sorts_ohlcv_rows():
     assert rows[1]["close"] == 104.0
 
 
+def test_retrieve_bars_infers_an_unmarked_intraday_tail_is_partial():
+    class StubClient(ProjectXClient):
+        def __init__(self):
+            super().__init__(base_url="https://example.test", username="demo", api_key="demo")
+
+        def _request(self, method, path, *, payload=None, with_auth):
+            return {
+                "bars": [
+                    {
+                        "t": "2026-04-27T00:00:00Z",
+                        "o": 100,
+                        "h": 102,
+                        "l": 99,
+                        "c": 101,
+                        "v": 10,
+                    }
+                ]
+            }
+
+    client = StubClient()
+    request = {
+        "contract_id": "CON.F.US.MNQ.M26",
+        "live": False,
+        "start": datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        "end": datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc),
+        "unit": 3,
+        "unit_number": 4,
+        "limit": 500,
+    }
+
+    assert client.retrieve_bars(**request, include_partial_bar=False) == []
+    included = client.retrieve_bars(**request, include_partial_bar=True)
+    assert len(included) == 1
+    assert included[0]["is_partial"] is True
+
+
 def test_place_order_uses_projectx_order_place_payload():
     class StubClient(ProjectXClient):
         def __init__(self):

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi, botsApi } from "./api";
+import { accountsApi, botsApi, buildProjectXCandleRequestKey } from "./api";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -168,5 +168,48 @@ describe("botsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual(payload);
+  });
+
+  it("deduplicates closed-history identities within the same candle bucket", () => {
+    const base = {
+      contractId: " con.f.us.mnq.m26 ",
+      symbol: " mnq ",
+      unit: "minute" as const,
+      unitNumber: 5,
+      limit: 300,
+      includePartialBar: false,
+    };
+
+    expect(
+      buildProjectXCandleRequestKey({
+        ...base,
+        start: "2026-07-10T13:00:01.000Z",
+        end: "2026-07-10T14:04:01.000Z",
+      }),
+    ).toBe(
+      buildProjectXCandleRequestKey({
+        ...base,
+        contractId: "CON.F.US.MNQ.M26",
+        symbol: "MNQ",
+        start: "2026-07-10T13:00:59.000Z",
+        end: "2026-07-10T14:04:59.000Z",
+      }),
+    );
+  });
+
+  it("keeps partial, repair, and authoritative refresh requests distinct", () => {
+    const query = {
+      contractId: "CON.F.US.MNQ.M26",
+      unit: "minute" as const,
+      unitNumber: 1,
+      start: "2026-07-10T14:00:00.000Z",
+      end: "2026-07-10T14:05:00.000Z",
+      limit: 5,
+    };
+    const normal = buildProjectXCandleRequestKey(query);
+
+    expect(buildProjectXCandleRequestKey({ ...query, includePartialBar: true })).not.toBe(normal);
+    expect(buildProjectXCandleRequestKey({ ...query, repair: true })).not.toBe(normal);
+    expect(buildProjectXCandleRequestKey({ ...query, refresh: true })).not.toBe(normal);
   });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi } from "./api";
+import { accountsApi, botsApi } from "./api";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -109,5 +109,64 @@ describe("accountsApi", () => {
     expect(trades.length).toBe(summary.trade_count);
     expect(calendar.length).toBeGreaterThan(10);
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("botsApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ id: 17 }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("posts backtests to the plural backend route", async () => {
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.runBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
+  });
+
+  it("prepares TopBot replay data through the dedicated cache route", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.prepareBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,7 +69,7 @@ import { getAccessToken } from "./supabase";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8000";
 const ACCOUNTS_CACHE_TTL_MS = 10 * 60_000;
 const ACCOUNT_READ_CACHE_TTL_MS = 10 * 60_000;
-const BACKTEST_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const BACKTEST_REQUEST_TIMEOUT_MS = 15 * 60_000;
 
 type QueryValue = string | number | boolean | null | undefined;
 
@@ -1101,14 +1101,14 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), BACKTEST_REQUEST_TIMEOUT_MS);
   try {
-    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtest`, {
+    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtests`, {
       method: "POST",
       body: payload,
       signal: controller.signal,
     });
   } catch (error) {
     if (isAbortError(error)) {
-      throw new Error("Backtest timed out after 5 minutes. Try again after the server finishes caching candles, or narrow the date range.");
+      throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
     }
     throw error;
   } finally {
@@ -1170,6 +1170,11 @@ export const botsApi = {
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
+    }),
+  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
+    requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
+      method: "POST",
+      body: payload,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -928,7 +928,7 @@ interface ContractSearchQuery {
   live?: boolean;
 }
 
-interface CandleQuery {
+export interface CandleQuery {
   contractId: string;
   symbol?: string;
   start?: string;
@@ -941,6 +941,61 @@ interface CandleQuery {
   refresh?: boolean;
   /** Force a full-window upstream fetch to backfill missing bars without pruning cache. */
   repair?: boolean;
+}
+
+const CANDLE_UNIT_MS: Record<BotTimeframeUnit, number> = {
+  second: 1_000,
+  minute: 60_000,
+  hour: 60 * 60_000,
+  day: 24 * 60 * 60_000,
+  week: 7 * 24 * 60 * 60_000,
+  month: 31 * 24 * 60 * 60_000,
+};
+
+function projectXCandleQueryParams(query: CandleQuery): Record<string, QueryValue> {
+  return {
+    contract_id: query.contractId,
+    symbol: query.symbol,
+    start: query.start,
+    end: query.end,
+    live: query.live ?? false,
+    unit: query.unit ?? "minute",
+    unit_number: query.unitNumber ?? 5,
+    limit: query.limit ?? 500,
+    include_partial_bar: query.includePartialBar ?? false,
+    refresh: query.refresh ?? false,
+    repair: query.repair ?? false,
+  };
+}
+
+/**
+ * Stable identity for deduplicating equivalent candle reads. Closed-candle
+ * ranges are bucketed to their chart interval: two callers within the same
+ * active bar need the same closed history even if their `Date` values differ by
+ * a few milliseconds. Partial/live reads retain exact timestamps.
+ */
+export function buildProjectXCandleRequestKey(query: CandleQuery): string {
+  const params = projectXCandleQueryParams(query);
+  if (!(query.includePartialBar ?? false)) {
+    const unit = query.unit ?? "minute";
+    const intervalMs = CANDLE_UNIT_MS[unit] * Math.max(1, Math.trunc(query.unitNumber ?? 5));
+    params.start = normalizeCandleRequestTimestamp(query.start, intervalMs);
+    params.end = normalizeCandleRequestTimestamp(query.end, intervalMs);
+  }
+  params.contract_id = query.contractId.trim().toUpperCase();
+  params.symbol = query.symbol?.trim().toUpperCase();
+  return `projectx-candles:${toSortedQueryCacheKey(params)}`;
+}
+
+function normalizeCandleRequestTimestamp(value: string | undefined, intervalMs: number): string | undefined {
+  if (!value) {
+    return value;
+  }
+  const timestampMs = Date.parse(value);
+  if (!Number.isFinite(timestampMs) || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return value;
+  }
+  return new Date(Math.floor(timestampMs / intervalMs) * intervalMs).toISOString();
 }
 
 interface MarketPriceStreamQuery {
@@ -1126,19 +1181,7 @@ export const botsApi = {
     }),
   getCandles: (query: CandleQuery, options: RequestSignalOptions = {}) =>
     requestJson<ProjectXMarketCandle[]>("/api/projectx/candles", {
-      query: {
-        contract_id: query.contractId,
-        symbol: query.symbol,
-        start: query.start,
-        end: query.end,
-        live: query.live ?? false,
-        unit: query.unit ?? "minute",
-        unit_number: query.unitNumber ?? 5,
-        limit: query.limit ?? 500,
-        include_partial_bar: query.includePartialBar ?? false,
-        refresh: query.refresh ?? false,
-        repair: query.repair ?? false,
-      },
+      query: projectXCandleQueryParams(query),
       signal: options.signal,
     }),
   listConfigs: (accountId?: number) =>

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -87,14 +87,18 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     setRunning(true);
     setError(null);
     try {
-      const nextResult = await botsApi.runBacktest(bot.id, {
+      const payload = {
         start: `${form.startDate}T00:00:00.000Z`,
         end: `${form.endDate}T23:59:59.999Z`,
         starting_balance: Number(form.startingBalance),
         commission_per_contract: Number(form.commissionPerContract),
         slippage_ticks: Number(form.slippageTicks),
         force_close_at_end: true,
-      });
+      };
+      if (bot.strategy_type === "topbot_adaptive") {
+        await botsApi.prepareBacktest(bot.id, payload);
+      }
+      const nextResult = await botsApi.runBacktest(bot.id, payload);
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -42,7 +42,7 @@ const strategyOptions: Array<{ value: BotStrategyType; label: string }> = [
   { value: "supertrend_pivot", label: "Supertrend + Pivot Points" },
   { value: "opening_rvol_breakout", label: "Opening 5m RVOL Breakout" },
   { value: "atr_adjusted_relative_strength", label: "ATR-Adjusted Relative Strength" },
-  { value: "relative_strength_spy", label: "Relative Strength vs SPY" },
+  { value: "relative_strength_spy", label: "Relative Strength vs MES" },
   { value: "pullback_trap_reversal", label: "Pullback Trap Reversal" },
   { value: "bollinger_mean_reversion", label: "Bollinger Band Mean Reversion" },
   { value: "bollinger_rsi_reversal", label: "Bollinger RSI Reversal" },
@@ -203,7 +203,7 @@ const VWAP_GAP_RETRACE_DEFAULTS = {
   maxDataStalenessSeconds: "180",
 };
 const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   moveLookbackBars: "3",
   atrPeriod: "14",
   relativeVolumePeriod: "20",
@@ -218,7 +218,7 @@ const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
   maxDataStalenessSeconds: "600",
 };
 const RELATIVE_STRENGTH_SPY_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   comparisonBars: "12",
   pullbackLookbackBars: "3",
   relativeVolumePeriod: "20",
@@ -278,8 +278,8 @@ const STRATEGY_DEFAULT_NAMES: Partial<Record<BotStrategyType, string>> = {
   liquidity_sweep_retest: "MNQ Liquidity Sweep + Zone Retest",
   supertrend_pivot: "MNQ Supertrend + Pivot Points",
   opening_rvol_breakout: "MNQ Opening 5m RVOL Breakout",
-  atr_adjusted_relative_strength: "AAPL ATR-Adjusted Relative Strength",
-  relative_strength_spy: "AAPL Relative Strength vs SPY",
+  atr_adjusted_relative_strength: "MNQ ATR-Adjusted Relative Strength",
+  relative_strength_spy: "MNQ Relative Strength vs MES",
   pullback_trap_reversal: "MNQ Pullback Trap Reversal",
   bollinger_mean_reversion: "MNQ Bollinger Band Mean Reversion",
   bollinger_rsi_reversal: "MNQ Bollinger RSI Reversal",
@@ -935,7 +935,7 @@ function strategyLabel(strategyType: BotStrategyType) {
     return "ATR-Adjusted Relative Strength";
   }
   if (strategyType === "relative_strength_spy") {
-    return "Relative Strength vs SPY";
+    return "Relative Strength vs MES";
   }
   if (strategyType === "pullback_trap_reversal") {
     return "Pullback Trap Reversal";
@@ -1047,7 +1047,7 @@ function strategySummary(bot: BotConfig) {
     const window = bot.strategy_params?.comparison_bars ?? RELATIVE_STRENGTH_SPY_DEFAULTS.comparisonBars;
     const rvol = bot.strategy_params?.minimum_relative_volume ?? RELATIVE_STRENGTH_SPY_DEFAULTS.minimumRelativeVolume;
     return {
-      label: "RS/SPY",
+      label: "RS/MES",
       value: `${window} x 5m · RVOL ${rvol}x`,
     };
   }
@@ -1883,6 +1883,10 @@ export function BotPage() {
       setFormError("9/15 EMA scalping requires a 3-minute or 5-minute chart.");
       return;
     }
+    if (form.strategyType === "topbot_adaptive" && form.timeframeUnit === "month") {
+      setFormError("TopBot Adaptive does not support monthly candles.");
+      return;
+    }
     if (form.strategyType === "support_resistance" && levelTolerancePercent === null) {
       setFormError("Level tolerance must be a valid positive percent.");
       return;
@@ -2531,7 +2535,7 @@ export function BotPage() {
                         value={form.timeframeUnit}
                         onChange={(event) => setForm({ ...form, timeframeUnit: event.target.value as BotTimeframeUnit })}
                       >
-                        {timeframeUnits.map((unit) => (
+                        {timeframeUnits.filter((unit) => unit !== "month").map((unit) => (
                           <option key={unit} value={unit}>
                             {unit}
                           </option>

--- a/frontend/src/pages/bot/BotSignalChart.tsx
+++ b/frontend/src/pages/bot/BotSignalChart.tsx
@@ -25,7 +25,8 @@ import {
 
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/Card";
-import { botsApi, streamProjectXMarketPrice } from "../../lib/api";
+import { botsApi, buildProjectXCandleRequestKey, streamProjectXMarketPrice, type CandleQuery } from "../../lib/api";
+import { ENABLE_PERF_LOGS, logPerfInfo } from "../../lib/perf";
 import { APP_THEME_CHANGED_EVENT } from "../../lib/theme";
 import type { BotActivity, BotConfig, BotEvaluation, BotTimeframeUnit, ProjectXMarketCandle, ProjectXMarketPrice } from "../../lib/types";
 import {
@@ -35,12 +36,15 @@ import {
   readBotCandleCache,
   upsertMarketCandles,
   writeBotCandleCache,
+  type CandleQueryWindow,
 } from "./botCandleCache";
 import {
   buildGapRangeKey,
   buildGapRepairWindows,
   findCandleGaps,
   isGapCoveredByRepairWindows,
+  planBotCandleFetches,
+  type BotCandleFetchRequest,
   type CandleGap,
 } from "./botCandleGaps";
 import type { BotMarketSnapshot } from "./botMarketContext";
@@ -94,7 +98,9 @@ import {
 import { BotEvaluationOverlayStatus } from "./BotEvaluationOverlayStatus";
 import {
   BOT_CHART_MAX_BARS,
+  BOT_CHART_TIMEFRAMES,
   buildBotChartQuery,
+  buildInitialBotChartQuery,
   buildBotLivePriceQuery,
   buildCandlestickData,
   buildEmaData,
@@ -107,12 +113,17 @@ import {
   toUtcTimestamp,
   type LiquidityLevel,
   type LiquiditySide,
+  type BotChartTimeframe,
+  type BotChartTimeframeId,
 } from "./botChartData";
 import {
   LatestRequestCoordinator,
+  LogicalViewportMemory,
+  PrioritizedRequestScheduler,
   getViewportRestoreRange,
   invalidateChartRequestLanes,
   type ChartViewportMutation,
+  type RequestPriority,
 } from "./botChartLifecycle";
 import { readBotChartThemeColors } from "./botChartTheme";
 import { buildVolumeData } from "./botChartVolume";
@@ -146,21 +157,29 @@ const LIVE_PRICE_STREAM_STALE_MS = 5_000;
 const LIVE_PRICE_STALE_AFTER_MS = 2 * LIVE_PRICE_POLL_INTERVAL_MS + 5_000;
 const CANDLE_REQUEST_TIMEOUT_MS = 70_000;
 const LIVE_PRICE_REQUEST_TIMEOUT_MS = 12_000;
-const MIN_CACHED_CHART_HYDRATION_BARS = 25;
+const BACKGROUND_CANDLE_START_INTERVAL_MS = 300;
 const LIQUIDITY_LINE_DRAG_HIT_RADIUS_PX = 8;
-const CHART_TIMEFRAME_OPTIONS = [
-  { id: "1m", label: "1m", unit: "minute", unitNumber: 1 },
-  { id: "5m", label: "5m", unit: "minute", unitNumber: 5 },
-  { id: "15m", label: "15m", unit: "minute", unitNumber: 15 },
-  { id: "1h", label: "1H", unit: "hour", unitNumber: 1 },
-  { id: "4h", label: "4H", unit: "hour", unitNumber: 4 },
-  { id: "1d", label: "1D", unit: "day", unitNumber: 1 },
-] as const;
-type ChartTimeframeOption = (typeof CHART_TIMEFRAME_OPTIONS)[number];
-type ChartTimeframeId = ChartTimeframeOption["id"];
-const DEFAULT_CHART_TIMEFRAME_ID: ChartTimeframeId = "5m";
+const DEFAULT_CHART_TIMEFRAME_ID: BotChartTimeframeId = "5m";
 const EASTERN_TIME_ZONE = "America/New_York";
 const VWAP_SESSION_START_TIME = "18:00";
+
+const candleRequestScheduler = new PrioritizedRequestScheduler<string>({
+  maxConcurrency: 2,
+  maxBackgroundConcurrency: 1,
+  minBackgroundStartIntervalMs: BACKGROUND_CANDLE_START_INTERVAL_MS,
+});
+
+function requestProjectXCandles(
+  query: CandleQuery,
+  priority: RequestPriority,
+  signal?: AbortSignal,
+): Promise<ProjectXMarketCandle[]> {
+  return candleRequestScheduler.schedule(
+    buildProjectXCandleRequestKey(query),
+    (sharedSignal) => botsApi.getCandles(query, { signal: sharedSignal }),
+    { priority, signal },
+  );
+}
 
 const lastLoadedFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: EASTERN_TIME_ZONE,
@@ -246,7 +265,7 @@ interface LivePricePoint {
 
 interface ChartTimeframeSelection {
   key: string;
-  id: ChartTimeframeId;
+  id: BotChartTimeframeId;
 }
 
 type LiquidityPriceOverrides = Partial<Record<LiquiditySide, number>>;
@@ -265,6 +284,23 @@ interface AppliedSeriesState {
   fast: LineData<UTCTimestamp>[];
   slow: LineData<UTCTimestamp>[];
   vwap: LineData<UTCTimestamp>[];
+}
+
+type SignalChartLoadKind = "cold" | "warm" | "timeframe-switch";
+
+interface PendingSignalChartLoadTiming {
+  contextKey: string;
+  kind: SignalChartLoadKind;
+  startedAtMs: number;
+  requestCount: number;
+  cacheHit: boolean;
+  measured: boolean;
+}
+
+interface SignalChartPerfContext {
+  contextKey: string;
+  botId: number | null;
+  contractId: string;
 }
 
 interface LiquidityDragState {
@@ -296,12 +332,18 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const fittedViewportRef = useRef<FittedViewportState | null>(null);
   const autoHistoryHookRef = useRef<((range: LogicalRange | null) => void) | null>(null);
   const appliedSeriesStateRef = useRef<AppliedSeriesState | null>(null);
+  const signalChartPerfContextRef = useRef<SignalChartPerfContext | null>(null);
+  const pendingSignalChartLoadTimingRef = useRef<PendingSignalChartLoadTiming | null>(null);
+  const signalChartMeasureFrameRef = useRef<number | null>(null);
   const candleRequestsRef = useRef(new LatestRequestCoordinator());
   const liveRequestsRef = useRef(new LatestRequestCoordinator());
   const historyRequestsRef = useRef(new LatestRequestCoordinator());
   const repairRequestsRef = useRef(new LatestRequestCoordinator());
+  const chartBackgroundControllerRef = useRef<AbortController | null>(null);
+  const warmTimeframesControllerRef = useRef<AbortController | null>(null);
   const requestTimeoutIdsRef = useRef<Set<number>>(new Set());
   const pendingViewportRestoreRef = useRef<LogicalRange | null>(null);
+  const viewportMemoryRef = useRef(new LogicalViewportMemory<string>());
   const viewportRestoreFrameRef = useRef<number | null>(null);
   const lastLiveStreamEventAtRef = useRef(0);
   const pendingLiveStreamPriceRef = useRef<ProjectXMarketPrice | null>(null);
@@ -352,7 +394,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }));
   const selectedTimeframeId =
     timeframeSelection.key === botTimeframeSelectionKey ? timeframeSelection.id : defaultChartTimeframeIdForBot(bot);
-  const chartTimeframe = CHART_TIMEFRAME_OPTIONS.find((option) => option.id === selectedTimeframeId) ?? CHART_TIMEFRAME_OPTIONS[0];
+  const chartTimeframe = BOT_CHART_TIMEFRAMES.find((option) => option.id === selectedTimeframeId) ?? BOT_CHART_TIMEFRAMES[0];
   const chartConfig = useMemo<BotConfig | null>(() => {
     if (!bot) {
       return null;
@@ -364,6 +406,11 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     };
   }, [bot, chartTimeframe]);
   const chartViewportKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${selectedTimeframeId}`;
+  const chartBotId = bot?.id ?? null;
+  const chartContractId = bot?.contract_id ?? "";
+  const warmContractKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${bot?.symbol ?? ""}`;
+  const warmBotRef = useRef<BotConfig | null>(bot);
+  warmBotRef.current = bot;
   const [marketDataContextKey, setMarketDataContextKey] = useState(chartViewportKey);
   const marketDataMatchesContext = marketDataContextKey === chartViewportKey;
 
@@ -482,7 +529,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const latestClosedCandle = useMemo(
     () =>
       marketDataMatchesContext
-        ? [...candles].reverse().find((candle) => !candle.is_partial && isRenderableMarketCandle(candle)) ?? null
+        ? findLatestClosedMarketCandle(candles)
         : null,
     [candles, marketDataMatchesContext],
   );
@@ -536,6 +583,38 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const drawingStorageScopeKey = drawingStorageScope ? buildBotDrawingStorageKey(drawingStorageScope) : null;
   const chartViewportKeyRef = useRef(chartViewportKey);
   chartViewportKeyRef.current = chartViewportKey;
+
+  useEffect(() => {
+    if (!ENABLE_PERF_LOGS || chartBotId === null) {
+      pendingSignalChartLoadTimingRef.current = null;
+      signalChartPerfContextRef.current =
+        chartBotId === null
+          ? null
+          : { contextKey: chartViewportKey, botId: chartBotId, contractId: chartContractId };
+      return;
+    }
+
+    const previous = signalChartPerfContextRef.current;
+    const timeframeSwitch =
+      previous !== null &&
+      previous.contextKey !== chartViewportKey &&
+      previous.botId === chartBotId &&
+      previous.contractId === chartContractId;
+    pendingSignalChartLoadTimingRef.current = {
+      contextKey: chartViewportKey,
+      kind: timeframeSwitch ? "timeframe-switch" : "cold",
+      startedAtMs: performance.now(),
+      requestCount: 0,
+      cacheHit: false,
+      measured: false,
+    };
+    signalChartPerfContextRef.current = {
+      contextKey: chartViewportKey,
+      botId: chartBotId,
+      contractId: chartContractId,
+    };
+  }, [chartBotId, chartContractId, chartViewportKey]);
+
   const queueViewportRestore = useCallback(
     (mutation: ChartViewportMutation, previousRows: ProjectXMarketCandle[], nextRows: ProjectXMarketCandle[]) => {
       const handles = chartHandlesRef.current;
@@ -628,6 +707,8 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   // Reset per-market transient state when the chart context changes.
   useEffect(() => {
     setMarketDataContextKey(chartViewportKey);
+    chartBackgroundControllerRef.current?.abort();
+    chartBackgroundControllerRef.current = null;
     candlesRef.current = [];
     liveCandleRef.current = null;
     setCandles([]);
@@ -658,6 +739,21 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     }
     setHistoryLoading(false);
     setGapRepairing(false);
+  }, [chartViewportKey]);
+
+  useEffect(() => {
+    const viewportMemory = viewportMemoryRef.current;
+    const rememberedRange = viewportMemory.restore(chartViewportKey);
+    if (rememberedRange) {
+      pendingViewportRestoreRef.current = rememberedRange;
+    }
+
+    return () => {
+      viewportMemory.save(
+        chartViewportKey,
+        chartHandlesRef.current?.chart.timeScale().getVisibleLogicalRange() ?? null,
+      );
+    };
   }, [chartViewportKey]);
 
   // Periodic tick so freshness text ("Updated Xs ago", stale chip) re-renders.
@@ -776,10 +872,161 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     writeBotDrawings(drawingStorageScope, drawings);
   }, [drawingStorageScope, drawingStorageScopeKey, drawings, hydratedDrawingScopeKey]);
 
+  const commitCandleFetch = useCallback(
+    ({
+      cacheKey,
+      cacheLimit,
+      contextKey,
+      request,
+      rows,
+      replaceCache = false,
+      applyToChart = true,
+      mutation,
+    }: {
+      cacheKey: string;
+      cacheLimit: number;
+      contextKey: string;
+      request: BotCandleFetchRequest;
+      rows: ProjectXMarketCandle[];
+      replaceCache?: boolean;
+      applyToChart?: boolean;
+      mutation?: ChartViewportMutation;
+    }) => {
+      const fetchedAt = new Date();
+      const previousEntry = readBotCandleCache(cacheKey);
+      const cacheBase = replaceCache ? [] : previousEntry?.candles ?? [];
+      const mergedCache = mergeMarketCandles(
+        cacheBase,
+        rows,
+        Math.min(
+          BOT_CHART_MAX_BARS,
+          Math.max(cacheLimit, previousEntry?.candles.length ?? 0, rows.length),
+        ),
+      );
+      const coverage = replaceCache
+        ? request.window
+        : mergeCandleCacheCoverage(previousEntry?.coverage ?? null, request.window);
+      writeBotCandleCache(cacheKey, mergedCache, cacheLimitForRows(cacheLimit, mergedCache.length), {
+        savedAt: fetchedAt,
+        coverage,
+      });
+
+      if (!applyToChart || contextKey !== chartViewportKeyRef.current) {
+        return;
+      }
+
+      const previousRows = candlesRef.current;
+      const nextRows = upsertMarketCandles(previousRows, rows, MAX_LOADED_BARS);
+      if (nextRows !== previousRows) {
+        queueViewportRestore(
+          mutation ??
+            (request.reason === "missing-history" || request.reason === "interior-gap" ? "pagination" : "live"),
+          previousRows,
+          nextRows,
+        );
+        candlesRef.current = nextRows;
+        setCandles(nextRows);
+      }
+      setLastLoadedAt(fetchedAt);
+      setServedFromCacheOnly(false);
+
+      if (request.reason === "interior-gap") {
+        const config = chartConfigRef.current;
+        if (config) {
+          const remaining = findCandleGaps(
+            candlesRef.current,
+            config.timeframe_unit,
+            config.timeframe_unit_number,
+          );
+          for (const gap of remaining) {
+            if (gap.kind === "data" && isGapCoveredByRepairWindows(gap, [request.window])) {
+              repairedGapKeysRef.current.add(buildGapRangeKey(gap));
+            }
+          }
+          setRepairVersion((current) => current + 1);
+        }
+      }
+    },
+    [queueViewportRestore],
+  );
+
+  const scheduleBackgroundCandleFetches = useCallback(
+    ({
+      cacheKey,
+      cacheLimit,
+      config,
+      contextKey,
+      requests,
+    }: {
+      cacheKey: string;
+      cacheLimit: number;
+      config: BotConfig;
+      contextKey: string;
+      requests: BotCandleFetchRequest[];
+    }) => {
+      chartBackgroundControllerRef.current?.abort();
+      const runnableRequests = requests.filter((request) => {
+        if (request.reason !== "interior-gap") {
+          return true;
+        }
+        return findCandleGaps(
+          candlesRef.current,
+          config.timeframe_unit,
+          config.timeframe_unit_number,
+        ).some(
+          (gap) =>
+            gap.kind === "data" &&
+            isGapCoveredByRepairWindows(gap, [request.window]) &&
+            !repairedGapKeysRef.current.has(buildGapRangeKey(gap)),
+        );
+      });
+      if (runnableRequests.length === 0) {
+        chartBackgroundControllerRef.current = null;
+        return;
+      }
+
+      const controller = new AbortController();
+      chartBackgroundControllerRef.current = controller;
+      let pendingCount = runnableRequests.length;
+      for (const request of runnableRequests) {
+        const query = candleQueryForFetchRequest(config, request);
+        void requestProjectXCandles(query, "background", controller.signal)
+          .then((rows) => {
+            commitCandleFetch({
+              cacheKey,
+              cacheLimit,
+              contextKey,
+              request,
+              rows,
+              applyToChart: contextKey === chartViewportKeyRef.current,
+            });
+          })
+          .catch((error) => {
+            if (!isAbortError(error)) {
+              logPerfInfo("[perf][signal-chart] background-fetch-error", {
+                contextKey,
+                reason: request.reason,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          })
+          .finally(() => {
+            pendingCount -= 1;
+            if (pendingCount === 0 && chartBackgroundControllerRef.current === controller) {
+              chartBackgroundControllerRef.current = null;
+            }
+          });
+      }
+    },
+    [commitCandleFetch],
+  );
+
   const loadCandles = useCallback(
     async ({ silent = false, forceRefresh = false }: LoadCandlesOptions = {}) => {
       if (!chartConfig) {
         candleRequestsRef.current.invalidate();
+        chartBackgroundControllerRef.current?.abort();
+        chartBackgroundControllerRef.current = null;
         setCandles([]);
         setLiveCandle(null);
         setStreamPrice(null);
@@ -804,10 +1051,9 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         setGapRepairing(false);
       }
 
-      const request = candleRequestsRef.current.begin(chartViewportKey);
-      const timeoutId = window.setTimeout(() => request.controller.abort(), CANDLE_REQUEST_TIMEOUT_MS);
-      requestTimeoutIdsRef.current.add(timeoutId);
-      const queryWindow = buildBotChartQuery(chartConfig);
+      const now = new Date();
+      const queryWindow = buildBotChartQuery(chartConfig, now);
+      const initialQueryWindow = buildInitialBotChartQuery(chartConfig, now);
       const cacheKey = buildBotCandleCacheKey({
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol,
@@ -817,60 +1063,123 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       });
       const cachedEntry = forceRefresh ? null : readBotCandleCache(cacheKey);
       const cachedCandles = cachedEntry ? filterMarketCandlesForWindow(cachedEntry.candles, queryWindow) : [];
-      const hydrateFromCache = shouldHydrateChartFromCache(cachedCandles.length, queryWindow.limit);
+      const plan = forceRefresh
+        ? null
+        : planBotCandleFetches({
+            targetWindow: queryWindow,
+            initialWindow: initialQueryWindow,
+            cache:
+              cachedEntry && cachedCandles.length > 0
+                ? {
+                    candles: cachedCandles,
+                    savedAt: cachedEntry.savedAt,
+                    coverage: cachedEntry.coverage,
+                  }
+                : null,
+            unit: chartConfig.timeframe_unit,
+            unitNumber: chartConfig.timeframe_unit_number,
+            now,
+            maxRepairWindows: MAX_GAP_REPAIR_WINDOWS,
+          });
+      const foregroundRequests: BotCandleFetchRequest[] = forceRefresh
+        ? [
+            {
+              reason: "stale-tail",
+              priority: "foreground",
+              window: { start: queryWindow.start, end: queryWindow.end },
+              limit: queryWindow.limit,
+              repair: false,
+            },
+          ]
+        : plan?.foreground ?? [];
+      const backgroundRequests = plan?.background ?? [];
 
-      if (cachedEntry && hydrateFromCache) {
-        // Paint cached bars immediately on cold loads; when in-memory data already
-        // exists (background polls), leave it alone so paged-in history survives.
+      if (cachedEntry && cachedCandles.length > 0) {
+        // Paint every valid cached row immediately. In-memory rows already on
+        // screen may include deeper paged history, so preserve them on polls.
         if (candlesRef.current.length === 0) {
           setCandles(cachedCandles);
           candlesRef.current = cachedCandles;
           setLastLoadedAt(cachedEntry.savedAt);
         }
+        const pendingTiming = pendingSignalChartLoadTimingRef.current;
+        if (pendingTiming?.contextKey === chartViewportKey) {
+          pendingTiming.cacheHit = true;
+          if (pendingTiming.kind === "cold") {
+            pendingTiming.kind = "warm";
+          }
+        }
         setLoading(false);
-        if (!silent) {
+        if (!silent && foregroundRequests.length > 0) {
           setRefreshing(true);
         }
       } else if (forceRefresh) {
         setRefreshing(true);
-      } else if (cachedEntry && !silent) {
-        setLoading(true);
-      } else if (!silent) {
+      } else if (!silent && foregroundRequests.length > 0) {
         setLoading(true);
       }
       setError(null);
 
-      try {
-        const rows = await botsApi.getCandles({
-          contractId: chartConfig.contract_id,
-          symbol: chartConfig.symbol ?? undefined,
-          start: queryWindow.start,
-          end: queryWindow.end,
-          live: false,
-          unit: chartConfig.timeframe_unit,
-          unitNumber: chartConfig.timeframe_unit_number,
-          limit: queryWindow.limit,
-          includePartialBar: false,
-          refresh: forceRefresh,
-        }, { signal: request.signal });
-        if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
-          return;
+      if (foregroundRequests.length === 0) {
+        setLoading(false);
+        setRefreshing(false);
+        if (cachedCandles.length > 0) {
+          setServedFromCacheOnly(false);
         }
-        const mergedRows = forceRefresh ? rows : mergeMarketCandles(cachedCandles, rows, queryWindow.limit);
-        // Keep older history the user already paged in; the fetch window only covers the recent range.
-        // Rolled partials also remain until ProjectX returns their authoritative
-        // closed replacement; upsert precedence guarantees closed always wins.
-        const nextRows = upsertMarketCandles(candlesRef.current, mergedRows, MAX_LOADED_BARS);
-        queueViewportRestore(forceRefresh ? "refresh" : "live", candlesRef.current, nextRows);
-        setCandles(nextRows);
-        candlesRef.current = nextRows;
-        writeBotCandleCache(cacheKey, mergedRows, queryWindow.limit);
-        setLastLoadedAt(new Date());
-        setServedFromCacheOnly(false);
+        if (backgroundRequests.length > 0) {
+          scheduleBackgroundCandleFetches({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            config: chartConfig,
+            contextKey: chartViewportKey,
+            requests: backgroundRequests,
+          });
+        }
+        return;
+      }
+
+      const request = candleRequestsRef.current.begin(chartViewportKey);
+      const timeoutId = window.setTimeout(() => request.controller.abort(), CANDLE_REQUEST_TIMEOUT_MS);
+      requestTimeoutIdsRef.current.add(timeoutId);
+      try {
+        for (const fetchRequest of foregroundRequests) {
+          const pendingTiming = pendingSignalChartLoadTimingRef.current;
+          if (pendingTiming?.contextKey === chartViewportKey) {
+            pendingTiming.requestCount += 1;
+          }
+          const rows = await requestProjectXCandles(
+            {
+              ...candleQueryForFetchRequest(chartConfig, fetchRequest),
+              refresh: forceRefresh,
+            },
+            "foreground",
+            request.signal,
+          );
+          if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
+            return;
+          }
+          commitCandleFetch({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            contextKey: chartViewportKey,
+            request: fetchRequest,
+            rows,
+            replaceCache: forceRefresh,
+            mutation: forceRefresh ? "refresh" : undefined,
+          });
+        }
         if (forceRefresh) {
           // Retry previously confirmed-empty holes after an explicit provider refresh.
           repairedGapKeysRef.current = new Set();
           setRepairVersion((current) => current + 1);
+        } else if (backgroundRequests.length > 0) {
+          scheduleBackgroundCandleFetches({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            config: chartConfig,
+            contextKey: chartViewportKey,
+            requests: backgroundRequests,
+          });
         }
       } catch (err) {
         if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
@@ -898,7 +1207,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         }
       }
     },
-    [chartConfig, chartViewportKey, queueViewportRestore],
+    [chartConfig, chartViewportKey, commitCandleFetch, scheduleBackgroundCandleFetches],
   );
 
   const loadLivePrice = useCallback(async ({ force = false }: LoadLivePriceOptions = {}) => {
@@ -920,7 +1229,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     const queryWindow = buildBotLivePriceQuery(chartConfig);
 
     try {
-      const rows = await botsApi.getCandles({
+      const rows = await requestProjectXCandles({
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol ?? undefined,
         start: queryWindow.start,
@@ -931,21 +1240,35 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         limit: queryWindow.limit,
         includePartialBar: true,
         refresh: true,
-      }, { signal: request.signal });
+      }, "foreground", request.signal);
       if (!liveRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
 
       // Promote closed candles from the live window into the chart immediately so a
       // just-finished bar does not vanish until the next slow poll.
-      const closedRows = rows
-        .filter((row) => !row.is_partial)
-        .filter((row) => !hasClosedCandleAtTimestamp(candlesRef.current, row));
+      const closedRows = rows.filter((row) => !row.is_partial);
       if (closedRows.length > 0) {
-        const merged = upsertMarketCandles(candlesRef.current, closedRows, MAX_LOADED_BARS);
-        queueViewportRestore("live", candlesRef.current, merged);
-        candlesRef.current = merged;
-        setCandles(merged);
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: chartConfig.contract_id,
+          symbol: chartConfig.symbol,
+          live: false,
+          unit: chartConfig.timeframe_unit,
+          unitNumber: chartConfig.timeframe_unit_number,
+        });
+        commitCandleFetch({
+          cacheKey,
+          cacheLimit: BOT_CHART_MAX_BARS,
+          contextKey: chartViewportKey,
+          request: {
+            reason: "stale-tail",
+            priority: "foreground",
+            window: { start: queryWindow.start, end: queryWindow.end },
+            limit: queryWindow.limit,
+            repair: false,
+          },
+          rows: closedRows,
+        });
       }
 
       const latest = getLatestMarketCandle(rows);
@@ -995,7 +1318,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       requestTimeoutIdsRef.current.delete(timeoutId);
       liveRequestsRef.current.finish(request);
     }
-  }, [chartConfig, chartViewportKey, queueViewportRestore]);
+  }, [chartConfig, chartViewportKey, commitCandleFetch]);
 
   const loadOlderCandles = useCallback(async () => {
     const config = chartConfigRef.current;
@@ -1022,7 +1345,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     requestTimeoutIdsRef.current.add(timeoutId);
     setHistoryLoading(true);
     try {
-      const rows = await botsApi.getCandles({
+      const rows = await requestProjectXCandles({
         contractId: config.contract_id,
         symbol: config.symbol ?? undefined,
         start: queryWindow.start,
@@ -1032,7 +1355,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         unitNumber: config.timeframe_unit_number,
         limit: queryWindow.limit,
         includePartialBar: false,
-      }, { signal: request.signal });
+      }, "foreground", request.signal);
       if (!historyRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
@@ -1048,11 +1371,27 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         return;
       }
 
-      const merged = upsertMarketCandles(candlesRef.current, olderRows, MAX_LOADED_BARS);
-      queueViewportRestore("pagination", candlesRef.current, merged);
-      candlesRef.current = merged;
-      setCandles(merged);
-      if (merged.length >= MAX_LOADED_BARS) {
+      const cacheKey = buildBotCandleCacheKey({
+        contractId: config.contract_id,
+        symbol: config.symbol,
+        live: false,
+        unit: config.timeframe_unit,
+        unitNumber: config.timeframe_unit_number,
+      });
+      commitCandleFetch({
+        cacheKey,
+        cacheLimit: BOT_CHART_MAX_BARS,
+        contextKey,
+        request: {
+          reason: "missing-history",
+          priority: "foreground",
+          window: { start: queryWindow.start, end: queryWindow.end },
+          limit: queryWindow.limit,
+          repair: false,
+        },
+        rows: olderRows,
+      });
+      if (candlesRef.current.length >= MAX_LOADED_BARS) {
         hasMoreHistoryRef.current = false;
         setHasMoreHistory(false);
       }
@@ -1067,7 +1406,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         setHistoryLoading(false);
       }
     }
-  }, [queueViewportRestore]);
+  }, [commitCandleFetch]);
 
   const repairDataGaps = useCallback(async () => {
     const config = chartConfigRef.current;
@@ -1095,7 +1434,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     try {
       const repairedRows: ProjectXMarketCandle[] = [];
       for (const window_ of windows) {
-        const rows = await botsApi.getCandles({
+        const rows = await requestProjectXCandles({
           contractId: config.contract_id,
           symbol: config.symbol ?? undefined,
           start: window_.start,
@@ -1106,7 +1445,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
           limit: BOT_CHART_MAX_BARS,
           includePartialBar: false,
           repair: true,
-        }, { signal: request.signal });
+        }, "foreground", request.signal);
         if (!repairRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
           return;
         }
@@ -1115,13 +1454,31 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         }
       }
       if (repairedRows.length > 0) {
-        const additiveRepairRows = repairedRows.filter(
-          (row) => row.is_partial || !hasClosedCandleAtTimestamp(candlesRef.current, row),
+        const previousRows = candlesRef.current;
+        const merged = upsertMarketCandles(previousRows, repairedRows, MAX_LOADED_BARS);
+        if (merged !== previousRows) {
+          queueViewportRestore("pagination", previousRows, merged);
+          candlesRef.current = merged;
+          setCandles(merged);
+        }
+
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: config.contract_id,
+          symbol: config.symbol,
+          live: false,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+        });
+        const previousEntry = readBotCandleCache(cacheKey);
+        const cacheRows = mergeMarketCandles(previousEntry?.candles ?? [], repairedRows, BOT_CHART_MAX_BARS);
+        const coverage = windows.reduce<CandleQueryWindow | null>(
+          (current, window_) => mergeCandleCacheCoverage(current, window_),
+          previousEntry?.coverage ?? null,
         );
-        const merged = upsertMarketCandles(candlesRef.current, additiveRepairRows, MAX_LOADED_BARS);
-        queueViewportRestore("pagination", candlesRef.current, merged);
-        candlesRef.current = merged;
-        setCandles(merged);
+        writeBotCandleCache(cacheKey, cacheRows, cacheLimitForRows(BOT_CHART_MAX_BARS, cacheRows.length), {
+          savedAt: new Date(),
+          coverage,
+        });
       }
 
       // Only gaps covered by this bounded pass can be confirmed empty. Remaining
@@ -2074,8 +2431,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     applySeriesData(handles.slowSeries, incremental ? previousState.slow : null, nextState.slow);
     applySeriesData(handles.vwapSeries, incremental ? previousState.vwap : null, nextState.vwap);
     appliedSeriesStateRef.current = nextState;
-    const restoreRange = pendingViewportRestoreRef.current;
-    pendingViewportRestoreRef.current = null;
+    const restoreRange = chartCandles.length > 0 ? pendingViewportRestoreRef.current : null;
+    if (chartCandles.length > 0) {
+      pendingViewportRestoreRef.current = null;
+    }
     if (viewportRestoreFrameRef.current !== null) {
       window.cancelAnimationFrame(viewportRestoreFrameRef.current);
       viewportRestoreFrameRef.current = null;
@@ -2086,6 +2445,54 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         if (chartHandlesRef.current === handles) {
           handles.chart.timeScale().setVisibleLogicalRange(restoreRange);
         }
+      });
+    }
+    const pendingTiming = pendingSignalChartLoadTimingRef.current;
+    if (
+      ENABLE_PERF_LOGS &&
+      chartCandles.length > 0 &&
+      pendingTiming &&
+      !pendingTiming.measured &&
+      pendingTiming.contextKey === timeframeKey
+    ) {
+      pendingTiming.measured = true;
+      if (signalChartMeasureFrameRef.current !== null) {
+        window.cancelAnimationFrame(signalChartMeasureFrameRef.current);
+      }
+      signalChartMeasureFrameRef.current = window.requestAnimationFrame(() => {
+        signalChartMeasureFrameRef.current = null;
+        if (pendingSignalChartLoadTimingRef.current !== pendingTiming) {
+          return;
+        }
+        const endedAtMs = performance.now();
+        const metricName = `topsignal:signal-chart:${pendingTiming.kind}-first-paint`;
+        const detail = {
+          contextKey: timeframeKey,
+          cacheHit: pendingTiming.cacheHit,
+          requestCount: pendingTiming.requestCount,
+          barCount: chartCandles.length,
+        };
+        try {
+          performance.measure(metricName, {
+            start: pendingTiming.startedAtMs,
+            end: endedAtMs,
+            detail,
+          });
+        } catch {
+          // Older browsers can omit PerformanceMeasureOptions.detail.
+          performance.measure(metricName, {
+            start: pendingTiming.startedAtMs,
+            end: endedAtMs,
+          });
+        }
+        logPerfInfo(
+          "[perf][signal-chart] first-paint",
+          JSON.stringify({
+            metricName,
+            durationMs: Math.round((endedAtMs - pendingTiming.startedAtMs) * 10) / 10,
+            ...detail,
+          }),
+        );
       });
     }
     setDrawingOverlayRevision((current) => current + 1);
@@ -2234,17 +2641,103 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }, [livePrice, livePriceIsStale, livePricePoint?.isPartial]);
 
   useEffect(() => {
-    let active = true;
-    void loadCandles().finally(() => {
-      if (active) {
-        void loadLivePrice({ force: true });
+    void loadCandles();
+    void loadLivePrice({ force: true });
+  }, [loadCandles, loadLivePrice, refreshToken]);
+
+  useEffect(() => {
+    warmTimeframesControllerRef.current?.abort();
+    const selectedBot = warmBotRef.current;
+    if (!selectedBot) {
+      warmTimeframesControllerRef.current = null;
+      return;
+    }
+
+    const controller = new AbortController();
+    warmTimeframesControllerRef.current = controller;
+    window.queueMicrotask(() => {
+      if (controller.signal.aborted || warmTimeframesControllerRef.current !== controller) {
+        return;
       }
+      const now = new Date();
+      let queuedCount = 0;
+      for (const timeframe of BOT_CHART_TIMEFRAMES) {
+        const config: BotConfig = {
+          ...selectedBot,
+          timeframe_unit: timeframe.unit,
+          timeframe_unit_number: timeframe.unitNumber,
+        };
+        const initialWindow = buildInitialBotChartQuery(config, now);
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: config.contract_id,
+          symbol: config.symbol,
+          live: false,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+        });
+        const cacheEntry = readBotCandleCache(cacheKey);
+        const cachedCandles = cacheEntry
+          ? filterMarketCandlesForWindow(cacheEntry.candles, initialWindow)
+          : [];
+        const plan = planBotCandleFetches({
+          targetWindow: initialWindow,
+          initialWindow,
+          cache:
+            cacheEntry && cachedCandles.length > 0
+              ? {
+                  candles: cachedCandles,
+                  savedAt: cacheEntry.savedAt,
+                  coverage: cacheEntry.coverage,
+                }
+              : null,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+          now,
+          maxRepairWindows: 1,
+        });
+
+        for (const fetchRequest of plan.requests) {
+          queuedCount += 1;
+          const query = candleQueryForFetchRequest(config, fetchRequest);
+          void requestProjectXCandles(query, "background", controller.signal)
+            .then((rows) => {
+              commitCandleFetch({
+                cacheKey,
+                cacheLimit: initialWindow.limit,
+                contextKey: `warm:${warmContractKey}:${timeframe.id}`,
+                request: fetchRequest,
+                rows,
+                applyToChart: false,
+              });
+            })
+            .catch((error) => {
+              if (!isAbortError(error)) {
+                logPerfInfo("[perf][signal-chart] warm-error", {
+                  contractKey: warmContractKey,
+                  timeframe: timeframe.id,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            });
+        }
+      }
+      logPerfInfo(
+        "[perf][signal-chart] warm-queued",
+        JSON.stringify({
+          contractKey: warmContractKey,
+          queuedCount,
+          timeframes: BOT_CHART_TIMEFRAMES.map((timeframe) => timeframe.id),
+        }),
+      );
     });
 
     return () => {
-      active = false;
+      controller.abort();
+      if (warmTimeframesControllerRef.current === controller) {
+        warmTimeframesControllerRef.current = null;
+      }
     };
-  }, [loadCandles, loadLivePrice, refreshToken]);
+  }, [commitCandleFetch, warmContractKey]);
 
   useEffect(() => {
     const candleRequests = candleRequestsRef.current;
@@ -2257,6 +2750,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       liveRequests.dispose();
       historyRequests.dispose();
       repairRequests.dispose();
+      chartBackgroundControllerRef.current?.abort();
+      chartBackgroundControllerRef.current = null;
+      warmTimeframesControllerRef.current?.abort();
+      warmTimeframesControllerRef.current = null;
       for (const timeoutId of requestTimeoutIds) {
         window.clearTimeout(timeoutId);
       }
@@ -2264,6 +2761,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       if (viewportRestoreFrameRef.current !== null) {
         window.cancelAnimationFrame(viewportRestoreFrameRef.current);
         viewportRestoreFrameRef.current = null;
+      }
+      if (signalChartMeasureFrameRef.current !== null) {
+        window.cancelAnimationFrame(signalChartMeasureFrameRef.current);
+        signalChartMeasureFrameRef.current = null;
       }
       if (liveStreamRenderTimeoutRef.current !== null) {
         window.clearTimeout(liveStreamRenderTimeoutRef.current);
@@ -2567,7 +3068,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         <div className="mt-3 flex flex-col gap-2 rounded-lg border border-app-border/80 bg-app-bg/40 p-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             <div className="inline-flex h-8 overflow-hidden rounded-md border border-app-border-strong/70 bg-app-surface/95 shadow-[0_10px_24px_-22px_rgb(var(--theme-shadow-color)/0.55)]" aria-label="Chart timeframe">
-              {CHART_TIMEFRAME_OPTIONS.map((option) => {
+              {BOT_CHART_TIMEFRAMES.map((option) => {
                 const active = option.id === selectedTimeframeId;
                 return (
                   <button
@@ -2775,14 +3276,53 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   );
 }
 
-function findMatchingTimeframeId(unit: BotTimeframeUnit, unitNumber: number): ChartTimeframeId | null {
+function candleQueryForFetchRequest(config: BotConfig, request: BotCandleFetchRequest): CandleQuery {
+  return {
+    contractId: config.contract_id,
+    symbol: config.symbol ?? undefined,
+    start: request.window.start,
+    end: request.window.end,
+    live: false,
+    unit: config.timeframe_unit,
+    unitNumber: config.timeframe_unit_number,
+    limit: request.limit,
+    includePartialBar: false,
+    repair: request.repair,
+  };
+}
+
+function mergeCandleCacheCoverage(
+  existing: CandleQueryWindow | null,
+  incoming: CandleQueryWindow,
+): CandleQueryWindow {
+  if (!existing) {
+    return incoming;
+  }
+  const existingStartMs = Date.parse(existing.start);
+  const existingEndMs = Date.parse(existing.end);
+  const incomingStartMs = Date.parse(incoming.start);
+  const incomingEndMs = Date.parse(incoming.end);
+  if (![existingStartMs, existingEndMs, incomingStartMs, incomingEndMs].every(Number.isFinite)) {
+    return incoming;
+  }
+  return {
+    start: new Date(Math.min(existingStartMs, incomingStartMs)).toISOString(),
+    end: new Date(Math.max(existingEndMs, incomingEndMs)).toISOString(),
+  };
+}
+
+function cacheLimitForRows(requestedLimit: number, rowCount: number): number {
+  return Math.min(BOT_CHART_MAX_BARS, Math.max(1, Math.trunc(requestedLimit), Math.trunc(rowCount)));
+}
+
+function findMatchingTimeframeId(unit: BotTimeframeUnit, unitNumber: number): BotChartTimeframeId | null {
   const normalizedNumber = Math.max(1, Math.trunc(unitNumber));
   return (
-    CHART_TIMEFRAME_OPTIONS.find((option) => option.unit === unit && option.unitNumber === normalizedNumber)?.id ?? null
+    BOT_CHART_TIMEFRAMES.find((option) => option.unit === unit && option.unitNumber === normalizedNumber)?.id ?? null
   );
 }
 
-function defaultChartTimeframeIdForBot(bot: BotConfig | null): ChartTimeframeId {
+function defaultChartTimeframeIdForBot(bot: BotConfig | null): BotChartTimeframeId {
   if (!bot) {
     return DEFAULT_CHART_TIMEFRAME_ID;
   }
@@ -2794,10 +3334,6 @@ function buildBotTimeframeSelectionKey(bot: BotConfig | null): string {
     return "none";
   }
   return `${bot.id}:${bot.timeframe_unit}:${Math.max(1, Math.trunc(bot.timeframe_unit_number))}`;
-}
-
-function shouldHydrateChartFromCache(candleCount: number, requestedLimit: number): boolean {
-  return candleCount >= Math.min(MIN_CACHED_CHART_HYDRATION_BARS, Math.max(1, Math.trunc(requestedLimit)));
 }
 
 const MAX_INCREMENTAL_APPEND_BARS = 8;
@@ -2966,7 +3502,7 @@ function compactMeridiem(value: string): string {
   return value.replace(/\s(AM|PM)$/, "$1");
 }
 
-function buildChartSubtitle(bot: BotConfig, chartTimeframe: ChartTimeframeOption): string {
+function buildChartSubtitle(bot: BotConfig, chartTimeframe: BotChartTimeframe): string {
   const market = bot.symbol ?? bot.contract_id;
   const botTimeframeLabel = formatTimeframeLabel(bot.timeframe_unit, bot.timeframe_unit_number);
   if (botTimeframeLabel === chartTimeframe.label) {
@@ -2977,7 +3513,7 @@ function buildChartSubtitle(bot: BotConfig, chartTimeframe: ChartTimeframeOption
 
 function formatTimeframeLabel(unit: BotTimeframeUnit, unitNumber: number): string {
   const normalizedNumber = Math.max(1, Math.trunc(unitNumber));
-  const preset = CHART_TIMEFRAME_OPTIONS.find((option) => option.unit === unit && option.unitNumber === normalizedNumber);
+  const preset = BOT_CHART_TIMEFRAMES.find((option) => option.unit === unit && option.unitNumber === normalizedNumber);
   if (preset) {
     return preset.label;
   }
@@ -3061,19 +3597,35 @@ function marketCandlesShareTimestamp(left: ProjectXMarketCandle, right: ProjectX
   return Number.isFinite(leftMs) && leftMs === rightMs;
 }
 
-function hasClosedCandleAtTimestamp(candles: readonly ProjectXMarketCandle[], candidate: ProjectXMarketCandle): boolean {
-  return candles.some((candle) => !candle.is_partial && marketCandlesShareTimestamp(candle, candidate));
-}
-
 function marketCandleFetchedAtMs(candle: ProjectXMarketCandle): number {
   const fetchedAtMs = candle.fetched_at ? Date.parse(candle.fetched_at) : Number.NaN;
   return Number.isFinite(fetchedAtMs) ? fetchedAtMs : 0;
 }
 
 function getLatestMarketCandle(candles: ProjectXMarketCandle[]): ProjectXMarketCandle | null {
-  return candles
-    .filter(isRenderableMarketCandle)
-    .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp))[0] ?? null;
+  let latest: ProjectXMarketCandle | null = null;
+  let latestTimestampMs = Number.NEGATIVE_INFINITY;
+  for (const candle of candles) {
+    if (!isRenderableMarketCandle(candle)) {
+      continue;
+    }
+    const timestampMs = Date.parse(candle.timestamp);
+    if (timestampMs >= latestTimestampMs) {
+      latest = candle;
+      latestTimestampMs = timestampMs;
+    }
+  }
+  return latest;
+}
+
+function findLatestClosedMarketCandle(candles: readonly ProjectXMarketCandle[]): ProjectXMarketCandle | null {
+  for (let index = candles.length - 1; index >= 0; index -= 1) {
+    const candle = candles[index];
+    if (!candle.is_partial && isRenderableMarketCandle(candle)) {
+      return candle;
+    }
+  }
+  return null;
 }
 
 function isRenderableMarketCandle(candle: ProjectXMarketCandle): boolean {

--- a/frontend/src/pages/bot/botCandleCache.test.ts
+++ b/frontend/src/pages/bot/botCandleCache.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildBotCandleCacheKey, filterMarketCandlesForWindow, mergeMarketCandles, upsertMarketCandles } from "./botCandleCache";
+import {
+  buildBotCandleCacheKey,
+  filterMarketCandlesForWindow,
+  mergeMarketCandles,
+  readBotCandleCache,
+  resetBotCandleMemoryCacheForTests,
+  upsertMarketCandles,
+  writeBotCandleCache,
+} from "./botCandleCache";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
 function candle(timestamp: string, close: number, overrides: Partial<ProjectXMarketCandle> = {}): ProjectXMarketCandle {
@@ -23,6 +31,43 @@ function candle(timestamp: string, close: number, overrides: Partial<ProjectXMar
   };
 }
 
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+beforeEach(() => {
+  resetBotCandleMemoryCacheForTests();
+});
+
+afterEach(() => {
+  resetBotCandleMemoryCacheForTests();
+  vi.unstubAllGlobals();
+});
+
 describe("buildBotCandleCacheKey", () => {
   it("normalizes equivalent bot market inputs to the same key", () => {
     expect(
@@ -42,6 +87,93 @@ describe("buildBotCandleCacheKey", () => {
         unitNumber: 5,
       }),
     );
+  });
+
+  it("isolates timeframe/cache-key switching", () => {
+    const minuteKey = buildBotCandleCacheKey({
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 1,
+    });
+    const fiveMinuteKey = buildBotCandleCacheKey({
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 5,
+    });
+
+    writeBotCandleCache(minuteKey, [candle("2026-06-25T14:00:00Z", 101)], 300);
+    writeBotCandleCache(fiveMinuteKey, [candle("2026-06-25T14:05:00Z", 105)], 300);
+
+    expect(minuteKey).not.toBe(fiveMinuteKey);
+    expect(readBotCandleCache(minuteKey)?.candles[0].close).toBe(101);
+    expect(readBotCandleCache(fiveMinuteKey)?.candles[0].close).toBe(105);
+  });
+});
+
+describe("cache persistence", () => {
+  it("uses even a single valid cached candle and persists coverage metadata", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:test";
+    const savedAt = new Date("2026-06-25T14:06:00Z");
+
+    writeBotCandleCache(
+      key,
+      [
+        candle("2026-06-25T14:00:00Z", 101),
+        candle("2026-06-25T14:05:00Z", 102, { is_partial: true }),
+      ],
+      300,
+      {
+        savedAt,
+        coverage: {
+          start: "2026-06-25T13:00:00Z",
+          end: "2026-06-25T14:06:00Z",
+        },
+      },
+    );
+
+    resetBotCandleMemoryCacheForTests();
+    const entry = readBotCandleCache(key);
+    expect(entry?.candles).toHaveLength(1);
+    expect(entry?.candles[0].is_partial).toBe(false);
+    expect(entry?.savedAt?.toISOString()).toBe(savedAt.toISOString());
+    expect(entry?.coverage).toEqual({
+      start: "2026-06-25T13:00:00.000Z",
+      end: "2026-06-25T14:06:00.000Z",
+    });
+  });
+
+  it("reads legacy v1 payloads without coverage", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:legacy";
+    storage.setItem(
+      key,
+      JSON.stringify({
+        savedAt: "2026-06-25T14:06:00Z",
+        candles: [candle("2026-06-25T14:00:00Z", 101)],
+      }),
+    );
+
+    expect(readBotCandleCache(key)).toMatchObject({
+      coverage: null,
+      candles: [{ close: 101 }],
+    });
+  });
+
+  it("serves repeated reads from memory before localStorage", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:memory";
+    writeBotCandleCache(key, [candle("2026-06-25T14:00:00Z", 101)], 300);
+    storage.setItem(key, "not-json");
+
+    expect(readBotCandleCache(key)?.candles[0].close).toBe(101);
   });
 });
 
@@ -84,6 +216,20 @@ describe("mergeMarketCandles", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toBe(closed);
+  });
+
+  it("returns the existing array identity for a semantic no-op merge", () => {
+    const existing = [
+      candle("2026-04-26T13:35:00Z", 100),
+      candle("2026-04-26T13:40:00Z", 101),
+    ];
+    const equivalentTail = candle("2026-04-26T13:40:00.000Z", 101, {
+      id: 42,
+      fetched_at: "2026-04-26T13:45:02Z",
+    });
+
+    expect(mergeMarketCandles(existing, [equivalentTail], 300)).toBe(existing);
+    expect(upsertMarketCandles(existing, [equivalentTail], 300)).toBe(existing);
   });
 });
 

--- a/frontend/src/pages/bot/botCandleCache.ts
+++ b/frontend/src/pages/bot/botCandleCache.ts
@@ -13,9 +13,13 @@ interface BotCandleCacheKeyInput {
 interface BotCandleCachePayload {
   savedAt: string;
   candles: ProjectXMarketCandle[];
+  /** Optional v1 extension. Old payloads without coverage remain readable. */
+  coverageStart?: string;
+  /** Optional v1 extension. Old payloads without coverage remain readable. */
+  coverageEnd?: string;
 }
 
-interface CandleQueryWindow {
+export interface CandleQueryWindow {
   start: string;
   end: string;
 }
@@ -23,7 +27,26 @@ interface CandleQueryWindow {
 export interface BotCandleCacheEntry {
   savedAt: Date | null;
   candles: ProjectXMarketCandle[];
+  /** The query range known to have been checked, including session-empty ranges. */
+  coverage: CandleQueryWindow | null;
 }
+
+export interface BotCandleCacheWriteMetadata {
+  /** Defaults to the current time. Supplying it keeps tests and warmers deterministic. */
+  savedAt?: Date;
+  /** Request coverage is more accurate than deriving coverage from the first/last row. */
+  coverage?: CandleQueryWindow | null;
+}
+
+/**
+ * The hot read path stays entirely in memory after the first localStorage read.
+ * Entries are scoped by the already contract+environment+timeframe-specific key.
+ */
+const memoryCache = new Map<string, BotCandleCacheEntry>();
+const canonicalMetadataByArray = new WeakMap<
+  ProjectXMarketCandle[],
+  { timestamps: number[]; hasPartial: boolean }
+>();
 
 export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
   const parts = [
@@ -37,6 +60,11 @@ export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
 }
 
 export function readBotCandleCache(cacheKey: string): BotCandleCacheEntry | null {
+  const inMemory = memoryCache.get(cacheKey);
+  if (inMemory) {
+    return inMemory;
+  }
+
   const storage = getLocalStorage();
   if (!storage) {
     return null;
@@ -51,52 +79,78 @@ export function readBotCandleCache(cacheKey: string): BotCandleCacheEntry | null
     if (!Array.isArray(parsed.candles)) {
       return null;
     }
-    const candles = selectMarketCandles(parsed.candles, false);
+    const candles = canonicalizeMarketCandles(parsed.candles, false).rows;
     if (candles.length === 0) {
       return null;
     }
-    const savedAtMs = typeof parsed.savedAt === "string" ? Date.parse(parsed.savedAt) : Number.NaN;
-    return {
-      savedAt: Number.isFinite(savedAtMs) ? new Date(savedAtMs) : null,
+    const savedAt = parseDate(parsed.savedAt);
+    const entry: BotCandleCacheEntry = {
+      savedAt,
       candles,
+      coverage: parseCoverage(parsed.coverageStart, parsed.coverageEnd),
     };
+    memoryCache.set(cacheKey, entry);
+    return entry;
   } catch {
     storage.removeItem(cacheKey);
     return null;
   }
 }
 
-export function writeBotCandleCache(cacheKey: string, candles: ProjectXMarketCandle[], limit: number): void {
+export function writeBotCandleCache(
+  cacheKey: string,
+  candles: ProjectXMarketCandle[],
+  limit: number,
+  metadata: BotCandleCacheWriteMetadata = {},
+): void {
+  const rows = trimCandlesForCache(candles, limit);
   const storage = getLocalStorage();
+  if (rows.length === 0) {
+    memoryCache.delete(cacheKey);
+    storage?.removeItem(cacheKey);
+    return;
+  }
+
+  const savedAt = validDateOrNow(metadata.savedAt);
+  const coverage = normalizeCoverage(metadata.coverage);
+  const entry: BotCandleCacheEntry = { savedAt, candles: rows, coverage };
+  memoryCache.set(cacheKey, entry);
+
   if (!storage) {
     return;
   }
 
-  const rows = trimCandlesForCache(candles, limit);
-  if (rows.length === 0) {
-    storage.removeItem(cacheKey);
-    return;
-  }
-
+  const payload: BotCandleCachePayload = {
+    savedAt: savedAt.toISOString(),
+    candles: rows,
+    ...(coverage ? { coverageStart: coverage.start, coverageEnd: coverage.end } : {}),
+  };
   try {
-    storage.setItem(
-      cacheKey,
-      JSON.stringify({
-        savedAt: new Date().toISOString(),
-        candles: rows,
-      } satisfies BotCandleCachePayload),
-    );
+    storage.setItem(cacheKey, JSON.stringify(payload));
   } catch {
-    // localStorage may be full or disabled; the network path still works.
+    // localStorage may be full or disabled; the memory/network paths still work.
   }
 }
 
+/**
+ * Clear only the process-local layer. Exported so tests can verify persisted-v1
+ * fallback without coupling production code to a browser storage event.
+ */
+export function resetBotCandleMemoryCacheForTests(): void {
+  memoryCache.clear();
+}
+
+/**
+ * Merge closed candles for persistence. Canonical inputs use a tail-aware
+ * linear merge and retain existing row references. Partial rows are never
+ * persisted, and a no-op returns `existingCandles` itself when it is canonical.
+ */
 export function mergeMarketCandles(
   existingCandles: ProjectXMarketCandle[],
   incomingCandles: ProjectXMarketCandle[],
   limit: number,
 ): ProjectXMarketCandle[] {
-  return trimCandlesForCache([...existingCandles, ...incomingCandles], limit);
+  return mergeCanonicalMarketCandles(existingCandles, incomingCandles, false, Math.max(1, Math.trunc(limit)));
 }
 
 export function filterMarketCandlesForWindow(
@@ -109,11 +163,13 @@ export function filterMarketCandlesForWindow(
     return [];
   }
 
-  return selectMarketCandles(candles, true)
-    .filter((candle) => {
-      const timestampMs = Date.parse(candle.timestamp);
-      return timestampMs >= startMs && timestampMs <= endMs;
-    });
+  const canonical = canonicalizeMarketCandles(candles, true);
+  const fromIndex = lowerBound(canonical.timestamps, startMs);
+  const toIndex = upperBound(canonical.timestamps, endMs);
+  if (canonical.reusedInput && fromIndex === 0 && toIndex === candles.length) {
+    return candles;
+  }
+  return canonical.rows.slice(fromIndex, toIndex);
 }
 
 /**
@@ -127,30 +183,74 @@ export function upsertMarketCandles(
   incomingCandles: ProjectXMarketCandle[],
   limit?: number,
 ): ProjectXMarketCandle[] {
-  const sorted = selectMarketCandles([...existingCandles, ...incomingCandles], true);
-  if (limit === undefined) {
-    return sorted;
-  }
-  return sorted.slice(-Math.max(1, Math.trunc(limit)));
+  const boundedLimit = limit === undefined ? Number.POSITIVE_INFINITY : Math.max(1, Math.trunc(limit));
+  return mergeCanonicalMarketCandles(existingCandles, incomingCandles, true, boundedLimit);
 }
 
 function trimCandlesForCache(candles: ProjectXMarketCandle[], limit: number): ProjectXMarketCandle[] {
   const boundedLimit = Math.max(1, Math.trunc(limit));
-  return selectMarketCandles(candles, false).slice(-boundedLimit);
+  const canonical = canonicalizeMarketCandles(candles, false);
+  if (canonical.rows.length <= boundedLimit) {
+    return canonical.rows;
+  }
+  return canonical.rows.slice(-boundedLimit);
+}
+
+interface CanonicalCandles {
+  rows: ProjectXMarketCandle[];
+  timestamps: number[];
+  reusedInput: boolean;
 }
 
 /**
- * Select one canonical row per instant without altering its provider OHLC.
- * Closed rows always outrank partial rows, regardless of array order or ISO
- * timestamp spelling; rows with equal completion state retain last-write-wins.
+ * Validate and canonicalize only when necessary. The overwhelmingly common
+ * API/cache arrays are already sorted and unique, so they skip Map allocation
+ * and sorting entirely.
  */
-function selectMarketCandles(candles: unknown[], includePartial: boolean): ProjectXMarketCandle[] {
+function canonicalizeMarketCandles(candles: unknown[], includePartial: boolean): CanonicalCandles {
+  const knownMetadata = canonicalMetadataByArray.get(candles as ProjectXMarketCandle[]);
+  if (knownMetadata && (includePartial || !knownMetadata.hasPartial)) {
+    return {
+      rows: candles as ProjectXMarketCandle[],
+      timestamps: knownMetadata.timestamps,
+      reusedInput: true,
+    };
+  }
+
+  const timestamps: number[] = [];
+  let previousTimestamp = Number.NEGATIVE_INFINITY;
+  let alreadyCanonical = true;
+  let hasPartial = false;
+
+  for (const value of candles) {
+    if (!isCachedMarketCandle(value) || (!includePartial && value.is_partial)) {
+      alreadyCanonical = false;
+      break;
+    }
+    hasPartial ||= value.is_partial;
+    const timestampMs = Date.parse(value.timestamp);
+    if (timestampMs <= previousTimestamp) {
+      alreadyCanonical = false;
+      break;
+    }
+    timestamps.push(timestampMs);
+    previousTimestamp = timestampMs;
+  }
+
+  if (alreadyCanonical) {
+    canonicalMetadataByArray.set(candles as ProjectXMarketCandle[], { timestamps, hasPartial });
+    return {
+      rows: candles as ProjectXMarketCandle[],
+      timestamps,
+      reusedInput: true,
+    };
+  }
+
   const byTimestamp = new Map<number, ProjectXMarketCandle>();
   for (const value of candles) {
     if (!isCachedMarketCandle(value) || (!includePartial && value.is_partial)) {
       continue;
     }
-
     const timestampMs = Date.parse(value.timestamp);
     const existing = byTimestamp.get(timestampMs);
     if (existing && !existing.is_partial && value.is_partial) {
@@ -159,9 +259,179 @@ function selectMarketCandles(candles: unknown[], includePartial: boolean): Proje
     byTimestamp.set(timestampMs, value);
   }
 
-  return Array.from(byTimestamp.entries())
-    .sort(([leftTimestamp], [rightTimestamp]) => leftTimestamp - rightTimestamp)
-    .map(([, candle]) => candle);
+  const entries = Array.from(byTimestamp.entries()).sort(
+    ([leftTimestamp], [rightTimestamp]) => leftTimestamp - rightTimestamp,
+  );
+  const rows = entries.map(([, candle]) => candle);
+  const sortedTimestamps = entries.map(([timestamp]) => timestamp);
+  canonicalMetadataByArray.set(rows, {
+    timestamps: sortedTimestamps,
+    hasPartial: rows.some((candle) => candle.is_partial),
+  });
+  return {
+    rows,
+    timestamps: sortedTimestamps,
+    reusedInput: false,
+  };
+}
+
+function mergeCanonicalMarketCandles(
+  existingInput: ProjectXMarketCandle[],
+  incomingInput: ProjectXMarketCandle[],
+  includePartial: boolean,
+  limit: number,
+): ProjectXMarketCandle[] {
+  const existing = canonicalizeMarketCandles(existingInput, includePartial);
+  const incoming = canonicalizeMarketCandles(incomingInput, includePartial);
+
+  if (existingInput === incomingInput && existing.reusedInput && existing.rows.length <= limit) {
+    return existingInput;
+  }
+
+  if (incoming.rows.length === 0) {
+    if (existing.rows.length <= limit) {
+      return existing.reusedInput ? existingInput : existing.rows;
+    }
+    return existing.rows.slice(-limit);
+  }
+  if (existing.rows.length === 0) {
+    if (incoming.rows.length <= limit) {
+      return incoming.rows;
+    }
+    return incoming.rows.slice(-limit);
+  }
+
+  const incomingFirstTimestamp = incoming.timestamps[0];
+  const existingLastIndex = existing.rows.length - 1;
+  const existingLastTimestamp = existing.timestamps[existingLastIndex];
+  if (incoming.rows.length === 1 && incomingFirstTimestamp === existingLastTimestamp) {
+    const existingLast = existing.rows[existingLastIndex];
+    const incomingLast = incoming.rows[0];
+    if (
+      (!existingLast.is_partial && incomingLast.is_partial) ||
+      marketCandlesSemanticallyEqual(existingLast, incomingLast)
+    ) {
+      return existing.rows.length <= limit && existing.reusedInput
+        ? existingInput
+        : existing.rows.slice(-limit);
+    }
+  }
+  if (incomingFirstTimestamp > existingLastTimestamp) {
+    const appended = [...existing.rows, ...incoming.rows];
+    const bounded = appended.length <= limit ? appended : appended.slice(-limit);
+    canonicalMetadataByArray.set(bounded, {
+      timestamps:
+        appended.length <= limit
+          ? [...existing.timestamps, ...incoming.timestamps]
+          : [...existing.timestamps, ...incoming.timestamps].slice(-limit),
+      hasPartial: bounded.some((candle) => candle.is_partial),
+    });
+    return bounded;
+  }
+
+  // Incoming polling data normally overlaps only the tail. Keep the older
+  // prefix without walking it, then linearly merge just the overlapping suffix.
+  const mergeFrom = lowerBound(existing.timestamps, incoming.timestamps[0]);
+  const merged = existing.rows.slice(0, mergeFrom);
+  let existingIndex = mergeFrom;
+  let incomingIndex = 0;
+  let changed = false;
+
+  while (existingIndex < existing.rows.length && incomingIndex < incoming.rows.length) {
+    const existingTimestamp = existing.timestamps[existingIndex];
+    const incomingTimestamp = incoming.timestamps[incomingIndex];
+    if (existingTimestamp < incomingTimestamp) {
+      merged.push(existing.rows[existingIndex]);
+      existingIndex += 1;
+      continue;
+    }
+    if (incomingTimestamp < existingTimestamp) {
+      merged.push(incoming.rows[incomingIndex]);
+      changed = true;
+      incomingIndex += 1;
+      continue;
+    }
+
+    const existingRow = existing.rows[existingIndex];
+    const incomingRow = incoming.rows[incomingIndex];
+    if (!existingRow.is_partial && incomingRow.is_partial) {
+      merged.push(existingRow);
+    } else if (marketCandlesSemanticallyEqual(existingRow, incomingRow)) {
+      // Retaining the existing object makes a semantically unchanged poll a
+      // complete array identity no-op after the comparison below.
+      merged.push(existingRow);
+    } else {
+      merged.push(incomingRow);
+      changed = true;
+    }
+    existingIndex += 1;
+    incomingIndex += 1;
+  }
+
+  while (existingIndex < existing.rows.length) {
+    merged.push(existing.rows[existingIndex]);
+    existingIndex += 1;
+  }
+  while (incomingIndex < incoming.rows.length) {
+    merged.push(incoming.rows[incomingIndex]);
+    changed = true;
+    incomingIndex += 1;
+  }
+
+  const bounded = merged.length <= limit ? merged : merged.slice(-limit);
+  if (existing.reusedInput && !changed && existing.rows.length <= limit) {
+    return existingInput;
+  }
+  canonicalMetadataByArray.set(bounded, {
+    timestamps: bounded.map((candle) => Date.parse(candle.timestamp)),
+    hasPartial: bounded.some((candle) => candle.is_partial),
+  });
+  return bounded;
+}
+
+function marketCandlesSemanticallyEqual(left: ProjectXMarketCandle, right: ProjectXMarketCandle): boolean {
+  return (
+    Date.parse(left.timestamp) === Date.parse(right.timestamp) &&
+    left.contract_id === right.contract_id &&
+    left.symbol === right.symbol &&
+    left.live === right.live &&
+    left.unit === right.unit &&
+    left.unit_number === right.unit_number &&
+    left.open === right.open &&
+    left.high === right.high &&
+    left.low === right.low &&
+    left.close === right.close &&
+    left.volume === right.volume &&
+    left.is_partial === right.is_partial
+  );
+}
+
+function lowerBound(values: readonly number[], target: number): number {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const midpoint = (low + high) >>> 1;
+    if (values[midpoint] < target) {
+      low = midpoint + 1;
+    } else {
+      high = midpoint;
+    }
+  }
+  return low;
+}
+
+function upperBound(values: readonly number[], target: number): number {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const midpoint = (low + high) >>> 1;
+    if (values[midpoint] <= target) {
+      low = midpoint + 1;
+    } else {
+      high = midpoint;
+    }
+  }
+  return low;
 }
 
 function isCachedMarketCandle(value: unknown): value is ProjectXMarketCandle {
@@ -180,6 +450,40 @@ function isCachedMarketCandle(value: unknown): value is ProjectXMarketCandle {
     typeof candle.volume === "number" && Number.isFinite(candle.volume) &&
     typeof candle.is_partial === "boolean"
   );
+}
+
+function parseCoverage(start: unknown, end: unknown): CandleQueryWindow | null {
+  if (typeof start !== "string" || typeof end !== "string") {
+    return null;
+  }
+  return normalizeCoverage({ start, end });
+}
+
+function normalizeCoverage(coverage: CandleQueryWindow | null | undefined): CandleQueryWindow | null {
+  if (!coverage) {
+    return null;
+  }
+  const startMs = Date.parse(coverage.start);
+  const endMs = Date.parse(coverage.end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs > endMs) {
+    return null;
+  }
+  return {
+    start: new Date(startMs).toISOString(),
+    end: new Date(endMs).toISOString(),
+  };
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs) : null;
+}
+
+function validDateOrNow(value: Date | undefined): Date {
+  return value && Number.isFinite(value.getTime()) ? new Date(value.getTime()) : new Date();
 }
 
 function getLocalStorage(): Storage | null {

--- a/frontend/src/pages/bot/botCandleGaps.test.ts
+++ b/frontend/src/pages/bot/botCandleGaps.test.ts
@@ -6,6 +6,7 @@ import {
   findCandleGaps,
   isGapCoveredByRepairWindows,
   isFuturesSessionOpen,
+  planBotCandleFetches,
 } from "./botCandleGaps";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
@@ -48,6 +49,179 @@ describe("isFuturesSessionOpen", () => {
     expect(isFuturesSessionOpen(Date.parse("2026-06-06T15:00:00Z"))).toBe(false); // Saturday
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T21:55:00Z"))).toBe(false); // Sun 17:55 ET
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T22:00:00Z"))).toBe(true); // Sun 18:00 ET
+  });
+});
+
+describe("planBotCandleFetches", () => {
+  const targetWindow = {
+    start: "2026-06-09T11:00:00Z",
+    end: "2026-06-09T14:30:00Z",
+    limit: 600,
+  };
+  const initialWindow = {
+    start: "2026-06-09T13:00:00Z",
+    end: "2026-06-09T14:30:00Z",
+    limit: 300,
+  };
+
+  it("plans a cold load as a 300-bar foreground fetch before older history", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: null,
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("cold");
+    expect(plan.cacheUsable).toBe(false);
+    expect(plan.foreground).toEqual([
+      {
+        reason: "cold",
+        priority: "foreground",
+        window: {
+          start: "2026-06-09T13:00:00.000Z",
+          end: "2026-06-09T14:30:00.000Z",
+        },
+        limit: 300,
+        repair: false,
+      },
+    ]);
+    expect(plan.background[0]).toMatchObject({
+      reason: "missing-history",
+      priority: "background",
+      repair: false,
+    });
+    expect(plan.requests.map((request) => request.priority)).toEqual(["foreground", "background"]);
+  });
+
+  it("plans a warm load with fresh covered cache without a full foreground fetch", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        // Fewer than 25 rows is still a valid immediate SWR hydration.
+        candles: [candle("2026-06-09T14:25:00Z")],
+        savedAt: new Date("2026-06-09T14:29:55Z"),
+        coverage: targetWindow,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("warm-fresh");
+    expect(plan.cacheUsable).toBe(true);
+    expect(plan.requests).toEqual([]);
+  });
+
+  it("plans missing-history work in the background without repair mode", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        candles: [candle("2026-06-09T13:00:00Z"), candle("2026-06-09T13:05:00Z")],
+        savedAt: "2026-06-09T14:29:55Z",
+        coverage: {
+          start: "2026-06-09T13:00:00Z",
+          end: "2026-06-09T14:30:00Z",
+        },
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.foreground).toEqual([]);
+    expect(plan.background).toHaveLength(1);
+    expect(plan.background[0]).toMatchObject({
+      reason: "missing-history",
+      priority: "background",
+      repair: false,
+      window: {
+        start: "2026-06-09T11:00:00.000Z",
+        end: "2026-06-09T13:00:00.000Z",
+      },
+    });
+  });
+
+  it("plans stale tail revalidation as a small overlapping foreground fetch", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        candles: [candle("2026-06-09T14:20:00Z"), candle("2026-06-09T14:25:00Z")],
+        savedAt: "2026-06-09T14:20:00Z",
+        coverage: targetWindow,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("warm-stale");
+    expect(plan.foreground).toHaveLength(1);
+    expect(plan.foreground[0]).toMatchObject({
+      reason: "stale-tail",
+      priority: "foreground",
+      limit: 8,
+      repair: false,
+    });
+    expect(Date.parse(plan.foreground[0].window.start)).toBeGreaterThan(Date.parse(targetWindow.start));
+  });
+
+  it("suppresses stale tail revalidation during a known closed futures session", () => {
+    const weekendTarget = {
+      start: "2026-06-05T14:00:00Z",
+      end: "2026-06-06T15:00:00Z",
+      limit: 300,
+    };
+    const plan = planBotCandleFetches({
+      targetWindow: weekendTarget,
+      initialWindow: weekendTarget,
+      cache: {
+        candles: [candle("2026-06-05T20:55:00Z")],
+        savedAt: "2026-06-05T21:00:00Z",
+        coverage: weekendTarget,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-06T15:00:00Z"),
+    });
+
+    expect(plan.isStale).toBe(true);
+    expect(plan.foreground).toEqual([]);
+  });
+
+  it("plans bounded interior data-gap repair in the background with repair mode", () => {
+    const gapTarget = {
+      start: "2026-06-09T13:55:00Z",
+      end: "2026-06-09T14:25:00Z",
+      limit: 300,
+    };
+    const plan = planBotCandleFetches({
+      targetWindow: gapTarget,
+      initialWindow: gapTarget,
+      cache: {
+        candles: [candle("2026-06-09T14:00:00Z"), candle("2026-06-09T14:20:00Z")],
+        savedAt: "2026-06-09T14:24:55Z",
+        coverage: gapTarget,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:25:00Z"),
+      maxRepairBars: 10,
+    });
+
+    expect(plan.foreground).toEqual([]);
+    expect(plan.background).toHaveLength(1);
+    expect(plan.background[0]).toMatchObject({
+      reason: "interior-gap",
+      priority: "background",
+      repair: true,
+    });
+    expect(plan.background[0].limit).toBeLessThanOrEqual(10);
   });
 });
 

--- a/frontend/src/pages/bot/botCandleGaps.ts
+++ b/frontend/src/pages/bot/botCandleGaps.ts
@@ -41,6 +41,65 @@ export interface GapRepairWindow {
   end: string;
 }
 
+export interface BotCandleFetchQueryWindow extends GapRepairWindow {
+  limit: number;
+}
+
+export type BotCandleFetchPriority = "foreground" | "background";
+export type BotCandleFetchReason =
+  | "cold"
+  | "missing-tail"
+  | "stale-tail"
+  | "missing-history"
+  | "interior-gap";
+
+export interface BotCandleFetchRequest {
+  reason: BotCandleFetchReason;
+  priority: BotCandleFetchPriority;
+  window: GapRepairWindow;
+  limit: number;
+  /** Only interior-hole requests trigger the backend automatic-repair path. */
+  repair: boolean;
+}
+
+export interface BotCandleFetchCacheSnapshot {
+  candles: ProjectXMarketCandle[];
+  savedAt: Date | string | null;
+  /** Query coverage can extend beyond the first/last returned trading bar. */
+  coverage?: GapRepairWindow | null;
+}
+
+export interface PlanBotCandleFetchesInput {
+  /** Full chart range ultimately desired (for example the bot lookback). */
+  targetWindow: BotCandleFetchQueryWindow;
+  /** Fast first-paint range, normally the 300-bar initial query. */
+  initialWindow: BotCandleFetchQueryWindow;
+  cache: BotCandleFetchCacheSnapshot | null;
+  unit: BotTimeframeUnit;
+  unitNumber: number;
+  now: Date;
+  /** Optional deterministic override; the default scales with the timeframe. */
+  staleAfterMs?: number;
+  /** Number of bars in a small overlapping tail revalidation. Defaults to 8. */
+  tailBars?: number;
+  /** Maximum independently repaired interior gaps. Defaults to 3. */
+  maxRepairWindows?: number;
+  /** Provider-result cap for any one interior repair. Defaults to 500. */
+  maxRepairBars?: number;
+}
+
+export type BotCandleFetchCacheState = "cold" | "warm-fresh" | "warm-stale";
+
+export interface BotCandleFetchPlan {
+  cacheState: BotCandleFetchCacheState;
+  cacheUsable: boolean;
+  isStale: boolean;
+  /** Ordered with every foreground request before all background work. */
+  requests: BotCandleFetchRequest[];
+  foreground: BotCandleFetchRequest[];
+  background: BotCandleFetchRequest[];
+}
+
 /** Whether a gap was actually included in one of the bounded repair requests. */
 export function isGapCoveredByRepairWindows(gap: CandleGap, windows: readonly GapRepairWindow[]): boolean {
   return windows.some((window_) => {
@@ -65,6 +124,9 @@ const SESSION_BREAK_START_MINUTES = 17 * 60;
 const SESSION_BREAK_END_MINUTES = 18 * 60;
 /** Cap per-gap bucket scans; beyond this a gap is sampled instead of walked. */
 const MAX_GAP_BUCKET_SCAN = 5_000;
+const DEFAULT_TAIL_REVALIDATION_BARS = 8;
+const DEFAULT_MAX_REPAIR_WINDOWS = 3;
+const DEFAULT_MAX_REPAIR_BARS = 500;
 
 const easternHourFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: EASTERN_TIME_ZONE,
@@ -153,6 +215,112 @@ function isUtcWeekday(timestampMs: number): boolean {
 
 export function intervalSecondsFor(unit: BotTimeframeUnit, unitNumber: number): number {
   return UNIT_SECONDS_BY_NAME[unit] * Math.max(1, Math.trunc(unitNumber));
+}
+
+/**
+ * Build a stale-while-revalidate request plan without reading clocks, storage,
+ * or network state. Any valid cached row is immediately usable; request
+ * priority determines scheduling, not whether cache hydration is allowed.
+ *
+ * Cold loads fetch only the small initial window in the foreground. Warm loads
+ * fetch a missing/stale overlapping tail only when the futures session is open.
+ * Older target coverage and bounded interior-hole repairs are background work.
+ */
+export function planBotCandleFetches(input: PlanBotCandleFetchesInput): BotCandleFetchPlan {
+  const target = parseQueryWindow(input.targetWindow);
+  const initial = parseQueryWindow(input.initialWindow);
+  const intervalMs = intervalSecondsFor(input.unit, input.unitNumber) * 1000;
+  if (!target || !initial || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return finishFetchPlan("cold", false, true, [], []);
+  }
+
+  const cacheBounds = findCandleBounds(input.cache?.candles ?? []);
+  const cacheUsable = cacheBounds !== null;
+  if (!input.cache || !cacheUsable) {
+    const foreground: BotCandleFetchRequest[] = [
+      fetchRequest("cold", "foreground", initial, initial.limit, false),
+    ];
+    const background = buildMissingHistoryRequests(target, initial.startMs, Math.max(1, target.limit - initial.limit));
+    return finishFetchPlan("cold", false, true, foreground, background);
+  }
+
+  const nowMs = input.now.getTime();
+  const savedAtMs = parseTimestamp(input.cache.savedAt);
+  const staleAfterMs = Number.isFinite(input.staleAfterMs)
+    ? Math.max(0, Number(input.staleAfterMs))
+    : defaultStaleAfterMs(intervalMs);
+  const ageMs = Number.isFinite(nowMs) && savedAtMs !== null ? Math.max(0, nowMs - savedAtMs) : Number.POSITIVE_INFINITY;
+  const isStale = ageMs > staleAfterMs;
+  const coverage = parseCoverageWindow(input.cache.coverage) ?? {
+    startMs: cacheBounds.firstMs,
+    endMs: cacheBounds.lastMs,
+  };
+
+  const foreground: BotCandleFetchRequest[] = [];
+  const background = buildMissingHistoryRequests(target, coverage.startMs, target.limit);
+  const sessionOpen = Number.isFinite(nowMs) && isFuturesSessionOpen(nowMs);
+  const uncoveredTailMs = target.endMs - coverage.endMs;
+  const normalizedTailBars = Math.max(2, Math.trunc(input.tailBars ?? DEFAULT_TAIL_REVALIDATION_BARS));
+
+  if (sessionOpen && uncoveredTailMs > intervalMs) {
+    const startMs = Math.max(target.startMs, coverage.endMs - intervalMs);
+    foreground.push(
+      fetchRequest(
+        "missing-tail",
+        "foreground",
+        { startMs, endMs: target.endMs },
+        estimateWindowLimit(startMs, target.endMs, intervalMs, target.limit),
+        false,
+      ),
+    );
+  } else if (sessionOpen && isStale) {
+    const startMs = Math.max(target.startMs, target.endMs - intervalMs * (normalizedTailBars - 1));
+    foreground.push(
+      fetchRequest(
+        "stale-tail",
+        "foreground",
+        { startMs, endMs: target.endMs },
+        Math.min(target.limit, normalizedTailBars),
+        false,
+      ),
+    );
+  }
+
+  const maxRepairWindows = Math.max(0, Math.trunc(input.maxRepairWindows ?? DEFAULT_MAX_REPAIR_WINDOWS));
+  if (maxRepairWindows > 0) {
+    const interiorGaps = findCandleGaps(input.cache.candles, input.unit, input.unitNumber).filter(
+      (gap) => gap.kind === "data" && gap.fromMs >= target.startMs && gap.toMs <= target.endMs,
+    );
+    const repairWindows = buildGapRepairWindows(
+      interiorGaps,
+      input.unit,
+      input.unitNumber,
+      maxRepairWindows,
+    );
+    const maxRepairBars = Math.max(1, Math.trunc(input.maxRepairBars ?? DEFAULT_MAX_REPAIR_BARS));
+    for (const repairWindow of repairWindows) {
+      const parsedRepair = parseCoverageWindow(repairWindow);
+      if (!parsedRepair) {
+        continue;
+      }
+      const startMs = Math.max(target.startMs, parsedRepair.startMs);
+      const endMs = Math.min(target.endMs, parsedRepair.endMs);
+      if (startMs >= endMs) {
+        continue;
+      }
+      background.push(
+        fetchRequest(
+          "interior-gap",
+          "background",
+          { startMs, endMs },
+          estimateWindowLimit(startMs, endMs, intervalMs, maxRepairBars),
+          true,
+        ),
+      );
+    }
+  }
+
+  return finishFetchPlan(isStale ? "warm-stale" : "warm-fresh", true, isStale, foreground, background);
 }
 
 /**
@@ -275,6 +443,133 @@ export function buildGapRepairWindows(
 
 export function buildGapRangeKey(gap: CandleGap): string {
   return `${gap.fromMs}:${gap.toMs}`;
+}
+
+interface ParsedQueryWindow {
+  startMs: number;
+  endMs: number;
+  limit: number;
+}
+
+interface ParsedWindow {
+  startMs: number;
+  endMs: number;
+}
+
+function parseQueryWindow(window_: BotCandleFetchQueryWindow): ParsedQueryWindow | null {
+  const parsed = parseCoverageWindow(window_);
+  if (!parsed || !Number.isFinite(window_.limit) || window_.limit <= 0) {
+    return null;
+  }
+  return {
+    ...parsed,
+    limit: Math.max(1, Math.trunc(window_.limit)),
+  };
+}
+
+function parseCoverageWindow(window_: GapRepairWindow | null | undefined): ParsedWindow | null {
+  if (!window_) {
+    return null;
+  }
+  const startMs = Date.parse(window_.start);
+  const endMs = Date.parse(window_.end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs > endMs) {
+    return null;
+  }
+  return { startMs, endMs };
+}
+
+function findCandleBounds(candles: readonly ProjectXMarketCandle[]): { firstMs: number; lastMs: number } | null {
+  let firstMs = Number.POSITIVE_INFINITY;
+  let lastMs = Number.NEGATIVE_INFINITY;
+  for (const candle of candles) {
+    const timestampMs = Date.parse(candle.timestamp);
+    if (!Number.isFinite(timestampMs)) {
+      continue;
+    }
+    firstMs = Math.min(firstMs, timestampMs);
+    lastMs = Math.max(lastMs, timestampMs);
+  }
+  return Number.isFinite(firstMs) && Number.isFinite(lastMs) ? { firstMs, lastMs } : null;
+}
+
+function parseTimestamp(value: Date | string | null): number | null {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function defaultStaleAfterMs(intervalMs: number): number {
+  return Math.max(15_000, Math.min(60_000, Math.trunc(intervalMs / 2)));
+}
+
+function buildMissingHistoryRequests(
+  target: ParsedQueryWindow,
+  coveredFromMs: number,
+  requestedLimit: number,
+): BotCandleFetchRequest[] {
+  if (!Number.isFinite(coveredFromMs) || target.startMs >= coveredFromMs) {
+    return [];
+  }
+  const endMs = Math.min(target.endMs, coveredFromMs);
+  if (target.startMs >= endMs) {
+    return [];
+  }
+  return [
+    fetchRequest(
+      "missing-history",
+      "background",
+      { startMs: target.startMs, endMs },
+      Math.min(target.limit, Math.max(1, Math.trunc(requestedLimit))),
+      false,
+    ),
+  ];
+}
+
+function estimateWindowLimit(startMs: number, endMs: number, intervalMs: number, cap: number): number {
+  const estimatedBars = Math.ceil(Math.max(0, endMs - startMs) / intervalMs) + 1;
+  return Math.min(Math.max(1, Math.trunc(cap)), Math.max(1, estimatedBars));
+}
+
+function fetchRequest(
+  reason: BotCandleFetchReason,
+  priority: BotCandleFetchPriority,
+  window_: ParsedWindow,
+  limit: number,
+  repair: boolean,
+): BotCandleFetchRequest {
+  return {
+    reason,
+    priority,
+    window: {
+      start: new Date(window_.startMs).toISOString(),
+      end: new Date(window_.endMs).toISOString(),
+    },
+    limit: Math.max(1, Math.trunc(limit)),
+    repair,
+  };
+}
+
+function finishFetchPlan(
+  cacheState: BotCandleFetchCacheState,
+  cacheUsable: boolean,
+  isStale: boolean,
+  foreground: BotCandleFetchRequest[],
+  background: BotCandleFetchRequest[],
+): BotCandleFetchPlan {
+  return {
+    cacheState,
+    cacheUsable,
+    isStale,
+    requests: [...foreground, ...background],
+    foreground,
+    background,
+  };
 }
 
 function dedupeSortedTimestamps(candles: ProjectXMarketCandle[]): { ms: number; iso: string }[] {

--- a/frontend/src/pages/bot/botChartData.test.ts
+++ b/frontend/src/pages/bot/botChartData.test.ts
@@ -4,6 +4,7 @@ import {
   BOT_CHART_INITIAL_BARS,
   BOT_CHART_MAX_BARS,
   BOT_CHART_MIN_BARS,
+  BOT_CHART_TIMEFRAMES,
   buildBotChartQuery,
   buildInitialBotChartQuery,
   buildBotLivePriceQuery,
@@ -318,6 +319,17 @@ describe("buildLiquidityLevels", () => {
 });
 
 describe("buildBotChartQuery", () => {
+  it("defines the six contract timeframes warmed by the signal chart", () => {
+    expect(BOT_CHART_TIMEFRAMES.map((timeframe) => timeframe.id)).toEqual([
+      "1m",
+      "5m",
+      "15m",
+      "1h",
+      "4h",
+      "1d",
+    ]);
+  });
+
   it("uses a practical capped history window based on the bot timeframe", () => {
     const window = buildBotChartQuery(
       botConfig({

--- a/frontend/src/pages/bot/botChartData.ts
+++ b/frontend/src/pages/bot/botChartData.ts
@@ -5,6 +5,21 @@ import type { BotConfig, BotDecision, BotEvaluation, BotTimeframeUnit, ProjectXM
 export const BOT_CHART_MAX_BARS = 2_000;
 export const BOT_CHART_MIN_BARS = 300;
 export const BOT_CHART_INITIAL_BARS = BOT_CHART_MIN_BARS;
+export const BOT_CHART_TIMEFRAMES = [
+  { id: "1m", label: "1m", unit: "minute", unitNumber: 1 },
+  { id: "5m", label: "5m", unit: "minute", unitNumber: 5 },
+  { id: "15m", label: "15m", unit: "minute", unitNumber: 15 },
+  { id: "1h", label: "1H", unit: "hour", unitNumber: 1 },
+  { id: "4h", label: "4H", unit: "hour", unitNumber: 4 },
+  { id: "1d", label: "1D", unit: "day", unitNumber: 1 },
+] as const satisfies readonly {
+  id: string;
+  label: string;
+  unit: BotTimeframeUnit;
+  unitNumber: number;
+}[];
+export type BotChartTimeframe = (typeof BOT_CHART_TIMEFRAMES)[number];
+export type BotChartTimeframeId = BotChartTimeframe["id"];
 const CHART_LOOKBACK_MULTIPLIER = 3;
 
 const UNIT_SECONDS_BY_NAME: Record<BotTimeframeUnit, number> = {

--- a/frontend/src/pages/bot/botChartLifecycle.test.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.test.ts
@@ -1,13 +1,35 @@
 import type { Logical, LogicalRange, UTCTimestamp } from "lightweight-charts";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   LatestRequestCoordinator,
+  LogicalViewportMemory,
+  PrioritizedRequestScheduler,
   getViewportRestoreRange,
   invalidateChartRequestLanes,
   isViewportAtLiveEdge,
   preserveLogicalViewport,
 } from "./botChartLifecycle";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function logicalRange(from: number, to: number): LogicalRange {
   return { from: from as Logical, to: to as Logical };
@@ -113,6 +135,279 @@ describe("LatestRequestCoordinator", () => {
     expect(live.accepts(liveRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(history.accepts(historyRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(repair.accepts(repairRequest, "bot-a:MNQ:5m")).toBe(false);
+  });
+});
+
+describe("PrioritizedRequestScheduler", () => {
+  it("deduplicates exact keys across queued and active subscribers", async () => {
+    const scheduler = new PrioritizedRequestScheduler({ maxConcurrency: 1 });
+    const blocker = deferred<string>();
+    const sharedWork = deferred<string>();
+    const sharedTask = vi.fn(() => sharedWork.promise);
+
+    const blockingRequest = scheduler.schedule("blocker", () => blocker.promise);
+    const first = scheduler.schedule("shared", sharedTask);
+    const secondTask = vi.fn(() => Promise.resolve("wrong task"));
+    const second = scheduler.schedule("shared", secondTask);
+
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+    expect(sharedTask).not.toHaveBeenCalled();
+    expect(secondTask).not.toHaveBeenCalled();
+
+    blocker.resolve("unblocked");
+    await expect(blockingRequest).resolves.toBe("unblocked");
+    expect(sharedTask).toHaveBeenCalledOnce();
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(0);
+    const activeDuplicateTask = vi.fn(() => Promise.resolve("wrong active task"));
+    const third = scheduler.schedule("shared", activeDuplicateTask);
+
+    sharedWork.resolve("shared result");
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      "shared result",
+      "shared result",
+      "shared result",
+    ]);
+    expect(sharedTask).toHaveBeenCalledOnce();
+    expect(secondTask).not.toHaveBeenCalled();
+    expect(activeDuplicateTask).not.toHaveBeenCalled();
+  });
+
+  it("always selects queued foreground work before background work", async () => {
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 1,
+      maxBackgroundConcurrency: 1,
+    });
+    const blocker = deferred<void>();
+    const foreground = deferred<string>();
+    const background = deferred<string>();
+    const starts: string[] = [];
+
+    const blockingRequest = scheduler.schedule("active", () => blocker.promise);
+    const backgroundRequest = scheduler.schedule(
+      "background",
+      () => {
+        starts.push("background");
+        return background.promise;
+      },
+      { priority: "background" },
+    );
+    const foregroundRequest = scheduler.schedule("foreground", () => {
+      starts.push("foreground");
+      return foreground.promise;
+    });
+
+    blocker.resolve();
+    await blockingRequest;
+    expect(starts).toEqual(["foreground"]);
+    expect(scheduler.queuedBackgroundCount).toBe(1);
+
+    foreground.resolve("visible");
+    await expect(foregroundRequest).resolves.toBe("visible");
+    expect(starts).toEqual(["foreground", "background"]);
+    background.resolve("warm");
+    await expect(backgroundRequest).resolves.toBe("warm");
+  });
+
+  it("upgrades a queued background task when a foreground subscriber joins", async () => {
+    const scheduler = new PrioritizedRequestScheduler({ maxConcurrency: 1 });
+    const blocker = deferred<void>();
+    const starts: string[] = [];
+
+    const blockingRequest = scheduler.schedule("active", () => blocker.promise);
+    const olderBackground = scheduler.schedule(
+      "older-background",
+      () => {
+        starts.push("older-background");
+        return "older";
+      },
+      { priority: "background" },
+    );
+    const upgradedTask = vi.fn(() => {
+      starts.push("upgraded");
+      return "upgraded";
+    });
+    const backgroundSubscriber = scheduler.schedule("upgrade-me", upgradedTask, {
+      priority: "background",
+    });
+    const ignoredDuplicateTask = vi.fn(() => "duplicate");
+    const foregroundSubscriber = scheduler.schedule(
+      "upgrade-me",
+      ignoredDuplicateTask,
+      { priority: "foreground" },
+    );
+
+    expect(scheduler.queuedForegroundCount).toBe(1);
+    expect(scheduler.queuedBackgroundCount).toBe(1);
+    blocker.resolve();
+    await blockingRequest;
+    await expect(Promise.all([backgroundSubscriber, foregroundSubscriber])).resolves.toEqual([
+      "upgraded",
+      "upgraded",
+    ]);
+    await expect(olderBackground).resolves.toBe("older");
+
+    expect(starts).toEqual(["upgraded", "older-background"]);
+    expect(upgradedTask).toHaveBeenCalledOnce();
+    expect(ignoredDuplicateTask).not.toHaveBeenCalled();
+  });
+
+  it("limits background concurrency while leaving capacity for foreground work", async () => {
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 2,
+      maxBackgroundConcurrency: 1,
+    });
+    const firstBackground = deferred<void>();
+    const secondBackground = deferred<void>();
+    const foreground = deferred<void>();
+    const starts: string[] = [];
+
+    const first = scheduler.schedule(
+      "background-1",
+      () => {
+        starts.push("background-1");
+        return firstBackground.promise;
+      },
+      { priority: "background" },
+    );
+    const second = scheduler.schedule(
+      "background-2",
+      () => {
+        starts.push("background-2");
+        return secondBackground.promise;
+      },
+      { priority: "background" },
+    );
+    const visible = scheduler.schedule("foreground", () => {
+      starts.push("foreground");
+      return foreground.promise;
+    });
+
+    expect(starts).toEqual(["background-1", "foreground"]);
+    expect(scheduler.activeCount).toBe(2);
+    expect(scheduler.activeBackgroundCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+
+    foreground.resolve();
+    await visible;
+    expect(starts).toEqual(["background-1", "foreground"]);
+    firstBackground.resolve();
+    await first;
+    expect(starts).toEqual(["background-1", "foreground", "background-2"]);
+    secondBackground.resolve();
+    await second;
+  });
+
+  it("rate-limits background starts even when another background slot is free", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 2,
+      maxBackgroundConcurrency: 2,
+      minBackgroundStartIntervalMs: 100,
+    });
+    const firstWork = deferred<void>();
+    const secondWork = deferred<void>();
+    const starts: number[] = [];
+
+    const first = scheduler.schedule(
+      "background-1",
+      () => {
+        starts.push(Date.now());
+        return firstWork.promise;
+      },
+      { priority: "background" },
+    );
+    const second = scheduler.schedule(
+      "background-2",
+      () => {
+        starts.push(Date.now());
+        return secondWork.promise;
+      },
+      { priority: "background" },
+    );
+
+    expect(starts).toEqual([1_000]);
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(starts).toEqual([1_000]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(starts).toEqual([1_000, 1_100]);
+
+    firstWork.resolve();
+    secondWork.resolve();
+    await Promise.all([first, second]);
+  });
+
+  it("cancels subscribers independently and aborts shared work only after the last leaves", async () => {
+    const scheduler = new PrioritizedRequestScheduler();
+    const transport = deferred<string>();
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const sharedTransport: { signal?: AbortSignal } = {};
+    const task = (signal: AbortSignal) => {
+      sharedTransport.signal = signal;
+      return transport.promise;
+    };
+
+    const first = scheduler.schedule("candles", task, { signal: firstController.signal });
+    const second = scheduler.schedule("candles", task, { signal: secondController.signal });
+    const firstOutcome = first.then(
+      () => "resolved",
+      (error: unknown) => (error as Error).name,
+    );
+    const secondOutcome = second.then(
+      () => "resolved",
+      (error: unknown) => (error as Error).name,
+    );
+
+    firstController.abort();
+    expect(await firstOutcome).toBe("AbortError");
+    expect(sharedTransport.signal?.aborted).toBe(false);
+    expect(scheduler.activeCount).toBe(1);
+
+    secondController.abort();
+    expect(await secondOutcome).toBe("AbortError");
+    expect(sharedTransport.signal?.aborted).toBe(true);
+    // An abort-unaware transport still occupies its slot, but cannot resolve
+    // either cancelled subscriber when it eventually returns.
+    expect(scheduler.activeCount).toBe(1);
+    transport.resolve("late candles");
+    await Promise.resolve();
+    expect(scheduler.activeCount).toBe(0);
+  });
+});
+
+describe("LogicalViewportMemory", () => {
+  it("saves and restores independent ranges across timeframe keys", () => {
+    const memory = new LogicalViewportMemory<string>();
+
+    expect(memory.save("MNQ:1m", logicalRange(10.25, 40.75))).toBe(true);
+    expect(memory.save("MNQ:1H", logicalRange(100.5, 130.5))).toBe(true);
+    expect(memory.restore("MNQ:1m")).toEqual(logicalRange(10.25, 40.75));
+    expect(memory.restore("MNQ:1H")).toEqual(logicalRange(100.5, 130.5));
+    expect(memory.restore("MNQ:5m")).toBeNull();
+  });
+
+  it("ignores invalid ranges and protects saved ranges from caller mutation", () => {
+    const memory = new LogicalViewportMemory<string>();
+    const range = logicalRange(1, 3);
+    memory.save("5m", range);
+
+    range.from = 99 as Logical;
+    const restored = memory.restore("5m");
+    expect(restored).toEqual(logicalRange(1, 3));
+    if (restored) {
+      restored.to = 100 as Logical;
+    }
+    expect(memory.restore("5m")).toEqual(logicalRange(1, 3));
+    expect(memory.save("5m", logicalRange(4, 2))).toBe(false);
+    expect(memory.restore("5m")).toEqual(logicalRange(1, 3));
+
+    expect(memory.delete("5m")).toBe(true);
+    expect(memory.restore("5m")).toBeNull();
   });
 });
 

--- a/frontend/src/pages/bot/botChartLifecycle.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.ts
@@ -84,6 +84,364 @@ export function invalidateChartRequestLanes(lanes: readonly LatestRequestCoordin
   }
 }
 
+export type RequestPriority = "foreground" | "background";
+
+export interface PrioritizedRequestSchedulerOptions {
+  /** Maximum number of tasks that may be running at once. */
+  maxConcurrency?: number;
+  /** Maximum number of running tasks that started as background work. */
+  maxBackgroundConcurrency?: number;
+  /** Minimum elapsed time between the starts of two background tasks. */
+  minBackgroundStartIntervalMs?: number;
+}
+
+export interface ScheduledRequestOptions {
+  /** Foreground by default so user-visible work is never accidentally deprioritized. */
+  priority?: RequestPriority;
+  /** Cancels only this subscription to a shared task. */
+  signal?: AbortSignal;
+}
+
+export type ScheduledRequestTask<TResult> = (
+  signal: AbortSignal,
+) => PromiseLike<TResult> | TResult;
+
+type ScheduledEntryState = "queued" | "active" | "detached" | "settled";
+
+interface RequestSubscriber {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (reason?: unknown) => void;
+  readonly signal?: AbortSignal;
+  abortListener?: () => void;
+  settled: boolean;
+}
+
+interface ScheduledEntry<TKey> {
+  readonly key: TKey;
+  readonly task: ScheduledRequestTask<unknown>;
+  readonly controller: AbortController;
+  readonly subscribers: Set<RequestSubscriber>;
+  priority: RequestPriority;
+  state: ScheduledEntryState;
+  startedAsBackground: boolean;
+}
+
+/**
+ * Runs deduplicated async work with separate foreground and background limits.
+ *
+ * Every exact key has at most one live queued/running task. Later callers with
+ * the same key subscribe to the first task, so a key must identify all inputs
+ * that affect both the request and its result type. Subscriber abort signals
+ * are independent; the shared task is aborted only after its final subscriber
+ * leaves. A transport that ignores abort is harmless because detached
+ * subscribers have already been rejected and are never resolved later.
+ */
+export class PrioritizedRequestScheduler<TKey = string> {
+  private readonly maxConcurrency: number;
+  private readonly maxBackgroundConcurrency: number;
+  private readonly minBackgroundStartIntervalMs: number;
+  private readonly entriesByKey = new Map<TKey, ScheduledEntry<TKey>>();
+  private readonly queuedEntries: ScheduledEntry<TKey>[] = [];
+  private readonly activeEntries = new Set<ScheduledEntry<TKey>>();
+  private activeBackgroundTasks = 0;
+  private lastBackgroundStartTime: number | null = null;
+  private backgroundStartTimer: ReturnType<typeof setTimeout> | null = null;
+  private backgroundStartTimerDueAt: number | null = null;
+  private pumping = false;
+
+  constructor(options: PrioritizedRequestSchedulerOptions = {}) {
+    this.maxConcurrency = positiveInteger(options.maxConcurrency ?? 2, "maxConcurrency");
+    this.maxBackgroundConcurrency = nonNegativeInteger(
+      options.maxBackgroundConcurrency ?? 1,
+      "maxBackgroundConcurrency",
+    );
+    this.minBackgroundStartIntervalMs = nonNegativeFiniteNumber(
+      options.minBackgroundStartIntervalMs ?? 0,
+      "minBackgroundStartIntervalMs",
+    );
+  }
+
+  /**
+   * Subscribe to keyed work, creating the underlying task only for the first
+   * subscriber. A queued background task is upgraded when a foreground caller
+   * subscribes to the same key.
+   */
+  schedule<TResult>(
+    key: TKey,
+    task: ScheduledRequestTask<TResult>,
+    options: ScheduledRequestOptions = {},
+  ): Promise<TResult> {
+    const priority = options.priority ?? "foreground";
+    const subscriberSignal = options.signal;
+    if (subscriberSignal?.aborted) {
+      return Promise.reject(abortReason(subscriberSignal));
+    }
+
+    let entry = this.entriesByKey.get(key);
+    if (!entry) {
+      entry = {
+        key,
+        task: task as ScheduledRequestTask<unknown>,
+        controller: new AbortController(),
+        subscribers: new Set(),
+        priority,
+        state: "queued",
+        startedAsBackground: false,
+      };
+      this.entriesByKey.set(key, entry);
+      this.queuedEntries.push(entry);
+    } else if (entry.state === "queued" && priority === "foreground") {
+      entry.priority = "foreground";
+    }
+
+    const promise = new Promise<TResult>((resolve, reject) => {
+      const subscriber: RequestSubscriber = {
+        resolve: (value) => resolve(value as TResult),
+        reject,
+        signal: subscriberSignal,
+        settled: false,
+      };
+      entry.subscribers.add(subscriber);
+
+      if (subscriberSignal) {
+        const abortListener = () => {
+          this.abortSubscriber(entry, subscriber, abortReason(subscriberSignal));
+        };
+        subscriber.abortListener = abortListener;
+        subscriberSignal.addEventListener("abort", abortListener, { once: true });
+
+        // Close the small race between the initial check and listener setup.
+        if (subscriberSignal.aborted) {
+          abortListener();
+        }
+      }
+    });
+
+    this.pump();
+    return promise;
+  }
+
+  get activeCount(): number {
+    return this.activeEntries.size;
+  }
+
+  get queuedCount(): number {
+    return this.queuedEntries.length;
+  }
+
+  get activeBackgroundCount(): number {
+    return this.activeBackgroundTasks;
+  }
+
+  get queuedForegroundCount(): number {
+    return this.queuedEntries.reduce(
+      (count, entry) => count + (entry.priority === "foreground" ? 1 : 0),
+      0,
+    );
+  }
+
+  get queuedBackgroundCount(): number {
+    return this.queuedEntries.reduce(
+      (count, entry) => count + (entry.priority === "background" ? 1 : 0),
+      0,
+    );
+  }
+
+  private abortSubscriber(
+    entry: ScheduledEntry<TKey>,
+    subscriber: RequestSubscriber,
+    reason: unknown,
+  ): void {
+    if (subscriber.settled) {
+      return;
+    }
+
+    this.settleSubscriber(subscriber, "reject", reason);
+    entry.subscribers.delete(subscriber);
+    if (entry.subscribers.size > 0) {
+      return;
+    }
+
+    // Remove the key immediately so a later caller can start fresh rather than
+    // joining an abort-unaware transport whose shared signal is already dead.
+    if (this.entriesByKey.get(entry.key) === entry) {
+      this.entriesByKey.delete(entry.key);
+    }
+
+    if (entry.state === "queued") {
+      this.removeQueuedEntry(entry);
+      entry.state = "settled";
+      entry.controller.abort(reason);
+      this.pump();
+      return;
+    }
+
+    if (entry.state === "active") {
+      entry.state = "detached";
+      entry.controller.abort(reason);
+    }
+  }
+
+  private pump(): void {
+    if (this.pumping) {
+      return;
+    }
+
+    this.pumping = true;
+    try {
+      while (this.activeEntries.size < this.maxConcurrency) {
+        const entry = this.takeNextRunnableEntry();
+        if (!entry) {
+          break;
+        }
+        this.startEntry(entry);
+      }
+
+      if (!this.queuedEntries.some((entry) => entry.priority === "background")) {
+        this.clearBackgroundStartTimer();
+      }
+    } finally {
+      this.pumping = false;
+    }
+  }
+
+  private takeNextRunnableEntry(): ScheduledEntry<TKey> | null {
+    const foregroundIndex = this.queuedEntries.findIndex(
+      (entry) => entry.priority === "foreground",
+    );
+    if (foregroundIndex >= 0) {
+      return this.queuedEntries.splice(foregroundIndex, 1)[0] ?? null;
+    }
+
+    const backgroundIndex = this.queuedEntries.findIndex(
+      (entry) => entry.priority === "background",
+    );
+    if (
+      backgroundIndex < 0 ||
+      this.activeBackgroundTasks >= this.maxBackgroundConcurrency
+    ) {
+      return null;
+    }
+
+    const waitMs = this.backgroundStartWaitMs();
+    if (waitMs > 0) {
+      this.scheduleBackgroundStart(waitMs);
+      return null;
+    }
+
+    return this.queuedEntries.splice(backgroundIndex, 1)[0] ?? null;
+  }
+
+  private startEntry(entry: ScheduledEntry<TKey>): void {
+    entry.state = "active";
+    entry.startedAsBackground = entry.priority === "background";
+    this.activeEntries.add(entry);
+    if (entry.startedAsBackground) {
+      this.activeBackgroundTasks += 1;
+      this.lastBackgroundStartTime = Date.now();
+    }
+
+    let result: PromiseLike<unknown> | unknown;
+    try {
+      result = entry.task(entry.controller.signal);
+    } catch (error) {
+      this.finishEntry(entry, "reject", error);
+      return;
+    }
+
+    Promise.resolve(result).then(
+      (value) => this.finishEntry(entry, "resolve", value),
+      (error: unknown) => this.finishEntry(entry, "reject", error),
+    );
+  }
+
+  private finishEntry(
+    entry: ScheduledEntry<TKey>,
+    outcome: "resolve" | "reject",
+    value: unknown,
+  ): void {
+    if (entry.state !== "active" && entry.state !== "detached") {
+      return;
+    }
+
+    this.activeEntries.delete(entry);
+    if (entry.startedAsBackground) {
+      this.activeBackgroundTasks -= 1;
+    }
+    if (this.entriesByKey.get(entry.key) === entry) {
+      this.entriesByKey.delete(entry.key);
+    }
+    entry.state = "settled";
+
+    for (const subscriber of entry.subscribers) {
+      this.settleSubscriber(subscriber, outcome, value);
+    }
+    entry.subscribers.clear();
+    this.pump();
+  }
+
+  private settleSubscriber(
+    subscriber: RequestSubscriber,
+    outcome: "resolve" | "reject",
+    value: unknown,
+  ): void {
+    if (subscriber.settled) {
+      return;
+    }
+    subscriber.settled = true;
+    if (subscriber.signal && subscriber.abortListener) {
+      subscriber.signal.removeEventListener("abort", subscriber.abortListener);
+    }
+    if (outcome === "resolve") {
+      subscriber.resolve(value);
+    } else {
+      subscriber.reject(value);
+    }
+  }
+
+  private removeQueuedEntry(entry: ScheduledEntry<TKey>): void {
+    const index = this.queuedEntries.indexOf(entry);
+    if (index >= 0) {
+      this.queuedEntries.splice(index, 1);
+    }
+  }
+
+  private backgroundStartWaitMs(): number {
+    if (this.lastBackgroundStartTime === null) {
+      return 0;
+    }
+    const nextStartTime =
+      this.lastBackgroundStartTime + this.minBackgroundStartIntervalMs;
+    return Math.max(0, nextStartTime - Date.now());
+  }
+
+  private scheduleBackgroundStart(waitMs: number): void {
+    const dueAt = Date.now() + waitMs;
+    if (
+      this.backgroundStartTimer !== null &&
+      this.backgroundStartTimerDueAt !== null &&
+      this.backgroundStartTimerDueAt <= dueAt
+    ) {
+      return;
+    }
+    this.clearBackgroundStartTimer();
+    this.backgroundStartTimerDueAt = dueAt;
+    this.backgroundStartTimer = setTimeout(() => {
+      this.backgroundStartTimer = null;
+      this.backgroundStartTimerDueAt = null;
+      this.pump();
+    }, waitMs);
+  }
+
+  private clearBackgroundStartTimer(): void {
+    if (this.backgroundStartTimer !== null) {
+      clearTimeout(this.backgroundStartTimer);
+      this.backgroundStartTimer = null;
+      this.backgroundStartTimerDueAt = null;
+    }
+  }
+}
+
 export type ChartViewportMutation = "refresh" | "pagination" | "live";
 
 export interface PreservedLogicalViewport {
@@ -95,6 +453,34 @@ export interface PreservedLogicalViewport {
 interface ViewportRestoreOptions {
   /** Bars from the final candle that still count as following live data. */
   liveEdgeTolerance?: number;
+}
+
+/** Stores independent logical ranges for chart contexts such as timeframes. */
+export class LogicalViewportMemory<TKey = string> {
+  private readonly ranges = new Map<TKey, LogicalRange>();
+
+  /** Saves a defensive copy of a valid range; invalid transient ranges are ignored. */
+  save(key: TKey, range: LogicalRange | null): boolean {
+    if (!isValidLogicalRange(range)) {
+      return false;
+    }
+    this.ranges.set(key, cloneLogicalRange(range));
+    return true;
+  }
+
+  /** Returns a defensive copy so chart-library mutations cannot corrupt memory. */
+  restore(key: TKey): LogicalRange | null {
+    const range = this.ranges.get(key);
+    return range ? cloneLogicalRange(range) : null;
+  }
+
+  delete(key: TKey): boolean {
+    return this.ranges.delete(key);
+  }
+
+  clear(): void {
+    this.ranges.clear();
+  }
 }
 
 /**
@@ -223,6 +609,35 @@ function isValidLogicalRange(range: LogicalRange | null): range is LogicalRange 
   return Number.isFinite(from) && Number.isFinite(to) && from <= to;
 }
 
+function cloneLogicalRange(range: LogicalRange): LogicalRange {
+  return { from: range.from, to: range.to };
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
   return Math.min(maximum, Math.max(minimum, value));
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function nonNegativeFiniteNumber(value: number, name: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }


### PR DESCRIPTION
## Summary

- build on the completed Agent 2 candle-repair and backtest-data integration, including inferred intraday partial bars, authoritative candle refreshes, batched candle upserts, and deterministic backtest preparation
- make the Signal Chart stale-while-revalidate: paint any valid cached candles immediately, then fetch only the cold initial window, uncovered history, stale tail, or bounded interior gaps
- add exact-key request deduplication, latest-response cancellation, foreground/background priority, strict background concurrency and rate limits, and concurrent live-price loading
- warm 1m, 5m, 15m, 1H, 4H, and 1D for the selected contract while preserving per-timeframe viewports
- use structural sharing and canonical candle metadata to avoid repeated sorting, merging, localStorage parsing, and React/chart updates
- guarantee that a partial bar never replaces an existing closed bar, while allowing a closed bar to replace a partial one

## Why

The chart previously re-read and re-sorted localStorage data, then requested the full 300–2,000-bar window on every load, poll, and timeframe change. Warm timeframe changes therefore behaved much like cold loads, duplicate requests could reach the synchronous backend, and repeated no-op candle merges still rebuilt arrays and rerendered the chart.

The backend also intentionally requires `repair=true` for interior cache holes, while normal reads only extend or revalidate the tail. The frontend now plans those request types separately and uses the backend repair path only for detected interior gaps.

## Backend integration

- closed-history requests keep `include_partial_bar=false`
- stale and missing tails use normal non-pruning requests
- detected interior gaps use bounded `repair=true` requests
- explicit refresh remains authoritative and may prune provider-missing rows
- frontend closed-over-partial precedence protects canonical chart/cache data even when partial responses arrive late

## Performance

Unthrottled local browser measurements with the 240-bar demo chart:

| Scenario | Median first paint | Range | Samples |
| --- | ---: | ---: | ---: |
| Cold load | 96.0 ms | 92.6–98.7 ms | 3 |
| Warm load | 108.1 ms | 97.2–117.6 ms | 6 |
| Warmed timeframe switch | 52.7 ms | 34.9–68.3 ms | 6 |

The demo provider is synchronous, so warm first paint is dominated by chart rendering rather than network latency. Warm loads made zero chart-history requests. Five of six warmed timeframe switches made zero foreground candle requests; the remaining switch issued one bounded stale-tail revalidation. Warmed switching was about 45% faster than cold first paint.

Local 2,000-bar CPU microbenchmarks improved as follows:

- hot cache read/filter: 5.793 ms → 0.0015 ms
- rejected partial-over-closed upsert: 1.372 ms → 0.0014 ms
- single-bar append: 1.277 ms → 0.0236 ms
- duplicate response merge: 2.886 ms → 1.137 ms

## Validation

- `npm test`: 42 files, 341 tests passed
- `npm run build`: TypeScript and Vite production build passed
- ESLint on all changed frontend files passed
- `python -m pytest tests/test_projectx_client.py tests/test_bot_service.py -q`: 119 tests passed
- `git diff --check`: passed
