### PR TITLE
Add one-click full-history backtests

### DIFF
--- a/backend/app/bot_schemas.py
+++ b/backend/app/bot_schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -434,15 +434,38 @@ class BotActivityOut(BaseModel):
 
 
 class BotBacktestIn(BaseModel):
-    start: datetime
-    end: datetime
+    start: datetime | None = None
+    end: datetime | None = None
     starting_balance: float = Field(default=50_000, gt=0, le=1_000_000_000)
     commission_per_contract: float = Field(default=0, ge=0, le=10_000)
     slippage_ticks: float = Field(default=0, ge=0, le=1_000)
     force_close_at_end: bool = True
 
+    @model_validator(mode="after")
+    def validate_optional_range(self):
+        if (self.start is None) != (self.end is None):
+            raise ValueError("backtest start and end must be provided together")
+        if self.start is not None and self.end is not None:
+            start = (
+                self.start.replace(tzinfo=timezone.utc)
+                if self.start.tzinfo is None
+                else self.start.astimezone(timezone.utc)
+            )
+            end = (
+                self.end.replace(tzinfo=timezone.utc)
+                if self.end.tzinfo is None
+                else self.end.astimezone(timezone.utc)
+            )
+            if end <= start:
+                raise ValueError("backtest end must be after start")
+        return self
+
 
 class BotBacktestRangeOut(BaseModel):
+    contract_id: str
+    symbol: str | None = None
+    timeframe_unit: TimeframeUnit
+    timeframe_unit_number: int = Field(gt=0)
     start: datetime
     end: datetime
     bar_count: int = Field(ge=1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,6 +207,7 @@ from .services.bot_backtesting import (
     MalformedBacktestDataError,
     UnsupportedBacktestStrategyError,
     create_bot_backtest,
+    prepare_bot_backtest_data,
     serialize_bot_backtest,
 )
 from .services.bot_serialization import serialize_supported_bot_configs
@@ -1615,6 +1616,45 @@ def delete_trading_bot(
     except LookupError as exc:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+    return Response(status_code=204)
+
+
+@app.post(
+    "/api/bots/{bot_config_id}/backtests/prepare",
+    status_code=204,
+)
+def prepare_trading_bot_backtest_data(
+    bot_config_id: int,
+    payload: BotBacktestIn,
+    db: Session = Depends(get_db),
+):
+    """Cache every historical stream required by a deterministic TopBot replay."""
+
+    user_id = get_authenticated_user_id()
+    if bot_config_id <= 0:
+        raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
+    try:
+        client = _projectx_client_for_user(db, user_id=user_id)
+        prepare_bot_backtest_data(
+            db,
+            user_id=user_id,
+            bot_config_id=bot_config_id,
+            payload=payload,
+            client=client,
+        )
+        db.commit()
+    except LookupError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
+    except BacktestError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
         db.rollback()
         raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,7 +207,6 @@ from .services.bot_backtesting import (
     MalformedBacktestDataError,
     UnsupportedBacktestStrategyError,
     create_bot_backtest,
-    prepare_bot_backtest_data,
     serialize_bot_backtest,
 )
 from .services.bot_serialization import serialize_supported_bot_configs
@@ -1623,45 +1622,6 @@ def delete_trading_bot(
 
 
 @app.post(
-    "/api/bots/{bot_config_id}/backtests/prepare",
-    status_code=204,
-)
-def prepare_trading_bot_backtest_data(
-    bot_config_id: int,
-    payload: BotBacktestIn,
-    db: Session = Depends(get_db),
-):
-    """Cache every historical stream required by a deterministic TopBot replay."""
-
-    user_id = get_authenticated_user_id()
-    if bot_config_id <= 0:
-        raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
-    try:
-        client = _projectx_client_for_user(db, user_id=user_id)
-        prepare_bot_backtest_data(
-            db,
-            user_id=user_id,
-            bot_config_id=bot_config_id,
-            payload=payload,
-            client=client,
-        )
-        db.commit()
-    except LookupError as exc:
-        db.rollback()
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProjectXClientError as exc:
-        db.rollback()
-        raise _to_http_exception(exc) from exc
-    except BacktestError as exc:
-        db.rollback()
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception:
-        db.rollback()
-        raise
-    return Response(status_code=204)
-
-
-@app.post(
     "/api/bots/{bot_config_id}/backtests",
     response_model=BotBacktestOut,
     status_code=201,
@@ -1671,19 +1631,31 @@ def create_trading_bot_backtest(
     payload: BotBacktestIn,
     db: Session = Depends(get_db),
 ):
-    """Replay stored candles without fetching data or invoking any order path."""
+    """Prepare required TopBot history, then replay closed candles without routing orders."""
 
     user_id = get_authenticated_user_id()
     if bot_config_id <= 0:
         raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
     try:
+        config = get_bot_config(db, user_id=user_id, bot_config_id=bot_config_id)
+        if config is None:
+            raise LookupError("bot_config_not_found")
+        client = (
+            _projectx_client_for_user(db, user_id=user_id)
+            if str(config.strategy_type) == "topbot_adaptive"
+            else None
+        )
         row = create_bot_backtest(
             db,
             user_id=user_id,
             bot_config_id=bot_config_id,
             payload=payload,
+            client=client,
         )
         db.commit()
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
     except LookupError as exc:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -32,20 +32,27 @@ from .bot_service import (
     _session_window_utc_for_reference,
 )
 from .instruments import load_instrument_specs, normalize_symbol_key
+from .projectx_client import ProjectXClient
 from .bot_strategy_registry import (
     BACKTEST_SUPPORTED_STRATEGY_IDENTIFIERS,
     get_strategy_definition,
 )
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    futures_session_is_open,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
-BACKTEST_ENGINE_VERSION = "1.1.0"
+BACKTEST_ENGINE_VERSION = "1.2.0"
 MAX_BACKTEST_BARS = 20_000
 MAX_BACKTEST_RANGE_DAYS = 366
 MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
 MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
 MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
 MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
+MAX_PROVIDER_FETCH_BARS = 20_000
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -62,7 +69,7 @@ UNSUPPORTED_BACKTEST_STRATEGY_REASONS: dict[str, str] = {
     "supertrend_pivot": "requires synchronized signal-timeframe and closed daily candles",
     "fvg_sweep_mss": "requires synchronized FVG and lower-timeframe structure streams",
     "atr_adjusted_relative_strength": "requires an exactly aligned benchmark candle stream",
-    "relative_strength_spy": "requires an exactly aligned SPY candle stream",
+    "relative_strength_spy": "requires an exactly aligned MES benchmark candle stream",
     "vwap_gap_retrace": "requires fixed 1-minute data and alternative exit-path replay",
     "donchian_breakout": "requires stateful channel, trailing-stop, sizing, and entry-plan replay",
     "ema_scalping": "requires exact strong-opposite-candle exit replay",
@@ -202,13 +209,13 @@ class BacktestEngine:
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
+        self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
         auxiliary_excluded_partial = 0
-        missing_replay_streams: list[str] = []
+        deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
             (
                 self.topbot_streams,
                 auxiliary_excluded_partial,
-                missing_replay_streams,
             ) = _prepare_topbot_replay_streams(
                 config,
                 primary_candles=self.all_candles,
@@ -232,11 +239,35 @@ class BacktestEngine:
                 1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
             )
             if closed_by_first_event < hard_minimum:
-                raise InsufficientBacktestDataError(
-                    "insufficient_backtest_data: insufficient_strategy_warmup: "
-                    f"{self.strategy_type} requires at least {hard_minimum} bars closed by the "
-                    f"first replay event; found {closed_by_first_event}"
+                deferred_execution_bars = hard_minimum - closed_by_first_event
+                self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                if len(self.execution_candles) < MIN_EXECUTION_BARS:
+                    available_closed_bars = sum(
+                        1
+                        for candle in self.all_candles
+                        if _candle_close_time(candle) <= self.settings.end
+                    )
+                    raise InsufficientBacktestDataError(
+                        "insufficient_backtest_data: insufficient_strategy_warmup: "
+                        f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
+                        f"only {available_closed_bars} were available"
+                    )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            session_execution_candles = [
+                candle
+                for candle in self.execution_candles
+                if _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
                 )
+            ]
+            coverage_candles = session_execution_candles or self.execution_candles
+            self.topbot_unavailable_sources = _topbot_unavailable_sources(
+                config,
+                streams=self.topbot_streams,
+                first_event=_candle_close_time(coverage_candles[0]),
+                last_event=_candle_close_time(coverage_candles[-1]),
+            )
         if len(self.execution_candles) > MAX_BACKTEST_BARS:
             raise BacktestConfigurationError(
                 f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}; "
@@ -254,9 +285,16 @@ class BacktestEngine:
             rolling_limit=self.evaluator_history_limit,
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            signal_evaluation_bars = sum(
+                _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
+                )
+                for candle in self.execution_candles
+            )
             estimated_operations = _estimate_topbot_evaluator_operations(
                 config,
-                execution_bars=len(self.execution_candles),
+                execution_bars=signal_evaluation_bars,
             )
             operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
         else:
@@ -278,11 +316,20 @@ class BacktestEngine:
             self.warnings.append(
                 f"Excluded {auxiliary_excluded_partial} partial auxiliary candle(s); only closed bars were replayed."
             )
-        if missing_replay_streams:
+        if deferred_execution_bars:
             self.warnings.append(
-                "TopBot source data was unavailable for stored replay stream(s): "
-                + ", ".join(sorted(missing_replay_streams))
-                + ". Affected sources were recorded as failed for ensemble voting."
+                f"Deferred replay by {deferred_execution_bars} candle(s) so the strategy had "
+                "its required closed-bar warmup before the first evaluation."
+            )
+        if self.topbot_unavailable_sources:
+            excluded = "; ".join(
+                f"{source} ({', '.join(keys)})"
+                for source, keys in sorted(self.topbot_unavailable_sources.items())
+            )
+            self.warnings.append(
+                "TopBot excluded source(s) whose required stored replay data was unavailable: "
+                + excluded
+                + ". Vote thresholds were unchanged."
             )
         self._add_data_quality_warnings()
 
@@ -338,6 +385,15 @@ class BacktestEngine:
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
+            if (
+                self.strategy_type == _TOPBOT_STRATEGY
+                and not _event_timestamp_is_in_configured_session(
+                    self.config,
+                    candle_start,
+                )
+            ):
+                self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
+                continue
             signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
@@ -392,8 +448,8 @@ class BacktestEngine:
         )
         return {
             "range": {
-                "start": self.settings.start.isoformat(),
-                "end": self.settings.end.isoformat(),
+                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
+                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
             },
             "config_snapshot": _config_snapshot(self.config),
@@ -532,8 +588,11 @@ class BacktestEngine:
         )
         source_overrides = topbot_params.get("source_strategy_params") or {}
         source_results: list[dict[str, Any]] = []
+        event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
+            if source_strategy in self.topbot_unavailable_sources:
+                continue
             source_params = bot_service_module._normalize_strategy_params(
                 source_strategy,
                 source_overrides.get(source_strategy, {}),
@@ -542,6 +601,7 @@ class BacktestEngine:
                 source_strategy,
                 source_params=source_params,
                 event_time=event_time,
+                event_timestamp=event_timestamp,
             )
             cached = self._topbot_source_cache.get(source_strategy)
             if cached is not None and cached[0] == signature:
@@ -552,6 +612,7 @@ class BacktestEngine:
                     source_strategy,
                     source_params=source_params,
                     event_time=event_time,
+                    event_timestamp=event_timestamp,
                 )
             except Exception as exc:
                 result = {
@@ -577,6 +638,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
         for key in _topbot_source_stream_keys(
@@ -602,6 +664,11 @@ class BacktestEngine:
                         self.position.take_profit,
                     )
                 )
+        if source_strategy == "delayed_orb_confirmation":
+            # A one-minute stream must advance through every primary event.
+            # Including the event prevents a stale final minute from being
+            # cached and reused across the rest of a session or a later day.
+            signature.append(("primary_event", _as_utc(event_timestamp)))
         return tuple(signature)
 
     def _evaluate_topbot_source(
@@ -610,6 +677,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> dict[str, Any]:
         fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
             source_strategy,
@@ -706,67 +774,93 @@ class BacktestEngine:
                 base_order_size=float(self.config.order_size),
             )
         elif source_strategy == "delayed_orb_confirmation":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                _topbot_asset_stream_key("minute", 1),
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:delayed_orb_confirmation",
-                enforce=True,
-                expected_interval_seconds=60,
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                candles=source_candles,
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    _topbot_asset_stream_key("minute", 1),
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                    enforce=True,
+                    expected_interval_seconds=60,
+                )
+                _require_stream_current_through_event(
+                    source_candles,
+                    event_time=event_time,
+                    interval_seconds=60,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    candles=source_candles,
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                )
         elif source_strategy == "orb_fibonacci_pullback":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                primary_key,
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:orb_fibonacci_pullback",
-                enforce=True,
-                expected_interval_seconds=_timeframe_seconds(
-                    str(self.config.timeframe_unit),
-                    int(self.config.timeframe_unit_number),
-                ),
-            )
-            _require_complete_orb_opening_range(
-                source_candles,
-                config=source_config,
-                session_start=session_start,
-                latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                source_candles,
-                timeframe_unit=str(self.config.timeframe_unit),
-                timeframe_unit_number=int(self.config.timeframe_unit_number),
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-                session_end_time=str(self.config.trading_end_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    primary_key,
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:orb_fibonacci_pullback",
+                    enforce=True,
+                    expected_interval_seconds=_timeframe_seconds(
+                        str(self.config.timeframe_unit),
+                        int(self.config.timeframe_unit_number),
+                    ),
+                )
+                _require_complete_orb_opening_range(
+                    source_candles,
+                    config=source_config,
+                    session_start=session_start,
+                    latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    source_candles,
+                    timeframe_unit=str(self.config.timeframe_unit),
+                    timeframe_unit_number=int(self.config.timeframe_unit_number),
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                    session_end_time=str(self.config.trading_end_time),
+                )
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
@@ -1293,11 +1387,30 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            gaps = 0
-            for previous, current in zip(self.execution_candles, self.execution_candles[1:]):
-                delta = (_as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)).total_seconds()
-                if delta > expected_seconds * 1.5:
-                    gaps += 1
+            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
+            actual_end = _candle_close_time(self.execution_candles[-1])
+            if _has_open_futures_interval(
+                self.settings.start,
+                actual_start,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles began after the requested start; replay coverage begins at "
+                    f"{actual_start.isoformat()}."
+                )
+            if _has_open_futures_interval(
+                actual_end,
+                self.settings.end,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles ended before the requested end; replay coverage ends at "
+                    f"{actual_end.isoformat()}. The configured futures delivery may have expired or rolled."
+                )
+            gaps = _count_futures_session_gaps(
+                self.execution_candles,
+                interval_seconds=expected_seconds,
+            )
             if gaps:
                 self.warnings.append(
                     f"Detected {gaps} candle gap(s); the engine used the next available bar without interpolation."
@@ -1334,14 +1447,9 @@ class BacktestEngine:
                     if _as_utc(row.candle_timestamp) >= self.settings.start
                     and _candle_close_time(row) <= self.settings.end
                 ]
-                gaps = sum(
-                    1
-                    for previous, current in zip(execution_rows, execution_rows[1:])
-                    if (
-                        _as_utc(current.candle_timestamp)
-                        - _as_utc(previous.candle_timestamp)
-                    ).total_seconds()
-                    > expected * 1.5
+                gaps = _count_futures_session_gaps(
+                    execution_rows,
+                    interval_seconds=expected,
                 )
                 if gaps:
                     self.warnings.append(
@@ -1436,6 +1544,23 @@ def _relative_strength_spy_history_limit(
             50,
         ),
     )
+
+
+def _matching_benchmark_contract(
+    config: BotConfig,
+    source_params: Mapping[str, Any],
+) -> tuple[str | None, str]:
+    explicit_contract = source_params.get("benchmark_contract_id")
+    benchmark_symbol = str(source_params.get("benchmark_symbol") or "MES").strip().upper()
+    benchmark_root = benchmark_symbol.rsplit(".", 1)[-1]
+    canonical_symbol = f"F.US.{benchmark_root}"
+    if explicit_contract:
+        return str(explicit_contract), canonical_symbol
+
+    parts = str(config.contract_id).strip().split(".")
+    if len(parts) == 5 and parts[:3] == ["CON", "F", "US"]:
+        return ".".join([*parts[:3], benchmark_root, parts[4]]), canonical_symbol
+    return None, canonical_symbol
 
 
 def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec]:
@@ -1539,30 +1664,34 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
                 min(5000, max(fvg_limit * ratio, fvg_limit + 25)),
             )
         elif source_strategy == "atr_adjusted_relative_strength":
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit=primary_unit,
                 unit_number=primary_unit_number,
                 warmup_bars=max(25, int(config.lookback_bars)),
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
         elif source_strategy == "relative_strength_spy":
             limit = _relative_strength_spy_history_limit(config, source_params)
             add_asset("minute", 5, limit)
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit="minute",
                 unit_number=5,
                 warmup_bars=limit,
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
@@ -1617,7 +1746,7 @@ def _prepare_topbot_replay_streams(
     *,
     primary_candles: list[ProjectXMarketCandle],
     replay_streams: Mapping[str, list[ProjectXMarketCandle]] | None,
-) -> tuple[dict[str, _PreparedReplayStream], int, list[str]]:
+) -> tuple[dict[str, _PreparedReplayStream], int]:
     provided = dict(replay_streams or {})
     primary_key = _topbot_asset_stream_key(
         str(config.timeframe_unit),
@@ -1626,7 +1755,6 @@ def _prepare_topbot_replay_streams(
     provided[primary_key] = primary_candles
     prepared: dict[str, _PreparedReplayStream] = {}
     excluded_partial = 0
-    missing: list[str] = []
 
     for key, spec in _topbot_stream_specs(config).items():
         rows, excluded = _validate_topbot_replay_stream(
@@ -1635,14 +1763,12 @@ def _prepare_topbot_replay_streams(
             config=config,
         )
         excluded_partial += excluded
-        if not rows:
-            missing.append(key)
         prepared[key] = _PreparedReplayStream(
             candles=rows,
             start_times=[_as_utc(row.candle_timestamp) for row in rows],
             close_times=[_candle_close_time(row) for row in rows],
         )
-    return prepared, excluded_partial, missing
+    return prepared, excluded_partial
 
 
 def _validate_topbot_replay_stream(
@@ -1651,7 +1777,7 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -1723,6 +1849,71 @@ def _validate_topbot_replay_stream(
             f"ambiguous_benchmark_replay_stream:{spec.key}: configure benchmark_contract_id"
         )
     return closed, excluded_partial
+
+
+def _topbot_unavailable_sources(
+    config: BotConfig,
+    *,
+    streams: Mapping[str, _PreparedReplayStream],
+    first_event: datetime,
+    last_event: datetime,
+) -> dict[str, tuple[str, ...]]:
+    params = bot_service_module._normalize_strategy_params(
+        _TOPBOT_STRATEGY,
+        config.strategy_params,
+    )
+    overrides = params.get("source_strategy_params") or {}
+    specs = _topbot_stream_specs(config)
+    unavailable: dict[str, tuple[str, ...]] = {}
+    for source_strategy in params["source_strategies"]:
+        source_params = bot_service_module._normalize_strategy_params(
+            source_strategy,
+            overrides.get(source_strategy, {}),
+        )
+        missing = tuple(
+            key
+            for key in _topbot_source_stream_keys(
+                config,
+                source_strategy,
+                source_params=source_params,
+            )
+            if not _prepared_stream_covers_replay_window(
+                streams.get(key),
+                spec=specs.get(key),
+                first_event=first_event,
+                last_event=last_event,
+            )
+        )
+        if missing:
+            unavailable[source_strategy] = missing
+    return unavailable
+
+
+def _prepared_stream_covers_replay_window(
+    stream: _PreparedReplayStream | None,
+    *,
+    spec: _TopBotReplayStreamSpec | None,
+    first_event: datetime,
+    last_event: datetime,
+) -> bool:
+    if stream is None or not stream.candles or spec is None:
+        return False
+    interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+    if interval_seconds is None or interval_seconds <= 0:
+        return False
+    for event_time in (first_event, last_event):
+        event_utc = _as_utc(event_time)
+        closed_count = bisect_right(stream.close_times, event_utc)
+        if closed_count <= 0:
+            return False
+        latest_close = stream.close_times[closed_count - 1]
+        if _has_open_futures_interval(
+            latest_close,
+            event_utc,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: int) -> int:
@@ -1848,7 +2039,10 @@ def _load_topbot_replay_streams(
         warmup_rows = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars)))
+            # One candle can start before the requested range while closing
+            # after the first replay event. Overfetch it so the requested
+            # number of genuinely closed warmup bars remains available.
+            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
             .all()
         )
         warmup_rows.reverse()
@@ -1862,6 +2056,225 @@ def _load_topbot_replay_streams(
             )
 
     return streams
+
+
+def prepare_bot_backtest_data(
+    db: Session,
+    *,
+    user_id: str,
+    bot_config_id: int,
+    payload: Any,
+    client: ProjectXClient,
+) -> int:
+    """Populate TopBot's deterministic replay cache without running a replay."""
+
+    config = (
+        db.query(BotConfig)
+        .filter(BotConfig.user_id == user_id)
+        .filter(BotConfig.id == bot_config_id)
+        .one_or_none()
+    )
+    if config is None:
+        raise LookupError("bot_config_not_found")
+    if str(config.strategy_type) != _TOPBOT_STRATEGY:
+        return 0
+    _validate_replay_configuration(config)
+
+    start = _as_utc(payload.start)
+    end = _as_utc(payload.end)
+    if end <= start:
+        raise BacktestConfigurationError("backtest end must be after start")
+    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
+        raise BacktestConfigurationError(
+            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
+        )
+
+    fetch_end = min(end, datetime.now(timezone.utc))
+    requests: dict[tuple[str, str, int], tuple[str | None, datetime, int]] = {}
+    for spec in _topbot_stream_specs(config).values():
+        interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+        if interval_seconds is None or interval_seconds <= 0:
+            raise BacktestConfigurationError(
+                f"unsupported_topbot_replay_timeframe:{spec.unit}:{spec.unit_number}"
+            )
+        contract_id = spec.contract_id or spec.symbol
+        if not contract_id:
+            raise BacktestConfigurationError(f"topbot_replay_contract_missing:{spec.key}")
+        fetch_start = start - timedelta(
+            seconds=interval_seconds * max(25, int(spec.warmup_bars)) * 3
+        )
+        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
+        existing = requests.get(identity)
+        if existing is None or fetch_start < existing[1]:
+            requests[identity] = (spec.symbol, fetch_start, int(spec.warmup_bars))
+        elif int(spec.warmup_bars) > existing[2]:
+            requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
+
+    primary_identity = (
+        str(config.contract_id),
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
+    primary_execution_rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    primary_execution_rows = [
+        row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+    ]
+    first_event = (
+        _candle_close_time(primary_execution_rows[0])
+        if primary_execution_rows
+        else start
+    )
+    last_event = (
+        _candle_close_time(primary_execution_rows[-1])
+        if primary_execution_rows
+        else fetch_end
+    )
+
+    prepared_count = 0
+    for (contract_id, unit, unit_number), (symbol, fetch_start, warmup_bars) in requests.items():
+        interval_seconds = _timeframe_seconds(unit, unit_number)
+        assert interval_seconds is not None
+        identity = (contract_id, unit, unit_number)
+        primary_cache_is_clean = not any(
+            _cached_candle_was_fetched_before_nominal_close(row)
+            for row in primary_execution_rows
+        ) and not _candle_stream_has_overlaps(primary_execution_rows)
+        if (
+            identity == primary_identity
+            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
+            and primary_cache_is_clean
+        ):
+            continue
+        if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
+            db,
+            user_id=user_id,
+            contract_id=contract_id,
+            unit=unit,
+            unit_number=unit_number,
+            fetch_start=fetch_start,
+            requested_start=start,
+            first_event=first_event,
+            last_event=last_event,
+            warmup_bars=warmup_bars,
+        ):
+            continue
+        cursor = fetch_start
+        chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
+        while cursor < fetch_end:
+            chunk_end = min(fetch_end, cursor + chunk_span)
+            bot_service_module.fetch_and_store_market_candles(
+                db,
+                user_id=user_id,
+                client=client,
+                contract_id=contract_id,
+                symbol=symbol,
+                live=False,
+                start=cursor,
+                end=chunk_end,
+                unit=unit,
+                unit_number=unit_number,
+                limit=MAX_PROVIDER_FETCH_BARS,
+                include_partial_bar=False,
+                prefer_current_contract=False,
+                preserve_cached_history=True,
+                authoritative_refresh=True,
+            )
+            if chunk_end >= fetch_end:
+                break
+            cursor = chunk_end
+        prepared_count += 1
+
+        if identity == primary_identity:
+            primary_execution_rows = (
+                db.query(ProjectXMarketCandle)
+                .filter(ProjectXMarketCandle.user_id == user_id)
+                .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+                .filter(ProjectXMarketCandle.live.is_(False))
+                .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+                .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+                .filter(ProjectXMarketCandle.is_partial.is_(False))
+                .filter(ProjectXMarketCandle.candle_timestamp >= start)
+                .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+                .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+                .all()
+            )
+            primary_execution_rows = [
+                row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+            ]
+            if primary_execution_rows:
+                first_event = _candle_close_time(primary_execution_rows[0])
+                last_event = _candle_close_time(primary_execution_rows[-1])
+
+    return prepared_count
+
+
+def _cached_replay_stream_covers(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    unit: str,
+    unit_number: int,
+    fetch_start: datetime,
+    requested_start: datetime,
+    first_event: datetime,
+    last_event: datetime,
+    warmup_bars: int,
+) -> bool:
+    interval_seconds = _timeframe_seconds(unit, unit_number)
+    if interval_seconds is None:
+        return False
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == contract_id)
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
+        return False
+    if _candle_stream_has_overlaps(rows):
+        return False
+    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
+    warmup_count = sum(
+        _as_utc(row.candle_timestamp) < requested_start
+        for row in closed_by_first
+    )
+    if warmup_count < max(1, int(warmup_bars)):
+        return False
+
+    for event, candidates in (
+        (first_event, closed_by_first),
+        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+    ):
+        if not candidates:
+            return False
+        latest_close = _candle_close_time(candidates[-1])
+        if _has_open_futures_interval(
+            latest_close,
+            event,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def run_backtest(
@@ -2032,8 +2445,8 @@ def create_bot_backtest(
         timeframe_unit_number=int(config.timeframe_unit_number),
         requested_start=start,
         requested_end=end,
-        actual_start=_as_utc(execution_rows[0].candle_timestamp) if execution_rows else start,
-        actual_end=_candle_close_time(execution_rows[-1]) if execution_rows else end,
+        actual_start=_as_utc(datetime.fromisoformat(str(result["range"]["start"]))),
+        actual_end=_as_utc(datetime.fromisoformat(str(result["range"]["end"]))),
         starting_balance=float(payload.starting_balance),
         commission_per_contract=float(payload.commission_per_contract),
         slippage_ticks=float(payload.slippage_ticks),
@@ -2197,7 +2610,7 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -2254,6 +2667,36 @@ def _validate_and_sort_candles(
         if values["volume"] < 0:
             raise MalformedBacktestDataError(f"negative_candle_volume:{timestamp.isoformat()}")
     return closed, excluded_partial
+
+
+def _cached_candle_is_effectively_partial(candle: ProjectXMarketCandle) -> bool:
+    return bool(candle.is_partial) or _cached_candle_was_fetched_before_nominal_close(candle)
+
+
+def _cached_candle_was_fetched_before_nominal_close(
+    candle: ProjectXMarketCandle,
+) -> bool:
+    if str(candle.unit) not in {"second", "minute", "hour"}:
+        return False
+    fetched_at = candle.fetched_at
+    if fetched_at is None:
+        return False
+    raw_payload = candle.raw_payload
+    if isinstance(raw_payload, dict) and any(
+        key in raw_payload for key in ("isPartial", "is_partial", "partial")
+    ):
+        return False
+    return _as_utc(fetched_at) < _candle_close_time(candle)
+
+
+def _candle_stream_has_overlaps(candles: list[ProjectXMarketCandle]) -> bool:
+    previous_close_time: datetime | None = None
+    for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp)):
+        timestamp = _as_utc(row.candle_timestamp)
+        if previous_close_time is not None and timestamp < previous_close_time:
+            return True
+        previous_close_time = _candle_close_time(row)
+    return False
 
 
 def _candle_close_time(candle: ProjectXMarketCandle) -> datetime:
@@ -2625,7 +3068,9 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
             "oversized_entries_are_blocked_not_capped"
         ),
         "session_rule": (
-            "entries_obey_bot_session_after-loss_cooldown_daily-trade_and_daily-loss_limits; "
+            "TopBot signals are evaluated only during the configured session while resting "
+            "brackets are processed on every execution candle; entries obey bot session "
+            "after-loss cooldown, daily-trade, and daily-loss limits; "
             "counters_reset_at_requested_start_and_loss_uses_isolated_simulated_realized_net_pnl"
         ),
         "commission_rule": "commission_per_contract_is_charged_per_side",
@@ -2647,6 +3092,61 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
 def _timeframe_seconds(unit: str, unit_number: int) -> int | None:
     seconds = _UNIT_SECONDS.get(unit)
     return seconds * unit_number if seconds is not None else None
+
+
+def _count_futures_session_gaps(
+    candles: list[ProjectXMarketCandle],
+    *,
+    interval_seconds: int,
+) -> int:
+    gaps = 0
+    for previous, current in zip(candles, candles[1:]):
+        previous_timestamp = _as_utc(previous.candle_timestamp)
+        current_timestamp = _as_utc(current.candle_timestamp)
+        elapsed = int((current_timestamp - previous_timestamp).total_seconds())
+        missing_slots = max(0, int(round(elapsed / interval_seconds)) - 1)
+        if missing_slots and _contains_open_futures_timestamp(
+            previous_timestamp + timedelta(seconds=interval_seconds),
+            current_timestamp,
+            step_seconds=interval_seconds,
+        ):
+            gaps += 1
+    return gaps
+
+
+def _has_open_futures_interval(
+    start: datetime,
+    end: datetime,
+    *,
+    interval_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc - cursor <= timedelta(seconds=interval_seconds * 1.5):
+        return False
+    return _contains_open_futures_timestamp(
+        cursor + timedelta(seconds=interval_seconds),
+        end_utc,
+        step_seconds=interval_seconds,
+    )
+
+
+def _contains_open_futures_timestamp(
+    start: datetime,
+    end: datetime,
+    *,
+    step_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    # Session boundaries are minute-aligned, so sub-minute streams need not
+    # scan every second across a weekend closure.
+    step = timedelta(seconds=max(60, int(step_seconds)))
+    while cursor < end_utc:
+        if futures_session_is_open(cursor):
+            return True
+        cursor += step
+    return False
 
 
 def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
@@ -2687,6 +3187,57 @@ def _first_index_at_or_after(
         else:
             high = middle
     return low
+
+
+def _topbot_outside_session_signal(
+    strategy_type: str,
+    *,
+    event_timestamp: datetime,
+) -> SignalResult:
+    return SignalResult(
+        action="HOLD",
+        reason="Outside the configured trading session.",
+        candle_timestamp=_as_utc(event_timestamp),
+        price=None,
+        raw_payload={
+            "strategy_type": strategy_type,
+            "outside_configured_session": True,
+        },
+    )
+
+
+def _event_timestamp_is_in_configured_session(
+    config: BotConfig,
+    event_timestamp: datetime,
+) -> bool:
+    timestamp = _as_utc(event_timestamp)
+    if not futures_session_is_open(timestamp):
+        return False
+    session_start, session_end = _session_window_utc_for_reference(
+        timestamp,
+        start_text=str(config.trading_start_time),
+        end_text=str(config.trading_end_time),
+    )
+    return session_start <= timestamp <= session_end
+
+
+def _require_stream_current_through_event(
+    candles: list[ProjectXMarketCandle],
+    *,
+    event_time: datetime,
+    interval_seconds: int,
+    strategy_type: str,
+) -> None:
+    if not candles:
+        return
+    expected_latest_start = _as_utc(event_time) - timedelta(seconds=interval_seconds)
+    actual_latest_start = _as_utc(candles[-1].candle_timestamp)
+    if actual_latest_start != expected_latest_start:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: incomplete_session_history: "
+            f"{strategy_type} is missing the closed candle at "
+            f"{expected_latest_start.isoformat()}"
+        )
 
 
 def _require_complete_session_prefix(

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -45,9 +45,8 @@ from .trading_day import (
 )
 
 
-BACKTEST_ENGINE_VERSION = "1.2.0"
+BACKTEST_ENGINE_VERSION = "1.3.0"
 MAX_BACKTEST_BARS = 20_000
-MAX_BACKTEST_RANGE_DAYS = 366
 MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
 MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
 MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
@@ -140,6 +139,17 @@ class BacktestSettings:
     tick_size: float
     tick_value: float
     force_close_at_end: bool = True
+
+
+@dataclass(frozen=True)
+class _ResolvedBacktestWindow:
+    """One captured request window used by preparation, replay, and persistence."""
+
+    requested_start: datetime
+    requested_end: datetime
+    start: datetime
+    end: datetime
+    full_history: bool
 
 
 @dataclass(frozen=True)
@@ -268,11 +278,6 @@ class BacktestEngine:
                 first_event=_candle_close_time(coverage_candles[0]),
                 last_event=_candle_close_time(coverage_candles[-1]),
             )
-        if len(self.execution_candles) > MAX_BACKTEST_BARS:
-            raise BacktestConfigurationError(
-                f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}; "
-                f"found {len(self.execution_candles)}"
-            )
         self.evaluator_history_limit = min(
             MAX_BACKTEST_BARS,
             max(
@@ -304,7 +309,8 @@ class BacktestEngine:
             operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
         if estimated_operations > operation_limit:
             raise BacktestConfigurationError(
-                "backtest_computation_limit_exceeded: reduce the date range or bot lookback; "
+                "backtest_computation_limit_exceeded: the complete resolved history and bot "
+                "lookback exceed the current replay resource budget; no partial result was saved; "
                 f"estimated evaluator bar-visits {estimated_operations:,} exceed "
                 f"{operation_limit:,}"
             )
@@ -451,6 +457,10 @@ class BacktestEngine:
                 "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
                 "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
+                "contract_id": str(self.execution_candles[0].contract_id),
+                "symbol": self.execution_candles[0].symbol or self.config.symbol,
+                "timeframe_unit": str(self.execution_candles[0].unit),
+                "timeframe_unit_number": int(self.execution_candles[0].unit_number),
             },
             "config_snapshot": _config_snapshot(self.config),
             "assumptions": _assumptions_snapshot(self.config, self.settings),
@@ -2065,6 +2075,8 @@ def prepare_bot_backtest_data(
     bot_config_id: int,
     payload: Any,
     client: ProjectXClient,
+    now: datetime | None = None,
+    include_primary: bool = True,
 ) -> int:
     """Populate TopBot's deterministic replay cache without running a replay."""
 
@@ -2084,12 +2096,14 @@ def prepare_bot_backtest_data(
     end = _as_utc(payload.end)
     if end <= start:
         raise BacktestConfigurationError("backtest end must be after start")
-    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
 
-    fetch_end = min(end, datetime.now(timezone.utc))
+    captured_now = _as_utc(now or datetime.now(timezone.utc))
+    fetch_end = min(end, captured_now)
+    primary_identity = (
+        str(config.contract_id),
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
     requests: dict[tuple[str, str, int], tuple[str | None, datetime, int]] = {}
     for spec in _topbot_stream_specs(config).values():
         interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
@@ -2100,21 +2114,18 @@ def prepare_bot_backtest_data(
         contract_id = spec.contract_id or spec.symbol
         if not contract_id:
             raise BacktestConfigurationError(f"topbot_replay_contract_missing:{spec.key}")
+        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
+        if identity == primary_identity and not include_primary:
+            continue
         fetch_start = start - timedelta(
             seconds=interval_seconds * max(25, int(spec.warmup_bars)) * 3
         )
-        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
         existing = requests.get(identity)
         if existing is None or fetch_start < existing[1]:
             requests[identity] = (spec.symbol, fetch_start, int(spec.warmup_bars))
         elif int(spec.warmup_bars) > existing[2]:
             requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
 
-    primary_identity = (
-        str(config.contract_id),
-        str(config.timeframe_unit),
-        int(config.timeframe_unit_number),
-    )
     primary_execution_rows = (
         db.query(ProjectXMarketCandle)
         .filter(ProjectXMarketCandle.user_id == user_id)
@@ -2151,10 +2162,23 @@ def prepare_bot_backtest_data(
             _cached_candle_was_fetched_before_nominal_close(row)
             for row in primary_execution_rows
         ) and not _candle_stream_has_overlaps(primary_execution_rows)
+        primary_cache_covers_window = (
+            len(primary_execution_rows) >= MIN_EXECUTION_BARS
+            and primary_cache_is_clean
+            and not _has_open_futures_interval(
+                start,
+                _as_utc(primary_execution_rows[0].candle_timestamp),
+                interval_seconds=interval_seconds,
+            )
+            and not _has_open_futures_interval(
+                _candle_close_time(primary_execution_rows[-1]),
+                fetch_end,
+                interval_seconds=interval_seconds,
+            )
+        )
         if (
             identity == primary_identity
-            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
-            and primary_cache_is_clean
+            and primary_cache_covers_window
         ):
             continue
         if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
@@ -2312,12 +2336,261 @@ def run_backtest(
     ).run()
 
 
+def _load_primary_closed_candles(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    closed_by: datetime,
+) -> list[ProjectXMarketCandle]:
+    """Load every eligible primary bar without rolling across futures deliveries."""
+
+    cutoff = _as_utc(closed_by)
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    return [
+        row
+        for row in rows
+        if not _cached_candle_is_effectively_partial(row)
+        and _candle_close_time(row) <= cutoff
+    ]
+
+
+def _requested_backtest_bounds(payload: Any) -> tuple[datetime, datetime] | None:
+    raw_start = getattr(payload, "start", None)
+    raw_end = getattr(payload, "end", None)
+    if (raw_start is None) != (raw_end is None):
+        raise BacktestConfigurationError(
+            "backtest start and end must be provided together"
+        )
+    if raw_start is None:
+        return None
+    start = _as_utc(raw_start)
+    end = _as_utc(raw_end)
+    if end <= start:
+        raise BacktestConfigurationError("backtest end must be after start")
+    return start, end
+
+
+def _resolve_backtest_window(
+    rows: list[ProjectXMarketCandle],
+    *,
+    payload: Any,
+    now: datetime,
+) -> _ResolvedBacktestWindow:
+    """Resolve absent dates to complete exact-contract coverage at one instant."""
+
+    captured_now = _as_utc(now)
+    requested = _requested_backtest_bounds(payload)
+    if requested is None:
+        eligible = rows
+        full_history = True
+    else:
+        requested_start, requested_end = requested
+        effective_end = min(requested_end, captured_now)
+        eligible = [
+            row
+            for row in rows
+            if _as_utc(row.candle_timestamp) >= requested_start
+            and _candle_close_time(row) <= effective_end
+        ]
+        full_history = False
+
+    if len(eligible) < MIN_EXECUTION_BARS:
+        mode = "full configured-contract history" if requested is None else "requested range"
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: at least 2 fully closed execution bars are required "
+            f"for the {mode}; found {len(eligible)}"
+        )
+
+    if requested is None:
+        start = _as_utc(eligible[0].candle_timestamp)
+        end = _candle_close_time(eligible[-1])
+        requested_start = start
+        requested_end = end
+    else:
+        requested_start, requested_end = requested
+        start = requested_start
+        end = min(requested_end, captured_now)
+
+    return _ResolvedBacktestWindow(
+        requested_start=requested_start,
+        requested_end=requested_end,
+        start=start,
+        end=end,
+        full_history=full_history,
+    )
+
+
+_FULL_HISTORY_DISCOVERY_START = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_MAX_PROVIDER_EMPTY_SPAN = timedelta(days=14)
+
+
+def _fetch_exact_primary_chunk(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: ProjectXClient,
+    start: datetime,
+    end: datetime,
+) -> list[ProjectXMarketCandle]:
+    """Fetch one exact-delivery chunk and propagate provider failures."""
+
+    if end <= start:
+        return []
+    unit = str(config.timeframe_unit)
+    provider_unit = bot_service_module._PROJECTX_UNIT_BY_NAME.get(unit)
+    if provider_unit is None:
+        raise BacktestConfigurationError(f"unsupported_candle_unit:{unit}")
+    bars = client.retrieve_bars(
+        contract_id=str(config.contract_id),
+        live=False,
+        start=_as_utc(start),
+        end=_as_utc(end),
+        unit=provider_unit,
+        unit_number=int(config.timeframe_unit_number),
+        limit=MAX_PROVIDER_FETCH_BARS,
+        include_partial_bar=False,
+    )
+    return bot_service_module.store_market_candles(
+        db,
+        user_id=user_id,
+        contract_id=str(config.contract_id),
+        symbol=config.symbol,
+        live=False,
+        unit=unit,
+        unit_number=int(config.timeframe_unit_number),
+        bars=bars,
+    )
+
+
+def _prepare_topbot_primary_full_history(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: ProjectXClient,
+    now: datetime,
+) -> None:
+    """Discover and persist the provider's complete configured-delivery history."""
+
+    captured_now = _as_utc(now)
+    interval_seconds = _timeframe_seconds(
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
+    if interval_seconds is None or interval_seconds <= 0:
+        raise BacktestConfigurationError(
+            "unsupported_topbot_replay_timeframe:"
+            f"{config.timeframe_unit}:{config.timeframe_unit_number}"
+        )
+    chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
+
+    seed = _fetch_exact_primary_chunk(
+        db,
+        user_id=user_id,
+        config=config,
+        client=client,
+        start=_FULL_HISTORY_DISCOVERY_START,
+        end=captured_now,
+    )
+    if not seed:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: provider returned no closed history for configured "
+            f"contract {config.contract_id}"
+        )
+
+    rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
+    )
+    if not rows:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: provider returned no valid closed history for "
+            f"configured contract {config.contract_id}"
+        )
+
+    earliest = _as_utc(rows[0].candle_timestamp)
+    backward_cursor = earliest
+    empty_span = timedelta(0)
+    while backward_cursor > _FULL_HISTORY_DISCOVERY_START:
+        chunk_start = max(_FULL_HISTORY_DISCOVERY_START, backward_cursor - chunk_span)
+        fetched = _fetch_exact_primary_chunk(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=chunk_start,
+            end=backward_cursor,
+        )
+        older = [
+            row for row in fetched if _as_utc(row.candle_timestamp) < earliest
+        ]
+        if older:
+            earliest = min(_as_utc(row.candle_timestamp) for row in older)
+            backward_cursor = earliest
+            empty_span = timedelta(0)
+            continue
+        empty_span += backward_cursor - chunk_start
+        backward_cursor = chunk_start
+        if empty_span >= _MAX_PROVIDER_EMPTY_SPAN:
+            break
+
+    rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
+    )
+    latest_timestamp = _as_utc(rows[-1].candle_timestamp)
+    forward_cursor = _candle_close_time(rows[-1])
+    empty_span = timedelta(0)
+    while forward_cursor < captured_now:
+        chunk_end = min(captured_now, forward_cursor + chunk_span)
+        fetched = _fetch_exact_primary_chunk(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=forward_cursor,
+            end=chunk_end,
+        )
+        newer = [
+            row for row in fetched if _as_utc(row.candle_timestamp) > latest_timestamp
+        ]
+        if newer:
+            latest_row = max(newer, key=lambda row: _as_utc(row.candle_timestamp))
+            latest_timestamp = _as_utc(latest_row.candle_timestamp)
+            forward_cursor = _candle_close_time(latest_row)
+            empty_span = timedelta(0)
+            continue
+        empty_span += chunk_end - forward_cursor
+        forward_cursor = chunk_end
+        if empty_span >= _MAX_PROVIDER_EMPTY_SPAN:
+            break
+
+
 def create_bot_backtest(
     db: Session,
     *,
     user_id: str,
     bot_config_id: int,
     payload: Any,
+    client: ProjectXClient | None = None,
+    now: datetime | None = None,
 ) -> BotBacktest:
     config = (
         db.query(BotConfig)
@@ -2328,15 +2601,7 @@ def create_bot_backtest(
     if config is None:
         raise LookupError("bot_config_not_found")
     _require_supported_strategy(str(config.strategy_type))
-
-    start = _as_utc(payload.start)
-    end = _as_utc(payload.end)
-    if end <= start:
-        raise BacktestConfigurationError("backtest end must be after start")
-    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
+    _validate_replay_configuration(config)
 
     specs = load_instrument_specs(db)
     symbol_key = normalize_symbol_key(config.symbol) or normalize_symbol_key(config.contract_id)
@@ -2346,25 +2611,62 @@ def create_bot_backtest(
             f"instrument_metadata_missing:{symbol_key or config.contract_id}"
         )
 
-    execution_query = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .limit(MAX_BACKTEST_BARS + 1)
+    captured_now = _as_utc(now or datetime.now(timezone.utc))
+    requested_bounds = _requested_backtest_bounds(payload)
+    is_topbot = str(config.strategy_type) == _TOPBOT_STRATEGY
+    if is_topbot:
+        if client is None:
+            raise BacktestConfigurationError("topbot_backtest_market_data_client_required")
+        if requested_bounds is None:
+            _prepare_topbot_primary_full_history(
+                db,
+                user_id=user_id,
+                config=config,
+                client=client,
+                now=captured_now,
+            )
+        else:
+            prepare_bot_backtest_data(
+                db,
+                user_id=user_id,
+                bot_config_id=bot_config_id,
+                payload=payload,
+                client=client,
+                now=captured_now,
+            )
+
+    primary_rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
     )
-    execution_rows = execution_query.all()
-    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-    if len(execution_rows) > MAX_BACKTEST_BARS:
-        raise BacktestConfigurationError(
-            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
+    window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
+
+    if is_topbot and requested_bounds is None:
+        prepare_bot_backtest_data(
+            db,
+            user_id=user_id,
+            bot_config_id=bot_config_id,
+            payload=window,
+            client=client,
+            now=captured_now,
+            include_primary=False,
         )
+        primary_rows = _load_primary_closed_candles(
+            db,
+            user_id=user_id,
+            config=config,
+            closed_by=captured_now,
+        )
+        window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
+
+    execution_rows = [
+        row
+        for row in primary_rows
+        if _as_utc(row.candle_timestamp) >= window.start
+        and _candle_close_time(row) <= window.end
+    ]
 
     rolling_warmup_limit = min(
         MAX_BACKTEST_BARS,
@@ -2373,7 +2675,7 @@ def create_bot_backtest(
             _strategy_history_bars(config, hard_minimum=False),
         ),
     )
-    if str(config.strategy_type) == _TOPBOT_STRATEGY:
+    if is_topbot:
         primary_key = _topbot_asset_stream_key(
             str(config.timeframe_unit),
             int(config.timeframe_unit_number),
@@ -2387,37 +2689,29 @@ def create_bot_backtest(
         config,
         rolling_limit=rolling_warmup_limit,
     )
-    warmup_rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp < start)
-        .order_by(ProjectXMarketCandle.candle_timestamp.desc())
-        .limit(warmup_limit)
-        .all()
-    )
-    warmup_rows.reverse()
+    warmup_candidates = [
+        row
+        for row in primary_rows
+        if _as_utc(row.candle_timestamp) < window.start
+    ]
+    warmup_rows = warmup_candidates[-warmup_limit:]
     replay_rows = [*warmup_rows, *execution_rows]
     replay_streams: dict[str, list[ProjectXMarketCandle]] | None = None
-    if str(config.strategy_type) == _TOPBOT_STRATEGY:
+    if is_topbot:
         replay_streams = _load_topbot_replay_streams(
             db,
             user_id=user_id,
             config=config,
-            start=start,
-            end=end,
+            start=window.start,
+            end=window.end,
             primary_rows=replay_rows,
         )
 
     result = run_backtest(
         config=config,
         candles=replay_rows,
-        start=start,
-        end=end,
+        start=window.start,
+        end=window.end,
         starting_balance=float(payload.starting_balance),
         commission_per_contract=float(payload.commission_per_contract),
         slippage_ticks=float(payload.slippage_ticks),
@@ -2443,8 +2737,8 @@ def create_bot_backtest(
         symbol=config.symbol,
         timeframe_unit=str(config.timeframe_unit),
         timeframe_unit_number=int(config.timeframe_unit_number),
-        requested_start=start,
-        requested_end=end,
+        requested_start=window.requested_start,
+        requested_end=window.requested_end,
         actual_start=_as_utc(datetime.fromisoformat(str(result["range"]["start"]))),
         actual_end=_as_utc(datetime.fromisoformat(str(result["range"]["end"]))),
         starting_balance=float(payload.starting_balance),
@@ -2590,10 +2884,6 @@ def _validate_settings(settings: BacktestSettings) -> BacktestSettings:
     )
     if normalized.end <= normalized.start:
         raise BacktestConfigurationError("backtest end must be after start")
-    if normalized.end - normalized.start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
     for name in ["starting_balance", "tick_size", "tick_value"]:
         value = getattr(normalized, name)
         if not math.isfinite(value) or value <= 0:
@@ -3077,7 +3367,10 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
         "slippage_rule": "configured_ticks_are_applied_adversely_to_every_entry_and_exit_fill",
         "pnl_rule": "price_delta_divided_by_tick_size_times_tick_value_times_quantity",
         "metric_basis": "profit_factor_expectancy_average_win_and_average_loss_use_net_trade_pnl",
-        "market_data": "stored_user_scoped_non_live_closed_candles_only; no_provider_fetch",
+        "market_data": (
+            "preparation_may_fetch_exact_configured_contract; replay_uses_persisted_"
+            "user_scoped_non_live_closed_candles_only"
+        ),
         "live_order_routing": "disabled_by_architecture",
         "timezone": str(getattr(TRADING_TZ, "key", "America/New_York")),
         "commission_per_contract": _clean(settings.commission_per_contract),

--- a/backend/app/services/bot_candle_acquisition.py
+++ b/backend/app/services/bot_candle_acquisition.py
@@ -219,7 +219,7 @@ def acquire_and_evaluate_strategy(
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             asset_candles=asset_candles,
-            benchmark_candles=candle_sets.get("SPY", []),
+            benchmark_candles=candle_sets.get("benchmark", []),
             strategy_params=strategy_params,
         )
         return asset_candles, signal

--- a/backend/app/services/bot_market_analysis.py
+++ b/backend/app/services/bot_market_analysis.py
@@ -5,6 +5,8 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Iterable, Sequence
 from zoneinfo import ZoneInfo
 
+from .trading_day import futures_session_is_open
+
 
 ANALYSIS_VERSION = "market_analysis_v2"
 PROBABILITY_METHOD = "heuristic_scenario_weight"
@@ -523,7 +525,7 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
         missing = sum(
             1
             for index in range(1, raw_missing + 1)
-            if _is_futures_session_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
+            if futures_session_is_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
         )
         if missing <= 0:
             continue
@@ -535,21 +537,6 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
             }
         )
     return gaps[:20]
-
-
-def _is_futures_session_open(timestamp: datetime) -> bool:
-    local = timestamp.astimezone(_NEW_YORK)
-    weekday = local.weekday()
-    local_time = local.time()
-    if weekday == 5:
-        return False
-    if weekday == 6 and local_time < time(18, 0):
-        return False
-    if weekday == 4 and local_time >= time(17, 0):
-        return False
-    if time(17, 0) <= local_time < time(18, 0):
-        return False
-    return True
 
 
 def _true_ranges(rows: list[dict[str, Any]]) -> list[float]:

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -72,6 +72,7 @@ _UNIT_SECONDS_BY_NAME = {
 }
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
+_MARKET_CANDLE_UPSERT_BATCH_SIZE = 1_000
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -301,7 +302,7 @@ _FVG_SWEEP_MSS_DEFAULTS = {
     "target_mode": _FVG_TARGET_MODE_NEXT_LIQUIDITY,
 }
 _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "move_lookback_bars": 3,
     "atr_period": 14,
     "relative_volume_period": 20,
@@ -314,7 +315,7 @@ _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
     "take_profit_r_multiple": 2.0,
 }
 _RELATIVE_STRENGTH_SPY_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "comparison_bars": 12,
     "pullback_lookback_bars": 3,
     "relative_volume_period": 20,
@@ -1476,7 +1477,7 @@ def fetch_and_store_relative_strength_spy_candles(
             prefer_current_contract=True,
             preserve_cached_history=True,
         ),
-        "SPY": fetch_and_store_market_candles(
+        "benchmark": fetch_and_store_market_candles(
             db,
             user_id=user_id,
             client=client,
@@ -1731,6 +1732,7 @@ def fetch_and_store_market_candles(
     include_partial_bar: bool = False,
     prefer_current_contract: bool = False,
     preserve_cached_history: bool = False,
+    authoritative_refresh: bool = False,
 ) -> list[ProjectXMarketCandle]:
     normalized_unit = str(unit).strip().lower()
     if normalized_unit not in _PROJECTX_UNIT_BY_NAME:
@@ -1785,6 +1787,31 @@ def fetch_and_store_market_candles(
         unit_number=unit_number,
         bars=bars,
     )
+    if authoritative_refresh and stored:
+        provider_timestamps = [_as_utc(row.candle_timestamp) for row in stored]
+        provider_timestamp_set = set(provider_timestamps)
+        provider_start = min(provider_timestamps)
+        provider_end = max(provider_timestamps)
+        prune_market_candle_cache_range(
+            db,
+            user_id=user_id,
+            contract_id=resolved_contract_id,
+            live=live,
+            start=provider_start,
+            end=provider_end,
+            unit=normalized_unit,
+            unit_number=unit_number,
+            keep_timestamps=provider_timestamps,
+        )
+        cached = [
+            row
+            for row in cached
+            if (
+                _as_utc(row.candle_timestamp) < provider_start
+                or _as_utc(row.candle_timestamp) > provider_end
+                or _as_utc(row.candle_timestamp) in provider_timestamp_set
+            )
+        ]
     if not preserve_cached_history:
         return stored
 
@@ -2210,31 +2237,33 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
         return
 
     table = ProjectXMarketCandle.__table__
-    insert_stmt = postgresql_insert(table).values(values)
-    excluded = insert_stmt.excluded
-    db.execute(
-        insert_stmt.on_conflict_do_update(
-            index_elements=[
-                table.c.user_id,
-                table.c.contract_id,
-                table.c.live,
-                table.c.unit,
-                table.c.unit_number,
-                table.c.candle_timestamp,
-            ],
-            set_={
-                "symbol": excluded.symbol,
-                "open_price": excluded.open_price,
-                "high_price": excluded.high_price,
-                "low_price": excluded.low_price,
-                "close_price": excluded.close_price,
-                "volume": excluded.volume,
-                "is_partial": excluded.is_partial,
-                "raw_payload": excluded.raw_payload,
-                "fetched_at": excluded.fetched_at,
-            },
+    for offset in range(0, len(values), _MARKET_CANDLE_UPSERT_BATCH_SIZE):
+        batch = values[offset : offset + _MARKET_CANDLE_UPSERT_BATCH_SIZE]
+        insert_stmt = postgresql_insert(table).values(batch)
+        excluded = insert_stmt.excluded
+        db.execute(
+            insert_stmt.on_conflict_do_update(
+                index_elements=[
+                    table.c.user_id,
+                    table.c.contract_id,
+                    table.c.live,
+                    table.c.unit,
+                    table.c.unit_number,
+                    table.c.candle_timestamp,
+                ],
+                set_={
+                    "symbol": excluded.symbol,
+                    "open_price": excluded.open_price,
+                    "high_price": excluded.high_price,
+                    "low_price": excluded.low_price,
+                    "close_price": excluded.close_price,
+                    "volume": excluded.volume,
+                    "is_partial": excluded.is_partial,
+                    "raw_payload": excluded.raw_payload,
+                    "fetched_at": excluded.fetched_at,
+                },
+            )
         )
-    )
 
 
 def _query_market_candles_by_timestamps(
@@ -2628,6 +2657,7 @@ def evaluate_relative_strength_vs_spy(
     strategy_params: dict[str, Any] | None = None,
 ) -> SignalResult:
     params = _normalize_strategy_params(_STRATEGY_RELATIVE_STRENGTH_SPY, strategy_params)
+    benchmark_name = str(params["benchmark_symbol"])
     comparison_bars = int(params["comparison_bars"])
     pullback_lookback_bars = int(params["pullback_lookback_bars"])
     relative_volume_period = int(params["relative_volume_period"])
@@ -2661,7 +2691,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="HOLD",
             reason=(
-                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and SPY; "
+                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and {benchmark_name}; "
                 f"found {len(aligned_asset)}."
             ),
             candle_timestamp=latest_timestamp,
@@ -2750,7 +2780,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol outperformed SPY over {comparison_bars} candles, but SPY is not in a meaningful pullback "
+                    f"Symbol outperformed {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful pullback "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2760,7 +2791,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent <= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol outperformed SPY overall, but it did not hold up better during the latest SPY pullback.",
+                reason=(
+                    f"Symbol outperformed {benchmark_name} overall, but it did not hold up better "
+                    f"during the latest {benchmark_name} pullback."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2807,7 +2841,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="BUY",
             reason=(
-                f"BUY on relative strength vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"BUY on relative strength vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {long_entry[0]} "
                 f"{_format_strategy_price(long_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -2823,7 +2857,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol lagged SPY over {comparison_bars} candles, but SPY is not in a meaningful bounce "
+                    f"Symbol lagged {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful bounce "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2833,7 +2868,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent >= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol lagged SPY overall, but it bounced too much during the latest SPY rebound.",
+                reason=(
+                    f"Symbol lagged {benchmark_name} overall, but it bounced too much during the "
+                    f"latest {benchmark_name} rebound."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2880,7 +2918,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="SELL",
             reason=(
-                f"SELL on relative weakness vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"SELL on relative weakness vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {short_entry[0]} "
                 f"{_format_strategy_price(short_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -9633,6 +9671,8 @@ def _validate_strategy_configuration(
     slow_period: int,
 ) -> None:
     _validate_strategy_periods(fast_period, slow_period)
+    if strategy_type == _STRATEGY_TOPBOT_ADAPTIVE and str(timeframe_unit) == "month":
+        raise ValueError("TopBot Adaptive does not support month candles.")
     if strategy_type != _STRATEGY_EMA_SCALPING:
         return
     if str(timeframe_unit) != "minute" or int(timeframe_unit_number) not in _EMA_SCALPING_ALLOWED_MINUTE_BUCKETS:
@@ -9852,8 +9892,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_ATR_ADJUSTED_RELATIVE_STRENGTH:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         return {
@@ -9932,8 +9973,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_RELATIVE_STRENGTH_SPY:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         swing_window = _bounded_int_param(
@@ -10902,6 +10944,15 @@ def _validate_unique_bot_name(
 
 def _looks_like_projectx_contract_id(value: str) -> bool:
     return value.upper().startswith("CON.")
+
+
+def _normalize_projectx_benchmark_symbol(value: Any, *, default: str) -> str:
+    """Map the legacy SPY benchmark to the MES futures feed ProjectX supports."""
+
+    normalized = _normalized_optional_text(value) or str(default)
+    if normalized.strip().upper() in {"SPY", "F.US.SPY"}:
+        return "MES"
+    return normalized.strip().upper()
 
 
 def _pick_market_contract(rows: Iterable[dict[str, Any]]) -> dict[str, Any] | None:

--- a/backend/app/services/projectx_client.py
+++ b/backend/app/services/projectx_client.py
@@ -23,6 +23,8 @@ _TOKEN_CACHE_BY_KEY: dict[str, _TokenCache] = {}
 _TOKEN_SAFETY_WINDOW = timedelta(seconds=60)
 _PROJECTX_ORDER_TYPES = {1, 2, 4, 5, 6, 7}
 _PROJECTX_ORDER_SIDES = {0, 1}
+_PROJECTX_INTRADAY_UNIT_SECONDS = {1: 1, 2: 60, 3: 60 * 60}
+_PARTIAL_BAR_KEYS = ("isPartial", "is_partial", "partial")
 
 
 class ProjectXClientError(RuntimeError):
@@ -183,6 +185,15 @@ class ProjectXClient:
             timestamp = _parse_datetime(_first_value(row, ["t", "timestamp", "time"]))
             if timestamp is None:
                 continue
+            has_partial_marker = any(key in row for key in _PARTIAL_BAR_KEYS)
+            is_partial = _is_truthy(_first_value(row, list(_PARTIAL_BAR_KEYS)))
+            interval_seconds = _PROJECTX_INTRADAY_UNIT_SECONDS.get(int(unit))
+            if not has_partial_marker and interval_seconds is not None:
+                is_partial = timestamp + timedelta(
+                    seconds=interval_seconds * max(1, int(unit_number))
+                ) > _as_utc(end)
+            if is_partial and not include_partial_bar:
+                continue
 
             output.append(
                 {
@@ -192,7 +203,7 @@ class ProjectXClient:
                     "low": _safe_float(_first_value(row, ["l", "low"])),
                     "close": _safe_float(_first_value(row, ["c", "close"])),
                     "volume": _safe_float(_first_value(row, ["v", "volume"])),
-                    "is_partial": _is_truthy(_first_value(row, ["isPartial", "is_partial", "partial"])),
+                    "is_partial": is_partial,
                     "raw_payload": row,
                 }
             )

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -34,3 +34,20 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     )
     end_local = start_local + timedelta(days=1) - timedelta(microseconds=1)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def futures_session_is_open(value: datetime) -> bool:
+    """Return whether a timestamp falls inside the regular CME Globex week."""
+
+    local = as_utc(value).astimezone(TRADING_TZ)
+    weekday = local.weekday()
+    local_time = local.time()
+    if weekday == 5:
+        return False
+    if weekday == 6 and local_time < time(hour=18):
+        return False
+    if weekday == 4 and local_time >= time(hour=17):
+        return False
+    if time(hour=17) <= local_time < time(hour=18):
+        return False
+    return True

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -1666,8 +1666,21 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
             raw_payload={"stop_loss": price - 10, "take_profit": price + 20},
         )
 
-    def unexpected_provider_call(*_args, **_kwargs):
-        raise AssertionError("TopBot backtest invoked a provider path")
+    class StubHistoryClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("configured deliveries must not be re-resolved")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return []
+
+    history_client = StubHistoryClient()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("TopBot backtest invoked an order path")
 
     monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
     monkeypatch.setattr(backtesting_module.bot_service_module, "dispatch_strategy_evaluator", fake_dispatch)
@@ -1678,10 +1691,11 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
         lambda **_kwargs: {"total_score": 85},
     )
     monkeypatch.setattr(
-        ProjectXClient,
-        "from_env",
-        classmethod(lambda cls: unexpected_provider_call()),
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: history_client,
     )
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
     payload = BotBacktestIn(
         start=BASE_TIME,
         end=BASE_TIME + timedelta(minutes=20),
@@ -1696,9 +1710,11 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
     )
     first_validated = BotBacktestOut.model_validate(first)
 
-    assert first_validated.engine_version == "1.2.0"
+    assert first_validated.engine_version == "1.3.0"
     assert first_validated.metrics.trade_count == 1
     assert not any("strategy_not_supported" in warning for warning in first["warnings"])
+    assert history_client.calls
+    assert all(call["contract_id"] == CONTRACT_ID for call in history_client.calls)
 
     one_hour.close_price = 101
     one_hour.high_price = 102
@@ -1753,3 +1769,244 @@ def test_backtest_route_scopes_bots_and_candles_to_authenticated_user(
     assert hidden.value.status_code == 404
     assert hidden.value.detail == "bot_config_not_found"
     assert db_session.query(BotBacktest).count() == 0
+
+
+def test_backtest_input_uses_absent_dates_for_full_history_and_keeps_paired_bounds():
+    full_history = BotBacktestIn()
+    bounded = BotBacktestIn(
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(days=800),
+    )
+
+    assert full_history.start is None
+    assert full_history.end is None
+    assert bounded.end - bounded.start == timedelta(days=800)
+    with pytest.raises(ValueError, match="provided together"):
+        BotBacktestIn(start=BASE_TIME)
+    with pytest.raises(ValueError, match="must be after start"):
+        BotBacktestIn(start=BASE_TIME, end=BASE_TIME)
+
+    mixed_awareness = BotBacktestIn(
+        start="2026-01-01T00:00:00",
+        end="2026-01-02T00:00:00Z",
+    )
+    assert mixed_awareness.start is not None
+    assert mixed_awareness.end is not None
+
+
+def test_full_history_uses_all_fully_closed_exact_contract_bars_without_old_cap(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session, lookback_bars=25)
+    exact_rows = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100 + index)
+        for index in range(6)
+    ]
+    other_delivery = _candle(
+        BASE_TIME - timedelta(minutes=5),
+        contract_id="CON.F.US.MNQ.U26",
+        symbol="MNQ",
+    )
+    inferred_partial = _candle(BASE_TIME + timedelta(minutes=30))
+    inferred_partial.fetched_at = BASE_TIME + timedelta(minutes=32)
+    inferred_partial.raw_payload = {"t": inferred_partial.candle_timestamp.isoformat()}
+    explicit_partial = _candle(
+        BASE_TIME + timedelta(minutes=35),
+        is_partial=True,
+    )
+    not_yet_closed = _candle(
+        BASE_TIME + timedelta(minutes=40),
+    )
+    db_session.add_all(
+        [other_delivery, *exact_rows, inferred_partial, explicit_partial, not_yet_closed]
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(backtesting_module, "MAX_BACKTEST_BARS", 2)
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("backtest invoked an order path")
+
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+
+    row = backtesting_module.create_bot_backtest(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            starting_balance=25_000,
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        now=BASE_TIME + timedelta(minutes=42),
+    )
+    result = backtesting_module.serialize_bot_backtest(row)
+    validated = BotBacktestOut.model_validate(result)
+
+    hard_minimum = backtesting_module._strategy_history_bars(config, hard_minimum=True)
+    first_execution_index = hard_minimum - 1
+    expected_execution = exact_rows[first_execution_index:]
+    assert validated.range.contract_id == CONTRACT_ID
+    assert validated.range.symbol == "MNQ"
+    assert validated.range.timeframe_unit == "minute"
+    assert validated.range.timeframe_unit_number == 5
+    assert validated.range.start == _utc(expected_execution[0].candle_timestamp)
+    assert validated.range.end == backtesting_module._candle_close_time(expected_execution[-1])
+    assert validated.range.bar_count == len(expected_execution)
+    assert validated.range.bar_count > backtesting_module.MAX_BACKTEST_BARS
+    assert _utc(row.requested_start) == BASE_TIME
+    assert _utc(row.requested_end) == BASE_TIME + timedelta(minutes=30)
+    assert result["assumptions"]["live_order_routing"] == "disabled_by_architecture"
+
+
+def test_full_history_route_is_deterministic_and_has_no_public_prepare_step(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session, execution_mode="live", lookback_bars=25)
+    for index in range(6):
+        db_session.add(
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+        )
+    db_session.commit()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("full-history backtest invoked an order path")
+
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+    payload = BotBacktestIn(
+        starting_balance=25_000,
+        commission_per_contract=0,
+        slippage_ticks=0,
+    )
+
+    first = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=payload,
+        db=db_session,
+    )
+    second = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=payload,
+        db=db_session,
+    )
+    first_validated = BotBacktestOut.model_validate(first)
+
+    assert first_validated.range.contract_id == CONTRACT_ID
+    assert first_validated.range.bar_count == 4
+    assert first["range"] == second["range"]
+    assert first["metrics"] == second["metrics"]
+    assert first["input_fingerprint"] == second["input_fingerprint"]
+    assert first["assumptions"]["configured_execution_mode_was_ignored"] == "live"
+    assert "/api/bots/{bot_config_id}/backtests/prepare" not in {
+        route.path for route in main_module.app.routes
+    }
+    assert db_session.query(BotBacktest).count() == 2
+
+
+@pytest.mark.parametrize(
+    "cached_count",
+    [0, 25],
+    ids=["empty-primary-cache", "stale-primary-cache"],
+)
+def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history(
+    db_session,
+    monkeypatch,
+    cached_count,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["sma_cross"]},
+        lookback_bars=25,
+    )
+    provider_bars = [
+        {
+            "timestamp": BASE_TIME + timedelta(minutes=5 * index),
+            "open": 100 + index,
+            "high": 101 + index,
+            "low": 99 + index,
+            "close": 100 + index,
+            "volume": 100,
+            "is_partial": False,
+            "raw_payload": {"isPartial": False},
+        }
+        for index in range(30)
+    ]
+    for bar in provider_bars[:cached_count]:
+        db_session.add(
+            _candle(
+                bar["timestamp"],
+                open_price=bar["open"],
+                high_price=bar["high"],
+                low_price=bar["low"],
+                close_price=bar["close"],
+                volume=bar["volume"],
+            )
+        )
+    db_session.commit()
+
+    class StubFullHistoryClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("full-history discovery must retain the configured delivery")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            start = _utc(kwargs["start"])
+            end = _utc(kwargs["end"])
+            rows = [
+                bar
+                for bar in provider_bars
+                if start <= _utc(bar["timestamp"]) <= end
+            ]
+            return rows[-int(kwargs["limit"]):]
+
+    client = StubFullHistoryClient()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("TopBot full-history replay invoked an order path")
+
+    monkeypatch.setattr(backtesting_module, "MAX_PROVIDER_FETCH_BARS", 5)
+    monkeypatch.setattr(
+        backtesting_module,
+        "_MAX_PROVIDER_EMPTY_SPAN",
+        timedelta(minutes=20),
+    )
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: client,
+    )
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+
+    response = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        db=db_session,
+    )
+    validated = BotBacktestOut.model_validate(response)
+
+    assert client.calls
+    assert all(call["contract_id"] == CONTRACT_ID for call in client.calls)
+    assert validated.range.contract_id == CONTRACT_ID
+    assert validated.range.start == BASE_TIME + timedelta(minutes=120)
+    assert validated.range.end == BASE_TIME + timedelta(minutes=150)
+    assert validated.range.bar_count == 6
+    assert (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
+        .count()
+        == 30
+    )

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -238,6 +238,55 @@ def test_signal_evaluation_receives_only_bars_closed_as_of_each_event():
     assert all(BASE_TIME + timedelta(minutes=15) not in call for call in observed)
 
 
+def test_topbot_defers_replay_when_requested_start_precedes_available_warmup():
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(30)
+    ]
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            strategy_params={"source_strategies": ["sma_cross"]},
+            lookback_bars=25,
+        ),
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=150),
+    )
+
+    assert result["range"]["start"] == (BASE_TIME + timedelta(minutes=120)).isoformat()
+    assert result["range"]["bar_count"] == 6
+    assert any("Deferred replay by 24 candle(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_only_evaluates_signals_inside_the_configured_session():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    bars = [
+        _candle(session_open + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-2, 2)
+    ]
+    evaluated: list[datetime] = []
+
+    def evaluator(candles):
+        evaluated.append(_utc(candles[-1].candle_timestamp))
+        return _hold(candles)
+
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            trading_start_time="09:30",
+            trading_end_time="15:45",
+        ),
+        evaluator=evaluator,
+        start=session_open - timedelta(minutes=10),
+        end=session_open + timedelta(minutes=10),
+    )
+
+    assert result["range"]["bar_count"] == 4
+    assert evaluated == [session_open, session_open + timedelta(minutes=5)]
+
+
 def test_orb_evaluator_keeps_the_true_session_open_beyond_configured_lookback():
     session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
     bars = [
@@ -948,7 +997,472 @@ def test_topbot_replay_records_missing_auxiliary_stream_as_source_failure():
 
     assert result["metrics"]["trade_count"] == 0
     assert any("asset:hour:1" in warning for warning in result["warnings"])
-    assert any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert not any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert any("TopBot excluded source(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_replay_excludes_a_benchmark_that_stops_before_the_replay_tail(
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": ["atr_adjusted_relative_strength"],
+            "minimum_directional_votes": 1,
+        },
+        lookback_bars=25,
+    )
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 4)
+    ]
+    benchmark = _candle(
+        BASE_TIME - timedelta(minutes=5),
+        contract_id="CON.F.US.MES.M26",
+        symbol="F.US.MES",
+    )
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"stale source {identifier} should have been excluded")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=20),
+        replay_streams={
+            backtesting_module._topbot_benchmark_stream_key(
+                "atr_adjusted_relative_strength"
+            ): [benchmark],
+        },
+    )
+
+    assert result["metrics"]["trade_count"] == 0
+    assert any(
+        "benchmark:atr_adjusted_relative_strength" in warning
+        and "TopBot excluded source(s)" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_benchmark_specs_use_mes_with_the_asset_delivery():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+            "source_strategy_params": {
+                "atr_adjusted_relative_strength": {"benchmark_symbol": "SPY"},
+                "relative_strength_spy": {"benchmark_symbol": "SPY"},
+            },
+        },
+        contract_id="CON.F.US.MNQ.M26",
+    )
+
+    specs = backtesting_module._topbot_stream_specs(config)
+
+    for source in ("atr_adjusted_relative_strength", "relative_strength_spy"):
+        spec = specs[backtesting_module._topbot_benchmark_stream_key(source)]
+        assert spec.contract_id == "CON.F.US.MES.M26"
+        assert spec.symbol == "F.US.MES"
+        assert spec.unit == "minute"
+        assert spec.unit_number == 5
+
+
+def test_topbot_cache_preparation_deduplicates_shared_mes_benchmark(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+
+    class StubClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("exact historical deliveries should not be re-resolved")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return []
+
+    client = StubClient()
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+        ),
+        client=client,
+    )
+
+    assert prepared == 2
+    assert {call["contract_id"] for call in client.calls} == {
+        CONTRACT_ID,
+        "CON.F.US.MES.M26",
+    }
+    assert sum(call["contract_id"] == "CON.F.US.MES.M26" for call in client.calls) == 1
+
+
+def test_topbot_cache_preparation_skips_streams_that_already_cover_the_replay(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+        lookback_bars=25,
+    )
+    db_session.add_all([_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))])
+    db_session.commit()
+
+    class UnexpectedClient:
+        def retrieve_bars(self, **_kwargs):
+            raise AssertionError("covered streams should not be fetched again")
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_cached_replay_stream_covers",
+        lambda *_args, **_kwargs: True,
+    )
+
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=10),
+        ),
+        client=UnexpectedClient(),
+    )
+
+    assert prepared == 0
+
+
+def test_topbot_cache_coverage_rejects_overlapping_candles(db_session):
+    canonical = [
+        _candle(
+            BASE_TIME - timedelta(hours=4 * index),
+            unit="hour",
+            unit_number=4,
+        )
+        for index in range(26, 0, -1)
+    ]
+    overlap = _candle(
+        BASE_TIME - timedelta(hours=6),
+        unit="hour",
+        unit_number=4,
+    )
+    db_session.add_all([*canonical, overlap])
+    db_session.commit()
+
+    assert not backtesting_module._cached_replay_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="hour",
+        unit_number=4,
+        fetch_start=BASE_TIME - timedelta(days=7),
+        requested_start=BASE_TIME,
+        first_event=BASE_TIME + timedelta(minutes=5),
+        last_event=BASE_TIME + timedelta(minutes=10),
+        warmup_bars=25,
+    )
+
+
+def test_topbot_replay_excludes_legacy_unmarked_four_hour_tail_snapshot():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+    )
+    fetched_after_close = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    canonical = [
+        _candle(
+            timestamp,
+            unit="hour",
+            unit_number=4,
+        )
+        for timestamp in (
+            datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        )
+    ]
+    for row in canonical:
+        row.fetched_at = fetched_after_close
+        row.raw_payload = {"t": row.candle_timestamp.isoformat()}
+    stale_tail = _candle(
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        unit="hour",
+        unit_number=4,
+    )
+    stale_tail.fetched_at = datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc)
+    stale_tail.raw_payload = {"t": stale_tail.candle_timestamp.isoformat()}
+    spec = backtesting_module._topbot_stream_specs(config)[
+        backtesting_module._topbot_asset_stream_key("hour", 4)
+    ]
+
+    rows, excluded = backtesting_module._validate_topbot_replay_stream(
+        [canonical[0], stale_tail, canonical[1]],
+        spec=spec,
+        config=config,
+    )
+
+    assert [_utc(row.candle_timestamp) for row in rows] == [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+    ]
+    assert excluded == 1
+
+
+def test_topbot_cache_preparation_rejects_monthly_primary_candles(db_session):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        timeframe_unit="month",
+        timeframe_unit_number=1,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="TopBot Adaptive does not support month candles",
+    ):
+        backtesting_module.prepare_bot_backtest_data(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(days=31),
+            ),
+            client=object(),
+        )
+
+
+@pytest.mark.parametrize(
+    "event_start",
+    [
+        datetime(2026, 7, 6, 13, 20, tzinfo=timezone.utc),  # Before 09:30 ET.
+        datetime(2026, 7, 6, 20, 0, tzinfo=timezone.utc),   # After 15:45 ET.
+        datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc),   # Sunday.
+    ],
+)
+def test_topbot_orb_skips_events_outside_the_configured_session(
+    event_start,
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert not any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_does_not_dispatch_during_a_sunday_closure(monkeypatch):
+    event_start = datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+    one_minute = [
+        _candle(
+            event_start + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(10)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_orb_still_reports_a_genuinely_missing_session_open():
+    event_start = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(event_start - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(event_start),
+        _candle(event_start + timedelta(minutes=5)),
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        and "requires the session-opening candle" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_excludes_a_truncated_one_minute_tail():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(session_open - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(session_open),
+        _candle(session_open + timedelta(minutes=5)),
+    ]
+    one_minute = [
+        _candle(
+            session_open + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(5)
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=session_open,
+        end=session_open + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert any(
+        "TopBot excluded source(s)" in warning
+        and "delayed_orb_confirmation (asset:minute:1)" in warning
+        for warning in result["warnings"]
+    )
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_futures_gap_detection_ignores_weekends_but_flags_open_session_holes():
+    friday_close = datetime(2026, 7, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)
+    weekend_rows = [_candle(friday_close), _candle(sunday_open)]
+    open_session_rows = [
+        _candle(BASE_TIME),
+        _candle(BASE_TIME + timedelta(minutes=10)),
+    ]
+
+    assert backtesting_module._count_futures_session_gaps(
+        weekend_rows,
+        interval_seconds=300,
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        open_session_rows,
+        interval_seconds=300,
+    ) == 1
+
+
+def test_backtest_range_reports_actual_stored_coverage():
+    bars = [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))]
+
+    result = _run(
+        bars,
+        evaluator=_hold,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(days=1),
+    )
+
+    assert result["range"]["start"] == BASE_TIME.isoformat()
+    assert result["range"]["end"] == (BASE_TIME + timedelta(minutes=10)).isoformat()
+    assert any("Stored candles ended before the requested end" in warning for warning in result["warnings"])
 
 
 def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
@@ -977,11 +1491,14 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             raw_payload={},
         )
 
-    benchmark = _candle(
-        BASE_TIME - timedelta(minutes=5),
-        contract_id="SPY",
-        symbol="SPY",
-    )
+    benchmark = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id="CON.F.US.MES.M26",
+            symbol="F.US.MES",
+        )
+        for index in range(-5, 3)
+    ]
     monkeypatch.setattr(backtesting_module.bot_service_module, "dispatch_strategy_evaluator", fake_dispatch)
 
     result = _run(
@@ -991,7 +1508,12 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
         end=BASE_TIME + timedelta(minutes=15),
         replay_streams={
             backtesting_module._topbot_asset_stream_key("minute", 1): [
-                _candle(BASE_TIME, unit="minute", unit_number=1)
+                _candle(
+                    BASE_TIME + timedelta(minutes=index),
+                    unit="minute",
+                    unit_number=1,
+                )
+                for index in range(15)
             ],
             backtesting_module._topbot_asset_stream_key("hour", 1): [
                 _candle(BASE_TIME - timedelta(hours=1), unit="hour", unit_number=1)
@@ -1004,10 +1526,10 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             ],
             backtesting_module._topbot_benchmark_stream_key(
                 "atr_adjusted_relative_strength"
-            ): [benchmark],
-            backtesting_module._topbot_benchmark_stream_key("relative_strength_spy"): [
-                benchmark
-            ],
+            ): benchmark,
+            backtesting_module._topbot_benchmark_stream_key(
+                "relative_strength_spy"
+            ): benchmark,
         },
     )
 
@@ -1174,7 +1696,7 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
     )
     first_validated = BotBacktestOut.model_validate(first)
 
-    assert first_validated.engine_version == "1.1.0"
+    assert first_validated.engine_version == "1.2.0"
     assert first_validated.metrics.trade_count == 1
     assert not any("strategy_not_supported" in warning for warning in first["warnings"])
 

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -2704,8 +2704,8 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2724,7 +2724,7 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
     )
 
     assert signal.action == "BUY"
-    assert "BUY on relative strength vs SPY" in signal.reason
+    assert "BUY on relative strength vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] > signal.price
     assert signal.raw_payload["stop_loss"] < signal.price
@@ -2763,8 +2763,8 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2783,13 +2783,13 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
     )
 
     assert signal.action == "SELL"
-    assert "SELL on relative weakness vs SPY" in signal.reason
+    assert "SELL on relative weakness vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] < signal.price
     assert signal.raw_payload["stop_loss"] > signal.price
 
 
-def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
+def test_relative_strength_vs_spy_fetches_symbol_and_mes_five_minute_candles():
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -2804,8 +2804,8 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             self.calls = []
 
         def search_contracts(self, *, search_text: str, live: bool = False):
-            if search_text == "SPY":
-                return [{"id": "CON.F.US.SPY.M26", "symbol_id": "SPY", "active_contract": True}]
+            if search_text == "MES":
+                return [{"id": "CON.F.US.MES.M26", "symbol_id": "F.US.MES", "active_contract": True}]
             return []
 
         def retrieve_bars(self, **kwargs):
@@ -2849,15 +2849,48 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             strategy_params={"benchmark_symbol": "SPY"},
         )
 
-        assert rows == {"5m": [], "SPY": []}
+        assert rows == {"5m": [], "benchmark": []}
         assert [(call["contract_id"], call["unit"], call["unit_number"], call["limit"]) for call in client.calls] == [
             ("CON.F.US.MNQ.M26", 2, 5, 50),
-            ("CON.F.US.SPY.M26", 2, 5, 50),
+            ("CON.F.US.MES.M26", 2, 5, 50),
         ]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
         engine.dispose()
+
+
+def test_postgres_market_candle_upserts_are_batched(monkeypatch):
+    batch_sizes: list[int] = []
+
+    class Excluded:
+        def __getattr__(self, name):
+            return name
+
+    class Insert:
+        excluded = Excluded()
+
+        def values(self, batch):
+            batch_sizes.append(len(batch))
+            return self
+
+        def on_conflict_do_update(self, **_kwargs):
+            return self
+
+    class StubDb:
+        def __init__(self):
+            self.execute_count = 0
+
+        def execute(self, _statement):
+            self.execute_count += 1
+
+    monkeypatch.setattr(bot_service_module, "postgresql_insert", lambda _table: Insert())
+    db = StubDb()
+
+    bot_service_module._upsert_market_candle_rows(db, values=[{} for _ in range(2_501)])
+
+    assert batch_sizes == [1_000, 1_000, 501]
+    assert db.execute_count == 3
 
 
 def test_fetch_market_candles_deduplicates_provider_timestamps():
@@ -2912,6 +2945,89 @@ def test_fetch_market_candles_deduplicates_provider_timestamps():
         assert rows[0].close_price == 13.0
         assert rows[0].volume == 2.0
         assert db.query(ProjectXMarketCandle).count() == 1
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def test_authoritative_market_candle_refresh_prunes_displaced_cached_bars():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    user_id = "00000000-0000-0000-0000-000000000000"
+    outside = datetime(2026, 4, 26, 18, 0, tzinfo=timezone.utc)
+    stale = [
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc),
+    ]
+    authoritative = [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 6, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 14, 0, tzinfo=timezone.utc),
+    ]
+
+    class StubClient:
+        def retrieve_bars(self, **_kwargs):
+            return [
+                {
+                    "timestamp": timestamp,
+                    "open": 100,
+                    "high": 102,
+                    "low": 99,
+                    "close": 101,
+                    "volume": 10,
+                    "is_partial": False,
+                }
+                for timestamp in authoritative
+            ]
+
+    try:
+        db.add_all(
+            [
+                _make_candle(
+                    timestamp,
+                    100,
+                    user_id=user_id,
+                    unit="hour",
+                    unit_number=4,
+                )
+                for timestamp in [outside, *stale]
+            ]
+        )
+        db.commit()
+
+        rows = fetch_and_store_market_candles(
+            db,
+            user_id=user_id,
+            client=StubClient(),
+            contract_id="CON.F.US.MNQ.M26",
+            symbol="MNQ",
+            live=False,
+            start=authoritative[0],
+            end=authoritative[-1] + timedelta(hours=4),
+            unit="hour",
+            unit_number=4,
+            limit=500,
+            preserve_cached_history=True,
+            authoritative_refresh=True,
+        )
+
+        assert [_as_test_utc(row.candle_timestamp) for row in rows] == authoritative
+        cached_timestamps = [
+            _as_test_utc(row.candle_timestamp)
+            for row in db.query(ProjectXMarketCandle)
+            .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+            .all()
+        ]
+        assert cached_timestamps == [outside, *authoritative]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
@@ -3037,6 +3153,47 @@ def test_create_bot_config_rejects_invalid_ema_scalping_timeframe():
         )
 
         with pytest.raises(ValueError, match="3-minute or 5-minute timeframe"):
+            create_bot_config(db, user_id=user_id, payload=payload)
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=tables)
+        engine.dispose()
+
+
+def test_create_bot_config_rejects_monthly_topbot_timeframe():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [Account.__table__, BotConfig.__table__]
+    Base.metadata.create_all(bind=engine, tables=tables)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user_id = "00000000-0000-0000-0000-000000000000"
+    try:
+        db.add(
+            Account(
+                user_id=user_id,
+                provider="projectx",
+                external_id="9001",
+                name="Practice 9001",
+                account_state="ACTIVE",
+                can_trade=True,
+                is_visible=True,
+            )
+        )
+        db.flush()
+        payload = _make_bot_create_payload(name="Monthly TopBot").model_copy(
+            update={
+                "strategy_type": "topbot_adaptive",
+                "timeframe_unit": "month",
+                "timeframe_unit_number": 1,
+            }
+        )
+
+        with pytest.raises(ValueError, match="does not support month candles"):
             create_bot_config(db, user_id=user_id, payload=payload)
     finally:
         db.close()

--- a/backend/tests/test_projectx_client.py
+++ b/backend/tests/test_projectx_client.py
@@ -276,6 +276,42 @@ def test_retrieve_bars_normalizes_and_sorts_ohlcv_rows():
     assert rows[1]["close"] == 104.0
 
 
+def test_retrieve_bars_infers_an_unmarked_intraday_tail_is_partial():
+    class StubClient(ProjectXClient):
+        def __init__(self):
+            super().__init__(base_url="https://example.test", username="demo", api_key="demo")
+
+        def _request(self, method, path, *, payload=None, with_auth):
+            return {
+                "bars": [
+                    {
+                        "t": "2026-04-27T00:00:00Z",
+                        "o": 100,
+                        "h": 102,
+                        "l": 99,
+                        "c": 101,
+                        "v": 10,
+                    }
+                ]
+            }
+
+    client = StubClient()
+    request = {
+        "contract_id": "CON.F.US.MNQ.M26",
+        "live": False,
+        "start": datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        "end": datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc),
+        "unit": 3,
+        "unit_number": 4,
+        "limit": 500,
+    }
+
+    assert client.retrieve_bars(**request, include_partial_bar=False) == []
+    included = client.retrieve_bars(**request, include_partial_bar=True)
+    assert len(included) == 1
+    assert included[0]["is_partial"] is True
+
+
 def test_place_order_uses_projectx_order_place_payload():
     class StubClient(ProjectXClient):
         def __init__(self):

--- a/docs/full-history-backtest-agent5.md
+++ b/docs/full-history-backtest-agent5.md
@@ -1,0 +1,31 @@
+# Full-history backtest integration boundary
+
+## Integration base
+
+- Feature branch: `feature/full-history-backtest`
+- Preserved parent: `74cc070` (`Integrate bot performance agent work for review`)
+- Agent 5 should branch from the final feature commit communicated after verification, not from `74cc070` directly.
+
+## Shared interfaces and assumptions
+
+- `BotBacktestIn.start` and `.end` are an optional pair. Omitting both requests full history; supplying both preserves bounded compatibility and test coverage. Supplying only one is invalid.
+- `create_bot_backtest(..., client: ProjectXClient | None = None, now: datetime | None = None)` is the single service entrypoint. `now` captures one deterministic closure boundary for tests and the whole request.
+- The primary replay query is always scoped to user, non-live data, the configured `contract_id`, and the configured timeframe. It must never resolve, roll, or merge futures deliveries.
+- Full-history resolution excludes explicit and inferred partial rows, then uses the earliest eligible stored bar through the latest bar whose nominal close is at or before the captured boundary.
+- TopBot full-history requests first discover and persist the exact configured primary delivery, paging backward and forward until provider exhaustion; empty and stale caches cannot define the reported range. Provider failures propagate instead of masquerading as complete cached history.
+- `run_backtest` remains provider-free and order-routing-free. TopBot data acquisition happens before it, inside the same public POST request.
+- Successful results report actual execution coverage in `range`: `contract_id`, `symbol`, `timeframe_unit`, `timeframe_unit_number`, `start`, `end`, and `bar_count`.
+- Fixed 366-day and 20,000 execution-bar caps were removed. No successful result may be a limited prefix; later resource controls must either process the complete resolved input or fail explicitly before persistence.
+
+## Ownership boundary for Agent 5
+
+Build upon these feature-owned seams in `backend/app/services/bot_backtesting.py`:
+
+- `_ResolvedBacktestWindow`, `_load_primary_closed_candles`, `_requested_backtest_bounds`, `_resolve_backtest_window`, and the exact-primary discovery helpers
+- Public orchestration in `prepare_bot_backtest_data` and `create_bot_backtest`
+- Actual range provenance returned by `BacktestEngine.run`
+- `_validate_settings` range policy and `_assumptions_snapshot` market-data wording
+
+Avoid changing those public contracts or response field names without coordinating first. Agent 5 owns follow-on performance work inside replay/preparation/query internals, measured resource controls, pagination or batching, and equivalence/resource-safety tests. Preserve exact-contract filtering, the single captured closure boundary, the one-call TopBot workflow, and fail-before-persist semantics.
+
+Frontend consumers depend on a single `POST /api/bots/{id}/backtests`; `/backtests/prepare` is intentionally not public.

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi } from "./api";
+import { accountsApi, botsApi } from "./api";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -109,5 +109,64 @@ describe("accountsApi", () => {
     expect(trades.length).toBe(summary.trade_count);
     expect(calendar.length).toBeGreaterThan(10);
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("botsApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ id: 17 }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("posts backtests to the plural backend route", async () => {
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.runBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
+  });
+
+  it("prepares TopBot replay data through the dedicated cache route", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.prepareBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
   });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -130,10 +130,8 @@ describe("botsApi", () => {
     vi.clearAllMocks();
   });
 
-  it("posts backtests to the plural backend route", async () => {
+  it("posts one date-free full-history request to the plural backend route", async () => {
     const payload = {
-      start: "2026-07-01T00:00:00.000Z",
-      end: "2026-07-08T23:59:59.999Z",
       starting_balance: 50_000,
       commission_per_contract: 1.2,
       slippage_ticks: 1,
@@ -148,25 +146,7 @@ describe("botsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual(payload);
-  });
-
-  it("prepares TopBot replay data through the dedicated cache route", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
-    const payload = {
-      start: "2026-07-01T00:00:00.000Z",
-      end: "2026-07-08T23:59:59.999Z",
-      starting_balance: 50_000,
-      commission_per_contract: 1.2,
-      slippage_ticks: 1,
-      force_close_at_end: true,
-    };
-
-    await botsApi.prepareBacktest(42, payload);
-
-    const fetchMock = vi.mocked(fetch);
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
-    expect(init?.method).toBe("POST");
-    expect(JSON.parse(String(init?.body))).toEqual(payload);
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("start");
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("end");
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1108,7 +1108,7 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
     });
   } catch (error) {
     if (isAbortError(error)) {
-      throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
+      throw new Error("Full-history backtest timed out after 15 minutes. Try again after the server finishes preparing candles.");
     }
     throw error;
   } finally {
@@ -1170,11 +1170,6 @@ export const botsApi = {
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
-    }),
-  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
-    requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
-      method: "POST",
-      body: payload,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,7 +69,7 @@ import { getAccessToken } from "./supabase";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8000";
 const ACCOUNTS_CACHE_TTL_MS = 10 * 60_000;
 const ACCOUNT_READ_CACHE_TTL_MS = 10 * 60_000;
-const BACKTEST_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const BACKTEST_REQUEST_TIMEOUT_MS = 15 * 60_000;
 
 type QueryValue = string | number | boolean | null | undefined;
 
@@ -1101,14 +1101,14 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), BACKTEST_REQUEST_TIMEOUT_MS);
   try {
-    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtest`, {
+    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtests`, {
       method: "POST",
       body: payload,
       signal: controller.signal,
     });
   } catch (error) {
     if (isAbortError(error)) {
-      throw new Error("Backtest timed out after 5 minutes. Try again after the server finishes caching candles, or narrow the date range.");
+      throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
     }
     throw error;
   } finally {
@@ -1170,6 +1170,11 @@ export const botsApi = {
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
+    }),
+  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
+    requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
+      method: "POST",
+      body: payload,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1190,8 +1190,8 @@ export interface BotEvaluation {
 }
 
 export interface BotBacktestInput {
-  start: string;
-  end: string;
+  start?: string;
+  end?: string;
   starting_balance: number;
   commission_per_contract: number;
   slippage_ticks: number;
@@ -1202,6 +1202,10 @@ export interface BotBacktestRange {
   start: string;
   end: string;
   bar_count: number;
+  contract_id: string;
+  symbol: string | null;
+  timeframe_unit: BotTimeframeUnit;
+  timeframe_unit_number: number;
 }
 
 export interface BotBacktestAssumptions {

--- a/frontend/src/pages/bot/BotBacktestPanel.test.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { BotBacktestBreakdown, BotBacktestResult } from "../../lib/types";
-import { BacktestResults } from "./BotBacktestPanel";
+import { BacktestResults, BotBacktestPanel } from "./BotBacktestPanel";
 
 const breakdown: BotBacktestBreakdown = {
   trade_count: 1,
@@ -24,7 +24,15 @@ const result: BotBacktestResult = {
   engine_version: "1.0.0",
   input_fingerprint: "test-fingerprint",
   created_at: "2026-02-02T18:00:00Z",
-  range: { start: "2026-01-01T00:00:00Z", end: "2026-01-31T23:59:59Z", bar_count: 500 },
+  range: {
+    start: "2026-01-02T14:30:00Z",
+    end: "2026-01-30T21:00:00Z",
+    bar_count: 500,
+    contract_id: "CON.F.US.MNQ.H26",
+    symbol: "MNQ",
+    timeframe_unit: "minute",
+    timeframe_unit_number: 5,
+  },
   config_snapshot: { strategy_type: "sma_cross", fast_period: 9, slow_period: 21 },
   assumptions: {
     fill_model: "next_bar_open",
@@ -121,9 +129,26 @@ describe("BacktestResults", () => {
     expect(markup).toContain("Sample-quality warnings");
     expect(markup).toContain("Only one trade occurred");
     expect(markup).toContain("Backtest equity and drawdown chart");
+    expect(markup).toContain("MNQ (CON.F.US.MNQ.H26)");
+    expect(markup).toContain("5-minute");
+    expect(markup).toContain("500 closed bars");
+    expect(markup).toContain("Jan 2, 2026");
+    expect(markup).toContain("Jan 30, 2026");
     expect(markup).toContain("next bar open");
     expect(markup).toContain("External routing disabled");
     expect(markup).toContain("Trade ledger");
     expect(markup).toContain("take profit");
+  });
+});
+
+describe("BotBacktestPanel", () => {
+  it("offers one full-history action without date inputs", () => {
+    const markup = renderToStaticMarkup(<BotBacktestPanel bot={null} />);
+
+    expect(markup).toContain("Run Full History Backtest");
+    expect(markup).toContain("No order routing");
+    expect(markup).not.toContain("Start date");
+    expect(markup).not.toContain("End date");
+    expect(markup).not.toContain('type="date"');
   });
 });

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -21,6 +21,7 @@ import {
   BACKTEST_DRAWDOWN_TOP,
   BACKTEST_EQUITY_HEIGHT,
   BACKTEST_EQUITY_TOP,
+  buildBacktestPayload,
   buildBacktestChartPaths,
   validateBacktestForm,
   type BotBacktestFormState,
@@ -43,15 +44,11 @@ const integerFormatter = new Intl.NumberFormat("en-US", {
 const timestampFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
+  year: "numeric",
   hour: "2-digit",
   minute: "2-digit",
+  timeZoneName: "short",
   timeZone: EASTERN_TIME_ZONE,
-});
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-  timeZone: "UTC",
 });
 
 interface BotBacktestPanelProps {
@@ -87,18 +84,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     setRunning(true);
     setError(null);
     try {
-      const payload = {
-        start: `${form.startDate}T00:00:00.000Z`,
-        end: `${form.endDate}T23:59:59.999Z`,
-        starting_balance: Number(form.startingBalance),
-        commission_per_contract: Number(form.commissionPerContract),
-        slippage_ticks: Number(form.slippageTicks),
-        force_close_at_end: true,
-      };
-      if (bot.strategy_type === "topbot_adaptive") {
-        await botsApi.prepareBacktest(bot.id, payload);
-      }
-      const nextResult = await botsApi.runBacktest(bot.id, payload);
+      const nextResult = await botsApi.runBacktest(bot.id, buildBacktestPayload(form));
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }
@@ -119,7 +105,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <CardTitle>Backtest</CardTitle>
-            <CardDescription>Deterministic replay using stored, closed ProjectX candles</CardDescription>
+            <CardDescription>Deterministic replay of the configured contract&apos;s complete closed-candle history</CardDescription>
           </div>
           <div className="flex flex-wrap gap-2">
             <Badge variant="accent">Next-bar fills</Badge>
@@ -128,19 +114,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-5">
-        <form className="grid gap-3 md:grid-cols-2 xl:grid-cols-[1fr_1fr_1fr_1fr_1fr_auto] xl:items-end" onSubmit={handleSubmit}>
-          <BacktestInput
-            label="Start date"
-            type="date"
-            value={form.startDate}
-            onChange={(value) => setForm((current) => ({ ...current, startDate: value }))}
-          />
-          <BacktestInput
-            label="End date"
-            type="date"
-            value={form.endDate}
-            onChange={(value) => setForm((current) => ({ ...current, endDate: value }))}
-          />
+        <form className="grid gap-3 md:grid-cols-2 xl:grid-cols-[1fr_1fr_1fr_auto] xl:items-end" onSubmit={handleSubmit}>
           <BacktestInput
             label="Starting balance"
             type="number"
@@ -166,7 +140,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
             onChange={(value) => setForm((current) => ({ ...current, slippageTicks: value }))}
           />
           <Button type="submit" disabled={!bot || running} className="w-full xl:w-auto">
-            {running ? "Running…" : "Run Backtest"}
+            {running ? "Running Full History…" : "Run Full History Backtest"}
           </Button>
         </form>
 
@@ -183,7 +157,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         ) : result ? (
           <BacktestResults result={result} />
         ) : (
-          <BacktestEmptyState message="Choose a bounded date range and execution costs, then run the replay." />
+          <BacktestEmptyState message="Set the execution costs, then replay every fully closed candle available for this contract." />
         )}
       </CardContent>
     </Card>
@@ -222,7 +196,7 @@ function BacktestRunningState() {
   return (
     <div role="status" className="flex items-center gap-3 rounded-xl border border-app-accent/30 bg-app-accent/10 px-4 py-4 text-sm text-app-text-soft">
       <span className="h-4 w-4 animate-spin rounded-full border-2 border-app-accent/25 border-t-app-accent" aria-hidden="true" />
-      Replaying closed candles. No orders can be routed from this run.
+      Preparing and replaying the full closed-candle history. No orders can be routed from this run.
     </div>
   );
 }
@@ -236,7 +210,10 @@ export function BacktestResults({ result }: { result: BotBacktestResult }) {
         <div>
           <h4 className="text-sm font-semibold text-app-text md:text-base">Results</h4>
           <p className="mt-1 text-xs text-app-muted">
-            {formatDate(result.range.start)} – {formatDate(result.range.end)} · {integerFormatter.format(result.range.bar_count)} bars · generated {formatTimestamp(result.created_at)}
+            {formatContract(result.range.symbol, result.range.contract_id)} · {formatTimeframe(result.range.timeframe_unit, result.range.timeframe_unit_number)} · {integerFormatter.format(result.range.bar_count)} closed bars
+          </p>
+          <p className="mt-1 text-xs text-app-muted">
+            {formatTimestamp(result.range.start)} – {formatTimestamp(result.range.end)} · generated {formatTimestamp(result.created_at)}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -518,20 +495,11 @@ function TradeLedger({ result }: { result: BotBacktestResult }) {
 }
 
 function buildDefaultForm(): BotBacktestFormState {
-  const end = new Date();
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - 30);
   return {
-    startDate: toDateInput(start),
-    endDate: toDateInput(end),
     startingBalance: "50000",
     commissionPerContract: "1.20",
     slippageTicks: "1",
   };
-}
-
-function toDateInput(value: Date): string {
-  return value.toISOString().slice(0, 10);
 }
 
 function formatCurrency(value: number): string {
@@ -562,9 +530,12 @@ function formatTimestamp(value: string): string {
   return Number.isNaN(date.getTime()) ? value : timestampFormatter.format(date);
 }
 
-function formatDate(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : dateFormatter.format(date);
+function formatContract(symbol: string | null, contractId: string): string {
+  return symbol ? `${symbol} (${contractId})` : contractId;
+}
+
+function formatTimeframe(unit: string, unitNumber: number): string {
+  return `${integerFormatter.format(unitNumber)}-${unit}`;
 }
 
 function humanize(value: string): string {

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -87,14 +87,18 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     setRunning(true);
     setError(null);
     try {
-      const nextResult = await botsApi.runBacktest(bot.id, {
+      const payload = {
         start: `${form.startDate}T00:00:00.000Z`,
         end: `${form.endDate}T23:59:59.999Z`,
         starting_balance: Number(form.startingBalance),
         commission_per_contract: Number(form.commissionPerContract),
         slippage_ticks: Number(form.slippageTicks),
         force_close_at_end: true,
-      });
+      };
+      if (bot.strategy_type === "topbot_adaptive") {
+        await botsApi.prepareBacktest(bot.id, payload);
+      }
+      const nextResult = await botsApi.runBacktest(bot.id, payload);
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -42,7 +42,7 @@ const strategyOptions: Array<{ value: BotStrategyType; label: string }> = [
   { value: "supertrend_pivot", label: "Supertrend + Pivot Points" },
   { value: "opening_rvol_breakout", label: "Opening 5m RVOL Breakout" },
   { value: "atr_adjusted_relative_strength", label: "ATR-Adjusted Relative Strength" },
-  { value: "relative_strength_spy", label: "Relative Strength vs SPY" },
+  { value: "relative_strength_spy", label: "Relative Strength vs MES" },
   { value: "pullback_trap_reversal", label: "Pullback Trap Reversal" },
   { value: "bollinger_mean_reversion", label: "Bollinger Band Mean Reversion" },
   { value: "bollinger_rsi_reversal", label: "Bollinger RSI Reversal" },
@@ -203,7 +203,7 @@ const VWAP_GAP_RETRACE_DEFAULTS = {
   maxDataStalenessSeconds: "180",
 };
 const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   moveLookbackBars: "3",
   atrPeriod: "14",
   relativeVolumePeriod: "20",
@@ -218,7 +218,7 @@ const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
   maxDataStalenessSeconds: "600",
 };
 const RELATIVE_STRENGTH_SPY_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   comparisonBars: "12",
   pullbackLookbackBars: "3",
   relativeVolumePeriod: "20",
@@ -278,8 +278,8 @@ const STRATEGY_DEFAULT_NAMES: Partial<Record<BotStrategyType, string>> = {
   liquidity_sweep_retest: "MNQ Liquidity Sweep + Zone Retest",
   supertrend_pivot: "MNQ Supertrend + Pivot Points",
   opening_rvol_breakout: "MNQ Opening 5m RVOL Breakout",
-  atr_adjusted_relative_strength: "AAPL ATR-Adjusted Relative Strength",
-  relative_strength_spy: "AAPL Relative Strength vs SPY",
+  atr_adjusted_relative_strength: "MNQ ATR-Adjusted Relative Strength",
+  relative_strength_spy: "MNQ Relative Strength vs MES",
   pullback_trap_reversal: "MNQ Pullback Trap Reversal",
   bollinger_mean_reversion: "MNQ Bollinger Band Mean Reversion",
   bollinger_rsi_reversal: "MNQ Bollinger RSI Reversal",
@@ -935,7 +935,7 @@ function strategyLabel(strategyType: BotStrategyType) {
     return "ATR-Adjusted Relative Strength";
   }
   if (strategyType === "relative_strength_spy") {
-    return "Relative Strength vs SPY";
+    return "Relative Strength vs MES";
   }
   if (strategyType === "pullback_trap_reversal") {
     return "Pullback Trap Reversal";
@@ -1047,7 +1047,7 @@ function strategySummary(bot: BotConfig) {
     const window = bot.strategy_params?.comparison_bars ?? RELATIVE_STRENGTH_SPY_DEFAULTS.comparisonBars;
     const rvol = bot.strategy_params?.minimum_relative_volume ?? RELATIVE_STRENGTH_SPY_DEFAULTS.minimumRelativeVolume;
     return {
-      label: "RS/SPY",
+      label: "RS/MES",
       value: `${window} x 5m · RVOL ${rvol}x`,
     };
   }
@@ -1883,6 +1883,10 @@ export function BotPage() {
       setFormError("9/15 EMA scalping requires a 3-minute or 5-minute chart.");
       return;
     }
+    if (form.strategyType === "topbot_adaptive" && form.timeframeUnit === "month") {
+      setFormError("TopBot Adaptive does not support monthly candles.");
+      return;
+    }
     if (form.strategyType === "support_resistance" && levelTolerancePercent === null) {
       setFormError("Level tolerance must be a valid positive percent.");
       return;
@@ -2531,7 +2535,7 @@ export function BotPage() {
                         value={form.timeframeUnit}
                         onChange={(event) => setForm({ ...form, timeframeUnit: event.target.value as BotTimeframeUnit })}
                       >
-                        {timeframeUnits.map((unit) => (
+                        {timeframeUnits.filter((unit) => unit !== "month").map((unit) => (
                           <option key={unit} value={unit}>
                             {unit}
                           </option>

--- a/frontend/src/pages/bot/botBacktest.test.ts
+++ b/frontend/src/pages/bot/botBacktest.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from "vitest";
 
 import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint } from "../../lib/types";
-import { buildBacktestChartPaths, validateBacktestForm, type BotBacktestFormState } from "./botBacktest";
+import {
+  buildBacktestChartPaths,
+  buildBacktestPayload,
+  validateBacktestForm,
+  type BotBacktestFormState,
+} from "./botBacktest";
 
 const validForm: BotBacktestFormState = {
-  startDate: "2026-01-01",
-  endDate: "2026-01-31",
   startingBalance: "50000",
   commissionPerContract: "1.20",
   slippageTicks: "1",
 };
 
 describe("validateBacktestForm", () => {
-  it("accepts a bounded range and non-negative execution costs", () => {
+  it("accepts full-history execution settings", () => {
     expect(validateBacktestForm(validForm)).toBeNull();
   });
 
-  it("rejects reversed ranges and malformed numeric settings", () => {
-    expect(validateBacktestForm({ ...validForm, startDate: "2026-02-01" })).toBe(
-      "Start date must be on or before the end date.",
-    );
+  it("rejects malformed numeric settings", () => {
     expect(validateBacktestForm({ ...validForm, startingBalance: "0" })).toBe(
       "Starting balance must be greater than zero.",
     );
@@ -29,6 +29,21 @@ describe("validateBacktestForm", () => {
     expect(validateBacktestForm({ ...validForm, slippageTicks: "0.5" })).toBe(
       "Slippage must be a whole number of ticks, zero or greater.",
     );
+  });
+});
+
+describe("buildBacktestPayload", () => {
+  it("omits date bounds from the normal full-history request", () => {
+    const payload = buildBacktestPayload(validForm);
+
+    expect(payload).toEqual({
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    });
+    expect(payload).not.toHaveProperty("start");
+    expect(payload).not.toHaveProperty("end");
   });
 });
 

--- a/frontend/src/pages/bot/botBacktest.ts
+++ b/frontend/src/pages/bot/botBacktest.ts
@@ -1,4 +1,4 @@
-import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint } from "../../lib/types";
+import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint, BotBacktestInput } from "../../lib/types";
 
 export const BACKTEST_CHART_WIDTH = 720;
 export const BACKTEST_EQUITY_TOP = 14;
@@ -7,8 +7,6 @@ export const BACKTEST_DRAWDOWN_TOP = 184;
 export const BACKTEST_DRAWDOWN_HEIGHT = 58;
 
 export interface BotBacktestFormState {
-  startDate: string;
-  endDate: string;
   startingBalance: string;
   commissionPerContract: string;
   slippageTicks: string;
@@ -24,18 +22,6 @@ export interface BotBacktestChartPaths {
 }
 
 export function validateBacktestForm(form: BotBacktestFormState): string | null {
-  if (!form.startDate || !form.endDate) {
-    return "Start and end dates are required.";
-  }
-  const start = Date.parse(`${form.startDate}T00:00:00.000Z`);
-  const end = Date.parse(`${form.endDate}T23:59:59.999Z`);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
-    return "Enter a valid date range.";
-  }
-  if (start > end) {
-    return "Start date must be on or before the end date.";
-  }
-
   const startingBalance = Number(form.startingBalance);
   if (!Number.isFinite(startingBalance) || startingBalance <= 0) {
     return "Starting balance must be greater than zero.";
@@ -49,6 +35,15 @@ export function validateBacktestForm(form: BotBacktestFormState): string | null 
     return "Slippage must be a whole number of ticks, zero or greater.";
   }
   return null;
+}
+
+export function buildBacktestPayload(form: BotBacktestFormState): BotBacktestInput {
+  return {
+    starting_balance: Number(form.startingBalance),
+    commission_per_contract: Number(form.commissionPerContract),
+    slippage_ticks: Number(form.slippageTicks),
+    force_close_at_end: true,
+  };
 }
 
 export function buildBacktestChartPaths(


### PR DESCRIPTION
## Summary

- replace the normal date-based backtest form with a single **Run Full History Backtest** action
- keep optional paired API dates for compatibility and deterministic bounded tests
- resolve the exact configured futures delivery from its earliest valid closed candle through its latest fully closed candle
- exclude explicit partial, inferred partial, and not-yet-closed bars without silently limiting successful results
- report the actual contract, symbol, timeframe, execution range, and closed-bar count used
- make TopBot primary discovery, auxiliary-stream preparation, and replay one backend request
- preserve the deterministic, provider-free replay engine boundary and disabled order-routing behavior
- include the prerequisite synchronized TopBot replay and performance foundation from the preserved integration parent

## Why

The previous workflow required users to choose start and end dates and required a separate TopBot preparation step. That made complete-history runs cumbersome and allowed stale or incomplete cached ranges to be mistaken for the requested coverage.

This change makes the backend authoritative about the replay window. TopBot full-history requests discover and page the exact configured delivery before resolving the range, refresh empty or stale caches, and fail explicitly rather than returning a truncated prefix.

## Developer impact

- `BotBacktestIn.start` and `end` are now an optional pair; omitting both requests full history.
- `POST /api/bots/{id}/backtests` is the only public preparation/execution endpoint.
- `range` responses now include `contract_id`, `symbol`, `timeframe_unit`, and `timeframe_unit_number`.
- the fixed 366-day and 20,000 execution-bar caps were removed; resource-limit failures persist no partial result
- shared ownership and follow-on performance constraints are documented in `docs/full-history-backtest-agent5.md`

## Validation

- `python -m pytest -q` — 479 passed
- frontend Vitest suite — 320 passed across 42 files
- production frontend build — passed
- `git diff --check` — passed
