### PR TITLE
Speed up full-history backtest engine

### DIFF
--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -46,12 +47,40 @@ from .trading_day import (
 
 
 BACKTEST_ENGINE_VERSION = "1.3.0"
+# Retained as a compatibility constant for callers/tests that display the old
+# limit. It is deliberately not used to truncate or reject replay history.
 MAX_BACKTEST_BARS = 20_000
-MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
-MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
-MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
-MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
 MAX_PROVIDER_FETCH_BARS = 20_000
+CANDLE_QUERY_CHUNK_SIZE = 8_192
+_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES = 1_536 * 1024 * 1024
+# cProfile showed CPU time scaling with evaluator-visible candle visits.  This
+# configurable ceiling replaces date/bar caps while rejecting pathological
+# repeated-indicator workloads before replay or persistence.
+_DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET = 500_000_000
+try:
+    BACKTEST_MEMORY_BUDGET_BYTES = int(
+        os.getenv(
+            "TOPSIGNAL_BACKTEST_MEMORY_BUDGET_BYTES",
+            str(_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES),
+        )
+    )
+except ValueError:
+    BACKTEST_MEMORY_BUDGET_BYTES = _DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES
+try:
+    BACKTEST_EVALUATOR_WORK_BUDGET = int(
+        os.getenv(
+            "TOPSIGNAL_BACKTEST_EVALUATOR_WORK_BUDGET",
+            str(_DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET),
+        )
+    )
+except ValueError:
+    BACKTEST_EVALUATOR_WORK_BUDGET = _DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET
+
+# Calibrated with tracemalloc and the projected-row benchmark. These estimates
+# intentionally include Python container overhead and the two per-bar result
+# series, not only raw OHLCV payload bytes.
+ESTIMATED_REPLAY_CANDLE_BYTES = 640
+ESTIMATED_EXECUTION_RESULT_BYTES = 704
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -170,6 +199,42 @@ class _PreparedReplayStream:
     close_times: list[datetime]
 
 
+class _ClosedCandleList(list[ProjectXMarketCandle]):
+    """Internal proof that a replay window is already closed and ordered."""
+
+    _topsignal_sorted_closed = True
+    _topsignal_physical_stream: tuple[str, str, str, int] | None = None
+    _topsignal_physical_row_count: int | None = None
+
+
+class _PhysicalReplayList(list[ProjectXMarketCandle]):
+    """Projected rows that share one physical query but still need validation."""
+
+    _topsignal_physical_stream: tuple[str, str, str, int] | None = None
+    _topsignal_physical_row_count: int | None = None
+
+
+@dataclass(slots=True)
+class _ProjectedCandle:
+    """Lightweight query result with the candle attribute contract evaluators use."""
+
+    user_id: Any
+    contract_id: str
+    symbol: str | None
+    live: bool
+    unit: str
+    unit_number: int
+    candle_timestamp: datetime
+    open_price: Any
+    high_price: Any
+    low_price: Any
+    close_price: Any
+    volume: Any
+    is_partial: bool
+    raw_payload: Any
+    fetched_at: datetime | None
+
+
 @dataclass(frozen=True)
 class _PendingSignal:
     action: str
@@ -215,11 +280,38 @@ class BacktestEngine:
         _require_supported_strategy(self.strategy_type)
         _validate_replay_configuration(config)
         uses_real_evaluator = signal_evaluator is None
+        self._uses_real_evaluator = uses_real_evaluator
         self.signal_evaluator = signal_evaluator or self._evaluate_real_strategy
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
+        self.all_start_times = [
+            _as_utc(candle.candle_timestamp) for candle in self.all_candles
+        ]
+        self.all_close_times = [
+            _candle_close_time(candle) for candle in self.all_candles
+        ]
+        self._sma_close_values = (
+            [float(candle.close_price) for candle in self.all_candles]
+            if uses_real_evaluator
+            and self.strategy_type == "sma_cross"
+            and evaluate_sma_cross is bot_service_module.evaluate_sma_cross
+            else None
+        )
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
         self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
+        self._topbot_params: dict[str, Any] = {}
+        self._topbot_source_params: dict[str, dict[str, Any]] = {}
+        self._topbot_source_keys: dict[str, tuple[str, ...]] = {}
+        self._topbot_source_configs: dict[str, _SourceConfigView] = {}
+        self._topbot_cursor_state: dict[str, tuple[datetime, int]] = {}
+        self._topbot_history_event: datetime | None = None
+        self._topbot_history_cache: dict[
+            tuple[str, int, datetime | None], list[ProjectXMarketCandle]
+        ] = {}
+        self._current_event_timestamp: datetime | None = None
+        self._current_event_in_session = False
+        self._configured_session_start = _parse_time(str(config.trading_start_time))
+        self._configured_session_end = _parse_time(str(config.trading_end_time))
         auxiliary_excluded_partial = 0
         deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
@@ -231,12 +323,13 @@ class BacktestEngine:
                 primary_candles=self.all_candles,
                 replay_streams=replay_streams,
             )
-        self.execution_candles = [
-            candle
-            for candle in self.all_candles
-            if _as_utc(candle.candle_timestamp) >= self.settings.start
-            and _candle_close_time(candle) <= self.settings.end
-        ]
+            self._prepare_topbot_runtime()
+
+        execution_start = bisect_left(self.all_start_times, self.settings.start)
+        execution_end = bisect_right(self.all_close_times, self.settings.end)
+        self.execution_candles = self.all_candles[execution_start:execution_end]
+        self.execution_start_times = self.all_start_times[execution_start:execution_end]
+        self.execution_close_times = self.all_close_times[execution_start:execution_end]
         if len(self.execution_candles) < MIN_EXECUTION_BARS:
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: at least 2 closed execution bars are required "
@@ -244,76 +337,128 @@ class BacktestEngine:
             )
         if uses_real_evaluator and self.strategy_type != "orb_fibonacci_pullback":
             hard_minimum = _strategy_history_bars(config, hard_minimum=True)
-            first_event = _candle_close_time(self.execution_candles[0])
-            closed_by_first_event = sum(
-                1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
-            )
+            first_event = self.execution_close_times[0]
+            closed_by_first_event = bisect_right(self.all_close_times, first_event)
             if closed_by_first_event < hard_minimum:
                 deferred_execution_bars = hard_minimum - closed_by_first_event
                 self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                self.execution_start_times = self.execution_start_times[
+                    deferred_execution_bars:
+                ]
+                self.execution_close_times = self.execution_close_times[
+                    deferred_execution_bars:
+                ]
                 if len(self.execution_candles) < MIN_EXECUTION_BARS:
-                    available_closed_bars = sum(
-                        1
-                        for candle in self.all_candles
-                        if _candle_close_time(candle) <= self.settings.end
+                    available_closed_bars = bisect_right(
+                        self.all_close_times,
+                        self.settings.end,
                     )
                     raise InsufficientBacktestDataError(
                         "insufficient_backtest_data: insufficient_strategy_warmup: "
                         f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
                         f"only {available_closed_bars} were available"
                     )
-        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            session_execution_candles = [
-                candle
-                for candle in self.execution_candles
-                if _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
-                )
+        self.execution_in_session = (
+            [
+                self._event_in_configured_session(timestamp)
+                for timestamp in self.execution_start_times
             ]
-            coverage_candles = session_execution_candles or self.execution_candles
+            if self.strategy_type == _TOPBOT_STRATEGY
+            else [True] * len(self.execution_candles)
+        )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            in_session_indexes = [
+                index
+                for index, inside in enumerate(self.execution_in_session)
+                if inside
+            ]
+            first_coverage_index = in_session_indexes[0] if in_session_indexes else 0
+            last_coverage_index = (
+                in_session_indexes[-1]
+                if in_session_indexes
+                else len(self.execution_candles) - 1
+            )
             self.topbot_unavailable_sources = _topbot_unavailable_sources(
                 config,
                 streams=self.topbot_streams,
-                first_event=_candle_close_time(coverage_candles[0]),
-                last_event=_candle_close_time(coverage_candles[-1]),
+                first_event=self.execution_close_times[first_coverage_index],
+                last_event=self.execution_close_times[last_coverage_index],
             )
-        self.evaluator_history_limit = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(config.lookback_bars),
-                _strategy_history_bars(config, hard_minimum=False),
-            ),
+        self.evaluator_history_limit = max(
+            int(config.lookback_bars),
+            _strategy_history_bars(config, hard_minimum=False),
         )
         self.max_evaluator_input_bars = _max_evaluator_input_bars(
             config,
             rolling_limit=self.evaluator_history_limit,
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            signal_evaluation_bars = sum(
-                _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
+            in_session_event_times = [
+                event_time
+                for event_time, inside_session in zip(
+                    self.execution_close_times,
+                    self.execution_in_session,
                 )
-                for candle in self.execution_candles
-            )
-            estimated_operations = _estimate_topbot_evaluator_operations(
+                if inside_session
+            ]
+            source_evaluations = _topbot_cached_source_evaluation_counts(
                 config,
-                execution_bars=signal_evaluation_bars,
+                streams=self.topbot_streams,
+                event_times=in_session_event_times,
+                unavailable_sources=self.topbot_unavailable_sources,
             )
-            operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
+            estimated_evaluator_work = _estimate_topbot_evaluator_operations(
+                config,
+                execution_bars=len(in_session_event_times),
+                source_evaluations=source_evaluations,
+                unavailable_sources=self.topbot_unavailable_sources,
+            )
+        elif self._sma_close_values is not None:
+            estimated_evaluator_work = len(self.execution_candles) * (
+                2 * int(config.fast_period) + 2 * int(config.slow_period)
+            )
         else:
-            estimated_operations = len(self.execution_candles) * min(
-                len(self.all_candles), self.max_evaluator_input_bars
+            estimated_evaluator_work = len(self.execution_candles) * min(
+                len(self.all_candles),
+                self.max_evaluator_input_bars,
             )
-            operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
-        if estimated_operations > operation_limit:
-            raise BacktestConfigurationError(
-                "backtest_computation_limit_exceeded: the complete resolved history and bot "
-                "lookback exceed the current replay resource budget; no partial result was saved; "
-                f"estimated evaluator bar-visits {estimated_operations:,} exceed "
-                f"{operation_limit:,}"
+        _enforce_backtest_work_budget(estimated_evaluator_work)
+
+        replay_row_count = len(self.all_candles)
+        if self.topbot_streams:
+            primary_stream_key = _topbot_asset_stream_key(
+                str(config.timeframe_unit),
+                int(config.timeframe_unit_number),
             )
+            physical_stream_rows: dict[tuple[str, str, str, int], int] = {}
+            logical_stream_rows = 0
+            for key, stream in self.topbot_streams.items():
+                if key == primary_stream_key:
+                    continue
+                physical_stream = getattr(
+                    stream.candles,
+                    "_topsignal_physical_stream",
+                    None,
+                )
+                physical_row_count = getattr(
+                    stream.candles,
+                    "_topsignal_physical_row_count",
+                    None,
+                )
+                if physical_stream is None or physical_row_count is None:
+                    logical_stream_rows += len(stream.candles)
+                    continue
+                physical_stream_rows[physical_stream] = max(
+                    physical_stream_rows.get(physical_stream, 0),
+                    int(physical_row_count),
+                )
+            replay_row_count += logical_stream_rows + sum(
+                physical_stream_rows.values()
+            )
+        _enforce_backtest_resource_budget(
+            replay_rows=replay_row_count,
+            execution_rows=len(self.execution_candles),
+        )
 
         self.warnings: list[str] = []
         if excluded_partial:
@@ -351,7 +496,8 @@ class BacktestEngine:
                 "unrealized_pnl": 0.0,
             }
         ]
-        self.exposed_bar_indexes: set[int] = set()
+        self.exposed_bar_count = 0
+        self._current_bar_exposed = False
         self.daily_entry_counts: dict[Any, int] = defaultdict(int)
         self.daily_net_activity: dict[Any, float] = defaultdict(float)
         self.last_loss_at: datetime | None = None
@@ -362,45 +508,53 @@ class BacktestEngine:
         self.topbot_source_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 
     def run(self) -> dict[str, Any]:
-        closed_history: list[ProjectXMarketCandle] = []
+        closed_history: list[ProjectXMarketCandle] = (
+            _ClosedCandleList() if self._uses_real_evaluator else []
+        )
         history_cursor = 0
-        for index, candle in enumerate(self.execution_candles):
-            candle_start = _as_utc(candle.candle_timestamp)
-            event_time = _candle_close_time(candle)
+        timeline = zip(
+            self.execution_candles,
+            self.execution_start_times,
+            self.execution_close_times,
+            self.execution_in_session,
+        )
+        for index, (candle, candle_start, event_time, inside_session) in enumerate(
+            timeline
+        ):
+            self._current_bar_exposed = False
+            self._current_event_timestamp = candle_start
+            self._current_event_in_session = inside_session
 
             counted_position = self.position
             if counted_position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 counted_position.bars_held += 1
                 self._process_open_gap(candle)
 
             if self.pending is not None:
                 pending = self.pending
                 self.pending = None
-                self._fill_pending_signal(pending, candle=candle, bar_index=index)
+                self._fill_pending_signal(pending, candle=candle)
 
             if self.position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 if self.position is not counted_position:
                     self.position.bars_held += 1
                 self._process_intrabar_bracket(candle)
 
             while (
                 history_cursor < len(self.all_candles)
-                and _candle_close_time(self.all_candles[history_cursor]) <= event_time
+                and self.all_close_times[history_cursor] <= event_time
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
-            if (
-                self.strategy_type == _TOPBOT_STRATEGY
-                and not _event_timestamp_is_in_configured_session(
-                    self.config,
-                    candle_start,
-                )
-            ):
+            if self.strategy_type == _TOPBOT_STRATEGY and not inside_session:
                 self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
                 continue
-            signal = self.signal_evaluator(self._evaluator_input(closed_history))
+            if self._sma_close_values is not None:
+                signal = self._evaluate_prepared_sma(history_cursor)
+            else:
+                signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
             if signal.action in {"BUY", "SELL"}:
@@ -431,7 +585,7 @@ class BacktestEngine:
 
         if self.position is not None and self.settings.force_close_at_end:
             final_candle = self.execution_candles[-1]
-            final_time = _candle_close_time(final_candle)
+            final_time = self.execution_close_times[-1]
             self._update_excursion(float(final_candle.close_price), float(final_candle.close_price))
             self._close_position(
                 raw_exit_price=float(final_candle.close_price),
@@ -450,12 +604,14 @@ class BacktestEngine:
             self.trades,
             equity_curve=self.equity_curve,
             drawdown_series=drawdown_series,
-            exposure_percent=(len(self.exposed_bar_indexes) / len(self.execution_candles) * 100.0),
+            exposure_percent=(
+                self.exposed_bar_count / len(self.execution_candles) * 100.0
+            ),
         )
         return {
             "range": {
-                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
-                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
+                "start": self.execution_start_times[0].isoformat(),
+                "end": self.execution_close_times[-1].isoformat(),
                 "bar_count": len(self.execution_candles),
                 "contract_id": str(self.execution_candles[0].contract_id),
                 "symbol": self.execution_candles[0].symbol or self.config.symbol,
@@ -473,6 +629,142 @@ class BacktestEngine:
             "warnings": self.warnings,
         }
 
+    def _prepare_topbot_runtime(self) -> None:
+        self._topbot_params = bot_service_module._normalize_strategy_params(
+            _TOPBOT_STRATEGY,
+            self.config.strategy_params,
+        )
+        source_overrides = self._topbot_params.get("source_strategy_params") or {}
+        self._topbot_source_static_errors: dict[str, str] = {}
+        self._topbot_generic_args: dict[str, dict[str, Any]] = {}
+        self._topbot_primary_limits: dict[str, int] = {}
+        for source_strategy in self._topbot_params["source_strategies"]:
+            source_params = bot_service_module._normalize_strategy_params(
+                source_strategy,
+                source_overrides.get(source_strategy, {}),
+            )
+            self._topbot_source_params[source_strategy] = source_params
+            self._topbot_source_keys[source_strategy] = tuple(
+                _topbot_source_stream_keys(
+                    self.config,
+                    source_strategy,
+                    source_params=source_params,
+                )
+            )
+            fast_period, slow_period = (
+                bot_service_module._normalized_strategy_period_values(
+                    source_strategy,
+                    fast_period=int(self.config.fast_period),
+                    slow_period=int(self.config.slow_period),
+                )
+            )
+            source_config = _SourceConfigView(
+                self.config,
+                strategy_type=source_strategy,
+                strategy_params=source_params,
+                fast_period=fast_period,
+                slow_period=slow_period,
+            )
+            self._topbot_source_configs[source_strategy] = source_config
+            self._topbot_primary_limits[source_strategy] = (
+                _topbot_primary_source_history_limit(
+                    self.config,
+                    source_strategy,
+                )
+            )
+            if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
+                self._topbot_generic_args[source_strategy] = (
+                    _generic_evaluator_arguments(
+                        source_strategy,
+                        config=source_config,
+                        strategy_params=source_params,
+                    )
+                )
+            try:
+                bot_service_module._validate_strategy_configuration(
+                    strategy_type=source_strategy,
+                    timeframe_unit=str(source_config.timeframe_unit),
+                    timeframe_unit_number=int(source_config.timeframe_unit_number),
+                    fast_period=fast_period,
+                    slow_period=slow_period,
+                )
+            except Exception as exc:
+                self._topbot_source_static_errors[source_strategy] = str(exc)
+
+    def _event_in_configured_session(self, event_timestamp: datetime) -> bool:
+        timestamp = _as_utc(event_timestamp)
+        if self._current_event_timestamp == timestamp:
+            return self._current_event_in_session
+        if not futures_session_is_open(timestamp):
+            return False
+        local_time = timestamp.astimezone(TRADING_TZ).time().replace(tzinfo=None)
+        start = self._configured_session_start
+        end = self._configured_session_end
+        if start <= end:
+            return start <= local_time <= end
+        return local_time >= start or local_time <= end
+
+    def _evaluate_prepared_sma(self, closed_count: int) -> SignalResult:
+        closes = self._sma_close_values
+        assert closes is not None
+        fast_period = int(self.config.fast_period)
+        slow_period = int(self.config.slow_period)
+        visible_count = min(closed_count, self.evaluator_history_limit)
+        latest_index = closed_count - 1
+        latest = self.all_candles[latest_index]
+        if visible_count < slow_period + 1:
+            return SignalResult(
+                action="HOLD",
+                reason=(
+                    f"Need at least {slow_period + 1} closed candles; "
+                    f"found {visible_count}."
+                ),
+                candle_timestamp=self.all_start_times[latest_index],
+                price=float(latest.close_price),
+                raw_payload={
+                    "fast_period": fast_period,
+                    "slow_period": slow_period,
+                    "closed_count": visible_count,
+                },
+            )
+
+        previous_fast = bot_service_module._average(
+            closes[closed_count - fast_period - 1 : closed_count - 1]
+        )
+        previous_slow = bot_service_module._average(
+            closes[closed_count - slow_period - 1 : closed_count - 1]
+        )
+        current_fast = bot_service_module._average(
+            closes[closed_count - fast_period : closed_count]
+        )
+        current_slow = bot_service_module._average(
+            closes[closed_count - slow_period : closed_count]
+        )
+        action = "HOLD"
+        if previous_fast <= previous_slow and current_fast > current_slow:
+            action = "BUY"
+        elif previous_fast >= previous_slow and current_fast < current_slow:
+            action = "SELL"
+        reason = (
+            "No SMA crossover on the latest closed candle."
+            if action == "HOLD"
+            else f"{fast_period}/{slow_period} SMA crossover generated {action}."
+        )
+        return SignalResult(
+            action=action,
+            reason=reason,
+            candle_timestamp=self.all_start_times[latest_index],
+            price=float(latest.close_price),
+            raw_payload={
+                "fast_period": fast_period,
+                "slow_period": slow_period,
+                "previous_fast": previous_fast,
+                "previous_slow": previous_slow,
+                "current_fast": current_fast,
+                "current_slow": current_slow,
+            },
+        )
+
     def _record_topbot_source_failures(self, signal: SignalResult) -> None:
         payload = signal.raw_payload if isinstance(signal.raw_payload, dict) else {}
         ensemble = payload.get("ensemble") if isinstance(payload.get("ensemble"), dict) else {}
@@ -489,7 +781,7 @@ class BacktestEngine:
         closed_history: list[ProjectXMarketCandle],
     ) -> list[ProjectXMarketCandle]:
         if not closed_history:
-            return []
+            return _ClosedCandleList()
         latest_timestamp = _as_utc(closed_history[-1].candle_timestamp)
         rolling_start = max(0, len(closed_history) - self.evaluator_history_limit)
 
@@ -500,11 +792,11 @@ class BacktestEngine:
                 end_text=str(self.config.trading_end_time),
             )
             if latest_timestamp < session_start:
-                return []
+                return _ClosedCandleList()
             if latest_timestamp > session_end:
-                return []
+                return _ClosedCandleList()
             session_start_index = _first_index_at_or_after(closed_history, session_start)
-            session_rows = closed_history[session_start_index:]
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
                 session_rows,
                 expected_start=session_start,
@@ -525,8 +817,9 @@ class BacktestEngine:
                 trading_day_date(latest_timestamp)
             )
             session_start_index = _first_index_at_or_after(closed_history, session_start)
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
-                closed_history[session_start_index:],
+                session_rows,
                 expected_start=session_start,
                 strategy_type=self.strategy_type,
                 enforce=_is_intraday_timeframe(self.config),
@@ -535,9 +828,12 @@ class BacktestEngine:
                     int(self.config.timeframe_unit_number),
                 ),
             )
-            return closed_history[min(rolling_start, session_start_index) :]
+            return _closed_candle_slice(
+                closed_history,
+                min(rolling_start, session_start_index),
+            )
 
-        return closed_history[rolling_start:]
+        return _closed_candle_slice(closed_history, rolling_start)
 
     def _evaluate_real_strategy(self, candles: list[ProjectXMarketCandle]) -> SignalResult:
         params = self.config.strategy_params
@@ -592,21 +888,14 @@ class BacktestEngine:
                 strategy_params=self.config.strategy_params,
             )
         event_time = _candle_close_time(primary_candles[-1])
-        topbot_params = bot_service_module._normalize_strategy_params(
-            _TOPBOT_STRATEGY,
-            self.config.strategy_params,
-        )
-        source_overrides = topbot_params.get("source_strategy_params") or {}
+        topbot_params = self._topbot_params
         source_results: list[dict[str, Any]] = []
         event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
             if source_strategy in self.topbot_unavailable_sources:
                 continue
-            source_params = bot_service_module._normalize_strategy_params(
-                source_strategy,
-                source_overrides.get(source_strategy, {}),
-            )
+            source_params = self._topbot_source_params[source_strategy]
             signature = self._topbot_source_cache_signature(
                 source_strategy,
                 source_params=source_params,
@@ -651,13 +940,8 @@ class BacktestEngine:
         event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
-        for key in _topbot_source_stream_keys(
-            self.config,
-            source_strategy,
-            source_params=source_params,
-        ):
-            stream = self.topbot_streams.get(key)
-            closed_count = bisect_right(stream.close_times, event_time) if stream is not None else 0
+        for key in self._topbot_source_keys[source_strategy]:
+            closed_count = self._topbot_closed_count(key, event_time)
             signature.append((key, closed_count))
         if source_strategy == "donchian_breakout":
             if self.position is None:
@@ -689,34 +973,18 @@ class BacktestEngine:
         event_time: datetime,
         event_timestamp: datetime,
     ) -> dict[str, Any]:
-        fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
-            source_strategy,
-            fast_period=int(self.config.fast_period),
-            slow_period=int(self.config.slow_period),
-        )
-        source_config = _SourceConfigView(
-            self.config,
-            strategy_type=source_strategy,
-            strategy_params=source_params,
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
-        bot_service_module._validate_strategy_configuration(
-            strategy_type=source_strategy,
-            timeframe_unit=str(source_config.timeframe_unit),
-            timeframe_unit_number=int(source_config.timeframe_unit_number),
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
+        static_error = self._topbot_source_static_errors.get(source_strategy)
+        if static_error is not None:
+            raise ValueError(static_error)
+        source_config = self._topbot_source_configs[source_strategy]
+        fast_period = int(source_config.fast_period)
+        slow_period = int(source_config.slow_period)
 
         primary_key = _topbot_asset_stream_key(
             str(self.config.timeframe_unit),
             int(self.config.timeframe_unit_number),
         )
-        primary_limit = _topbot_primary_source_history_limit(
-            self.config,
-            source_strategy,
-        )
+        primary_limit = self._topbot_primary_limits[source_strategy]
 
         if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
             source_candles = self._topbot_stream_history(
@@ -742,11 +1010,7 @@ class BacktestEngine:
             signal = bot_service_module.dispatch_strategy_evaluator(
                 source_strategy,
                 source_candles,
-                **_generic_evaluator_arguments(
-                    source_strategy,
-                    config=source_config,
-                    strategy_params=source_params,
-                ),
+                **self._topbot_generic_args[source_strategy],
             )
         elif source_strategy == "donchian_breakout":
             source_candles = self._topbot_stream_history(
@@ -789,10 +1053,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -802,7 +1063,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     _topbot_asset_stream_key("minute", 1),
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit="minute",
+                        unit_number=1,
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -830,10 +1095,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -843,7 +1105,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     primary_key,
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit=str(self.config.timeframe_unit),
+                        unit_number=int(self.config.timeframe_unit_number),
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -874,14 +1140,11 @@ class BacktestEngine:
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(self.config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            limit = max(
+                int(self.config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             source_candles = self._topbot_stream_history(
                 _topbot_asset_stream_key("minute", 5),
@@ -1041,21 +1304,49 @@ class BacktestEngine:
         stream = self.topbot_streams.get(key)
         if stream is None or not stream.candles:
             raise ValueError(f"missing_stored_replay_stream:{key}")
-        end_index = bisect_right(stream.close_times, _as_utc(event_time))
+        event_utc = _as_utc(event_time)
+        if self._topbot_history_event != event_utc:
+            self._topbot_history_event = event_utc
+            self._topbot_history_cache.clear()
+        normalized_not_before = _as_utc(not_before) if not_before is not None else None
+        cache_key = (key, max(1, int(limit)), normalized_not_before)
+        cached = self._topbot_history_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        end_index = self._topbot_closed_count(key, event_utc)
         start_index = max(0, end_index - max(1, int(limit)))
-        if not_before is not None:
+        if normalized_not_before is not None:
             start_index = max(
                 start_index,
-                bisect_left(stream.start_times, _as_utc(not_before)),
+                bisect_left(stream.start_times, normalized_not_before),
             )
-        return stream.candles[start_index:end_index]
+        history = _closed_candle_slice(stream.candles, start_index, end_index)
+        self._topbot_history_cache[cache_key] = history
+        return history
+
+    def _topbot_closed_count(self, key: str, event_time: datetime) -> int:
+        stream = self.topbot_streams.get(key)
+        if stream is None:
+            return 0
+        event_utc = _as_utc(event_time)
+        previous_event, count = self._topbot_cursor_state.get(
+            key,
+            (datetime.min.replace(tzinfo=timezone.utc), 0),
+        )
+        if event_utc < previous_event:
+            count = bisect_right(stream.close_times, event_utc)
+        elif event_utc > previous_event:
+            while count < len(stream.close_times) and stream.close_times[count] <= event_utc:
+                count += 1
+        self._topbot_cursor_state[key] = (event_utc, count)
+        return count
 
     def _fill_pending_signal(
         self,
         pending: _PendingSignal,
         *,
         candle: ProjectXMarketCandle,
-        bar_index: int,
     ) -> None:
         fill_time = _as_utc(candle.candle_timestamp)
         if not _signal_fill_is_in_same_session(
@@ -1071,7 +1362,7 @@ class BacktestEngine:
         is_exit_only = signal_category == "exit"
 
         if self.position is not None and self.position.side != desired_side:
-            self.exposed_bar_indexes.add(bar_index)
+            self._current_bar_exposed = True
             self._update_excursion(float(candle.open_price), float(candle.open_price))
             exit_reason = str(pending.payload.get("exit_reason") or "position_reversal")
             self._close_position(
@@ -1136,7 +1427,7 @@ class BacktestEngine:
             stop_loss=stop_loss,
             take_profit=take_profit,
         )
-        self.exposed_bar_indexes.add(bar_index)
+        self._current_bar_exposed = True
 
     def _can_enter(self, timestamp: datetime) -> bool:
         if not _contract_is_allowed(self.config):
@@ -1330,6 +1621,8 @@ class BacktestEngine:
         return float(raw + slip if action == "BUY" else raw - slip)
 
     def _record_equity(self, *, event_time: datetime, mark_price: float) -> None:
+        if self._current_bar_exposed:
+            self.exposed_bar_count += 1
         unrealized = 0.0
         if self.position is not None:
             unrealized = _price_pnl(
@@ -1363,18 +1656,13 @@ class BacktestEngine:
             self.equity_curve.append(point)
 
     def _add_data_quality_warnings(self) -> None:
-        warmup_count = sum(
-            1
-            for row in self.all_candles
-            if _as_utc(row.candle_timestamp) < self.settings.start
-            and _candle_close_time(row) <= _candle_close_time(self.execution_candles[0])
+        warmup_count = min(
+            bisect_left(self.all_start_times, self.settings.start),
+            bisect_right(self.all_close_times, self.execution_close_times[0]),
         )
-        requested_warmup = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(self.config.lookback_bars),
-                _strategy_history_bars(self.config, hard_minimum=False),
-            ),
+        requested_warmup = max(
+            int(self.config.lookback_bars),
+            _strategy_history_bars(self.config, hard_minimum=False),
         )
         if self.strategy_type == _TOPBOT_STRATEGY:
             primary_key = _topbot_asset_stream_key(
@@ -1397,8 +1685,8 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
-            actual_end = _candle_close_time(self.execution_candles[-1])
+            actual_start = self.execution_start_times[0]
+            actual_end = self.execution_close_times[-1]
             if _has_open_futures_interval(
                 self.settings.start,
                 actual_start,
@@ -1430,7 +1718,7 @@ class BacktestEngine:
                 str(self.config.timeframe_unit),
                 int(self.config.timeframe_unit_number),
             )
-            first_event = _candle_close_time(self.execution_candles[0])
+            first_event = self.execution_close_times[0]
             for key, spec in sorted(_topbot_stream_specs(self.config).items()):
                 if key == primary_key:
                     continue
@@ -1512,9 +1800,9 @@ def _topbot_primary_source_history_limit(config: BotConfig, source_strategy: str
         int(config.timeframe_unit_number),
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return limit
     session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-    return min(MAX_BACKTEST_BARS, max(limit, session_capacity))
+    return max(limit, session_capacity)
 
 
 def _topbot_configured_session_capacity(
@@ -1525,7 +1813,7 @@ def _topbot_configured_session_capacity(
 ) -> int:
     timeframe_seconds = _timeframe_seconds(unit, unit_number)
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return max(1, int(config.lookback_bars))
     start = _parse_time(str(config.trading_start_time))
     end = _parse_time(str(config.trading_end_time))
     start_seconds = start.hour * 3600 + start.minute * 60 + start.second
@@ -1533,26 +1821,20 @@ def _topbot_configured_session_capacity(
     duration = end_seconds - start_seconds
     if duration < 0:
         duration += 24 * 60 * 60
-    return min(
-        MAX_BACKTEST_BARS,
-        max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2),
-    )
+    return max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2)
 
 
 def _relative_strength_spy_history_limit(
     config: BotConfig,
     source_params: Mapping[str, Any],
 ) -> int:
-    return min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            int(source_params["comparison_bars"]) + 1,
-            int(source_params["pullback_lookback_bars"]) + 1,
-            int(source_params["relative_volume_period"]) + 1,
-            int(source_params["major_level_lookback_bars"]),
-            50,
-        ),
+    return max(
+        int(config.lookback_bars),
+        int(source_params["comparison_bars"]) + 1,
+        int(source_params["pullback_lookback_bars"]) + 1,
+        int(source_params["relative_volume_period"]) + 1,
+        int(source_params["major_level_lookback_bars"]),
+        50,
     )
 
 
@@ -1634,14 +1916,11 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            opening_limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            opening_limit = max(
+                int(config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             add_asset("minute", 5, opening_limit)
         elif source_strategy == "delayed_orb_confirmation":
@@ -1787,9 +2066,16 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    _copy_closed_candle_metadata(candles, closed)
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     contract_ids: set[str] = set()
@@ -1926,46 +2212,112 @@ def _prepared_stream_covers_replay_window(
     return True
 
 
-def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: int) -> int:
+def _topbot_cached_source_evaluation_counts(
+    config: BotConfig,
+    *,
+    streams: Mapping[str, _PreparedReplayStream],
+    event_times: list[datetime],
+    unavailable_sources: Mapping[str, tuple[str, ...]],
+) -> dict[str, int]:
+    """Count source evaluations after unchanged synchronized states are cached."""
+
+    if not event_times:
+        return {}
     params = bot_service_module._normalize_strategy_params(
         _TOPBOT_STRATEGY,
         config.strategy_params,
     )
     overrides = params.get("source_strategy_params") or {}
-    per_event = 0
+    counts_by_keys: dict[tuple[str, ...], int] = {}
+    source_counts: dict[str, int] = {}
     for source in params["source_strategies"]:
+        if source in unavailable_sources:
+            continue
         source_params = bot_service_module._normalize_strategy_params(
             source,
             overrides.get(source, {}),
         )
+        if source in {"delayed_orb_confirmation", "donchian_breakout"}:
+            # These signatures include the primary event or mutable position.
+            source_counts[source] = len(event_times)
+            continue
+        keys = _topbot_source_stream_keys(
+            config,
+            source,
+            source_params=source_params,
+        )
+        cached_count = counts_by_keys.get(keys)
+        if cached_count is None:
+            cursors = [0] * len(keys)
+            previous_signature: tuple[int, ...] | None = None
+            cached_count = 0
+            for event_time in event_times:
+                signature: list[int] = []
+                for index, key in enumerate(keys):
+                    stream = streams.get(key)
+                    close_times = stream.close_times if stream is not None else []
+                    cursor = cursors[index]
+                    while cursor < len(close_times) and close_times[cursor] <= event_time:
+                        cursor += 1
+                    cursors[index] = cursor
+                    signature.append(cursor)
+                current_signature = tuple(signature)
+                if current_signature != previous_signature:
+                    cached_count += 1
+                    previous_signature = current_signature
+            counts_by_keys[keys] = cached_count
+        source_counts[source] = cached_count
+    return source_counts
+
+
+def _estimate_topbot_evaluator_operations(
+    config: BotConfig,
+    *,
+    execution_bars: int,
+    source_evaluations: Mapping[str, int] | None = None,
+    unavailable_sources: Mapping[str, tuple[str, ...]] | None = None,
+) -> int:
+    params = bot_service_module._normalize_strategy_params(
+        _TOPBOT_STRATEGY,
+        config.strategy_params,
+    )
+    overrides = params.get("source_strategy_params") or {}
+    # The ensemble vote still runs on every in-session primary event, even
+    # when every source result is cached or unavailable.
+    estimated = max(0, execution_bars) * max(1, len(params["source_strategies"]))
+    for source in params["source_strategies"]:
+        if unavailable_sources is not None and source in unavailable_sources:
+            continue
+        source_params = bot_service_module._normalize_strategy_params(
+            source,
+            overrides.get(source, {}),
+        )
+        source_cost = 0
         if source in _TOPBOT_SHARED_CONFIGURED_STRATEGIES or source == "donchian_breakout":
-            per_event += _topbot_primary_source_history_limit(config, source)
+            source_cost += _topbot_primary_source_history_limit(config, source)
         elif source in _TOPBOT_LEVEL_STRATEGIES:
-            per_event += int(source_params["bars_per_timeframe"]) * 2
+            source_cost += int(source_params["bars_per_timeframe"]) * 2
         elif source == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_days = max(lookback_days + 14, 21)
-            per_event += min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            source_cost += max(
+                int(config.lookback_bars),
+                (calendar_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
         elif source == "delayed_orb_confirmation":
-            per_event += 1500
+            source_cost += 1500
         elif source == "orb_fibonacci_pullback":
             timeframe_seconds = _timeframe_seconds(
                 str(config.timeframe_unit),
                 int(config.timeframe_unit_number),
             ) or 60
-            per_event += max(1, math.ceil((25 * 60 * 60) / timeframe_seconds))
+            source_cost += max(1, math.ceil((25 * 60 * 60) / timeframe_seconds))
         elif source == "vwap_gap_retrace":
-            per_event += int(source_params["bars_to_fetch"])
+            source_cost += int(source_params["bars_to_fetch"])
         elif source == "supertrend_pivot":
-            per_event += max(
+            source_cost += max(
                 int(config.lookback_bars),
                 int(source_params["supertrend_period"])
                 + int(source_params["chop_lookback_bars"])
@@ -1983,17 +2335,29 @@ def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: 
             ) or 1
             structure_seconds = _timeframe_seconds(unit, unit_number) or 1
             ratio = max(1, int(round(base_seconds / structure_seconds)))
-            per_event += fvg_limit + min(5000, max(fvg_limit * ratio, fvg_limit + 25))
+            source_cost += fvg_limit + min(
+                5000,
+                max(fvg_limit * ratio, fvg_limit + 25),
+            )
         elif source == "atr_adjusted_relative_strength":
-            per_event += _topbot_primary_source_history_limit(
+            source_cost += _topbot_primary_source_history_limit(
                 config,
                 source,
             ) + max(25, int(config.lookback_bars))
         elif source == "relative_strength_spy":
-            per_event += _relative_strength_spy_history_limit(config, source_params) * 2
+            source_cost += _relative_strength_spy_history_limit(
+                config,
+                source_params,
+            ) * 2
         else:
-            per_event += _topbot_primary_source_history_limit(config, source)
-    return execution_bars * max(1, per_event)
+            source_cost += _topbot_primary_source_history_limit(config, source)
+        evaluation_count = (
+            int(source_evaluations.get(source, execution_bars))
+            if source_evaluations is not None
+            else execution_bars
+        )
+        estimated += max(0, evaluation_count) * max(1, source_cost)
+    return estimated
 
 
 def _load_topbot_replay_streams(
@@ -2010,13 +2374,42 @@ def _load_topbot_replay_streams(
         int(config.timeframe_unit_number),
     )
     streams: dict[str, list[ProjectXMarketCandle]] = {primary_key: primary_rows}
+    specs = _topbot_stream_specs(config)
     total_rows = len(primary_rows)
+    replay_start = _as_utc(start)
+    replay_end = _as_utc(end)
+    primary_execution_count = 0
+    primary_index = _first_index_at_or_after(primary_rows, replay_start)
+    while (
+        primary_index < len(primary_rows)
+        and _candle_close_time(primary_rows[primary_index]) <= replay_end
+    ):
+        primary_execution_count += 1
+        primary_index += 1
 
-    for key, spec in _topbot_stream_specs(config).items():
+    def stream_identity(spec: _TopBotReplayStreamSpec) -> tuple[str, str, str, int]:
+        if spec.contract_id is not None:
+            return ("contract", spec.contract_id, spec.unit, spec.unit_number)
+        return ("symbol", str(spec.symbol or ""), spec.unit, spec.unit_number)
+
+    specs_by_identity: dict[
+        tuple[str, str, str, int],
+        list[tuple[str, _TopBotReplayStreamSpec]],
+    ] = {}
+    for key, spec in specs.items():
         if key == primary_key:
             continue
+        identity = stream_identity(spec)
+        specs_by_identity.setdefault(identity, []).append((key, spec))
+
+    for identity, grouped_specs in specs_by_identity.items():
+        spec = grouped_specs[0][1]
+        max_warmup_bars = max(
+            int(grouped_spec.warmup_bars)
+            for _grouped_key, grouped_spec in grouped_specs
+        )
         query = (
-            db.query(ProjectXMarketCandle)
+            _projected_candle_query(db)
             .filter(ProjectXMarketCandle.user_id == user_id)
             .filter(ProjectXMarketCandle.live.is_(False))
             .filter(ProjectXMarketCandle.unit == spec.unit)
@@ -2033,37 +2426,49 @@ def _load_topbot_replay_streams(
                 )
             )
 
-        execution_rows = (
+        execution_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp >= start)
             .filter(ProjectXMarketCandle.candle_timestamp <= end)
             .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-            .limit(MAX_TOPBOT_REPLAY_STREAM_BARS + 1)
-            .all()
+        )
+        execution_rows = _collect_projected_candles(
+            execution_query,
+            reserved_replay_rows=total_rows,
+            reserved_execution_rows=primary_execution_count,
         )
         execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-        if len(execution_rows) > MAX_TOPBOT_REPLAY_STREAM_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_stream_bar_limit_exceeded: "
-                f"{key} exceeds {MAX_TOPBOT_REPLAY_STREAM_BARS:,} bars; reduce the date range"
-            )
-        warmup_rows = (
+        warmup_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
             # One candle can start before the requested range while closing
             # after the first replay event. Overfetch it so the requested
             # number of genuinely closed warmup bars remains available.
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
-            .all()
+            .limit(max(1, max_warmup_bars + 1))
+        )
+        warmup_rows = _collect_projected_candles(
+            warmup_query,
+            reserved_replay_rows=total_rows + len(execution_rows),
+            reserved_execution_rows=primary_execution_count,
         )
         warmup_rows.reverse()
-        rows = [*warmup_rows, *execution_rows]
-        streams[key] = rows
-        total_rows += len(rows)
-        if total_rows > MAX_TOPBOT_REPLAY_TOTAL_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_total_bar_limit_exceeded: synchronized streams contain "
-                f"more than {MAX_TOPBOT_REPLAY_TOTAL_BARS:,} bars; reduce the date range"
+        physical_row_count = len(warmup_rows) + len(execution_rows)
+        total_rows += physical_row_count
+        _enforce_backtest_resource_budget(
+            replay_rows=total_rows,
+            execution_rows=primary_execution_count,
+        )
+
+        # Query one physical stream once, but preserve the historical per-key
+        # warmup window.  That keeps persisted fingerprints byte-for-byte
+        # compatible while sharing the projected candle objects in memory.
+        for key, grouped_spec in grouped_specs:
+            requested_warmup = max(1, int(grouped_spec.warmup_bars) + 1)
+            rows = _PhysicalReplayList(
+                [*warmup_rows[-requested_warmup:], *execution_rows]
             )
+            rows._topsignal_physical_stream = identity
+            rows._topsignal_physical_row_count = physical_row_count
+            streams[key] = rows
 
     return streams
 
@@ -2126,22 +2531,13 @@ def prepare_bot_backtest_data(
         elif int(spec.warmup_bars) > existing[2]:
             requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
 
-    primary_execution_rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    primary_execution_rows = _load_primary_candle_range(
+        db,
+        user_id=user_id,
+        config=config,
+        start_at=start,
+        closed_by=fetch_end,
     )
-    primary_execution_rows = [
-        row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
-    ]
     first_event = (
         _candle_close_time(primary_execution_rows[0])
         if primary_execution_rows
@@ -2192,6 +2588,7 @@ def prepare_bot_backtest_data(
             first_event=first_event,
             last_event=last_event,
             warmup_bars=warmup_bars,
+            reserved_replay_rows=len(primary_execution_rows),
         ):
             continue
         cursor = fetch_start
@@ -2221,22 +2618,13 @@ def prepare_bot_backtest_data(
         prepared_count += 1
 
         if identity == primary_identity:
-            primary_execution_rows = (
-                db.query(ProjectXMarketCandle)
-                .filter(ProjectXMarketCandle.user_id == user_id)
-                .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-                .filter(ProjectXMarketCandle.live.is_(False))
-                .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-                .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-                .filter(ProjectXMarketCandle.is_partial.is_(False))
-                .filter(ProjectXMarketCandle.candle_timestamp >= start)
-                .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
-                .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-                .all()
+            primary_execution_rows = _load_primary_candle_range(
+                db,
+                user_id=user_id,
+                config=config,
+                start_at=start,
+                closed_by=fetch_end,
             )
-            primary_execution_rows = [
-                row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
-            ]
             if primary_execution_rows:
                 first_event = _candle_close_time(primary_execution_rows[0])
                 last_event = _candle_close_time(primary_execution_rows[-1])
@@ -2256,12 +2644,13 @@ def _cached_replay_stream_covers(
     first_event: datetime,
     last_event: datetime,
     warmup_bars: int,
+    reserved_replay_rows: int = 0,
 ) -> bool:
     interval_seconds = _timeframe_seconds(unit, unit_number)
     if interval_seconds is None:
         return False
-    rows = (
-        db.query(ProjectXMarketCandle)
+    query = (
+        _projected_candle_query(db)
         .filter(ProjectXMarketCandle.user_id == user_id)
         .filter(ProjectXMarketCandle.contract_id == contract_id)
         .filter(ProjectXMarketCandle.live.is_(False))
@@ -2271,23 +2660,27 @@ def _cached_replay_stream_covers(
         .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
         .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
         .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    )
+    rows = _collect_projected_candles(
+        query,
+        reserved_replay_rows=reserved_replay_rows,
     )
     if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
         return False
     if _candle_stream_has_overlaps(rows):
         return False
-    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
-    warmup_count = sum(
-        _as_utc(row.candle_timestamp) < requested_start
-        for row in closed_by_first
-    )
+    close_times = [_candle_close_time(row) for row in rows]
+    start_times = [_as_utc(row.candle_timestamp) for row in rows]
+    first_end = bisect_right(close_times, first_event)
+    last_end = bisect_right(close_times, last_event)
+    closed_by_first = rows[:first_end]
+    warmup_count = min(first_end, bisect_left(start_times, requested_start))
     if warmup_count < max(1, int(warmup_bars)):
         return False
 
     for event, candidates in (
         (first_event, closed_by_first),
-        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+        (last_event, rows[:last_end]),
     ):
         if not candidates:
             return False
@@ -2336,6 +2729,85 @@ def run_backtest(
     ).run()
 
 
+def _projected_candle_query(db: Session):
+    """Select only replay fields, avoiding ORM identity-map materialization."""
+
+    return db.query(
+        ProjectXMarketCandle.user_id,
+        ProjectXMarketCandle.contract_id,
+        ProjectXMarketCandle.symbol,
+        ProjectXMarketCandle.live,
+        ProjectXMarketCandle.unit,
+        ProjectXMarketCandle.unit_number,
+        ProjectXMarketCandle.candle_timestamp,
+        ProjectXMarketCandle.open_price,
+        ProjectXMarketCandle.high_price,
+        ProjectXMarketCandle.low_price,
+        ProjectXMarketCandle.close_price,
+        ProjectXMarketCandle.volume,
+        ProjectXMarketCandle.is_partial,
+        ProjectXMarketCandle.raw_payload,
+        ProjectXMarketCandle.fetched_at,
+    )
+
+
+def _collect_projected_candles(
+    query: Any,
+    *,
+    reserved_replay_rows: int = 0,
+    reserved_execution_rows: int = 0,
+) -> list[ProjectXMarketCandle]:
+    rows: list[ProjectXMarketCandle] = []
+    for values in query.yield_per(CANDLE_QUERY_CHUNK_SIZE):
+        rows.append(_ProjectedCandle(*values))
+        if len(rows) % CANDLE_QUERY_CHUNK_SIZE == 0:
+            _enforce_backtest_resource_budget(
+                replay_rows=reserved_replay_rows + len(rows),
+                execution_rows=reserved_execution_rows,
+            )
+    # Enforce the final partial chunk too.  This is also the only check for
+    # small queries, which must not allocate on top of an exhausted budget.
+    _enforce_backtest_resource_budget(
+        replay_rows=reserved_replay_rows + len(rows),
+        execution_rows=reserved_execution_rows,
+    )
+    return rows
+
+
+def _load_primary_candle_range(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    closed_by: datetime,
+    start_at: datetime | None = None,
+) -> _ClosedCandleList:
+    cutoff = _as_utc(closed_by)
+    query = (
+        _projected_candle_query(db)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
+    )
+    if start_at is not None:
+        query = query.filter(
+            ProjectXMarketCandle.candle_timestamp >= _as_utc(start_at)
+        )
+    rows = _collect_projected_candles(
+        query.order_by(ProjectXMarketCandle.candle_timestamp.asc())
+    )
+    return _ClosedCandleList(
+        row
+        for row in rows
+        if not _cached_candle_is_effectively_partial(row)
+        and _candle_close_time(row) <= cutoff
+    )
+
+
 def _load_primary_closed_candles(
     db: Session,
     *,
@@ -2345,25 +2817,12 @@ def _load_primary_closed_candles(
 ) -> list[ProjectXMarketCandle]:
     """Load every eligible primary bar without rolling across futures deliveries."""
 
-    cutoff = _as_utc(closed_by)
-    rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    return _load_primary_candle_range(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=closed_by,
     )
-    return [
-        row
-        for row in rows
-        if not _cached_candle_is_effectively_partial(row)
-        and _candle_close_time(row) <= cutoff
-    ]
 
 
 def _requested_backtest_bounds(payload: Any) -> tuple[datetime, datetime] | None:
@@ -2661,19 +3120,21 @@ def create_bot_backtest(
         )
         window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
 
-    execution_rows = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) >= window.start
-        and _candle_close_time(row) <= window.end
+    primary_start_times = [
+        _as_utc(row.candle_timestamp) for row in primary_rows
     ]
+    primary_close_times = [_candle_close_time(row) for row in primary_rows]
+    execution_start_index = bisect_left(primary_start_times, window.start)
+    execution_end_index = bisect_right(primary_close_times, window.end)
+    execution_rows = _closed_candle_slice(
+        primary_rows,
+        execution_start_index,
+        execution_end_index,
+    )
 
-    rolling_warmup_limit = min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            _strategy_history_bars(config, hard_minimum=False),
-        ),
+    rolling_warmup_limit = max(
+        int(config.lookback_bars),
+        _strategy_history_bars(config, hard_minimum=False),
     )
     if is_topbot:
         primary_key = _topbot_asset_stream_key(
@@ -2681,21 +3142,22 @@ def create_bot_backtest(
             int(config.timeframe_unit_number),
         )
         primary_spec = _topbot_stream_specs(config)[primary_key]
-        rolling_warmup_limit = min(
-            MAX_BACKTEST_BARS,
-            max(rolling_warmup_limit, primary_spec.warmup_bars),
+        rolling_warmup_limit = max(
+            rolling_warmup_limit,
+            primary_spec.warmup_bars,
         )
     warmup_limit = _max_evaluator_input_bars(
         config,
         rolling_limit=rolling_warmup_limit,
     )
-    warmup_candidates = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) < window.start
-    ]
-    warmup_rows = warmup_candidates[-warmup_limit:]
-    replay_rows = [*warmup_rows, *execution_rows]
+    warmup_start_index = max(0, execution_start_index - warmup_limit)
+    warmup_rows = _closed_candle_slice(
+        primary_rows,
+        warmup_start_index,
+        execution_start_index,
+    )
+    replay_rows = _ClosedCandleList(warmup_rows)
+    replay_rows.extend(execution_rows)
     replay_streams: dict[str, list[ProjectXMarketCandle]] | None = None
     if is_topbot:
         replay_streams = _load_topbot_replay_streams(
@@ -2772,7 +3234,12 @@ def serialize_bot_backtest(row: BotBacktest) -> dict[str, Any]:
 
 
 def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
-    canonical = [
+    ordered = (
+        candles
+        if getattr(candles, "_topsignal_sorted_closed", False)
+        else sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+    )
+    return _incremental_candle_fingerprint(
         {
             "contract_id": str(row.contract_id),
             "live": bool(row.live),
@@ -2786,37 +3253,60 @@ def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
             "volume": str(row.volume),
             "is_partial": bool(row.is_partial),
         }
-        for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+        for row in ordered
         if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    )
 
 
 def candle_stream_input_fingerprint(
     streams: Mapping[str, list[ProjectXMarketCandle]],
 ) -> str:
-    canonical = [
-        {
-            "stream": key,
-            "contract_id": str(row.contract_id),
-            "live": bool(row.live),
-            "unit": str(row.unit),
-            "unit_number": int(row.unit_number),
-            "timestamp": _as_utc(row.candle_timestamp).isoformat(),
-            "open": str(row.open_price),
-            "high": str(row.high_price),
-            "low": str(row.low_price),
-            "close": str(row.close_price),
-            "volume": str(row.volume),
-            "is_partial": bool(row.is_partial),
-        }
-        for key in sorted(streams)
-        for row in sorted(streams[key], key=lambda candle: _as_utc(candle.candle_timestamp))
-        if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    def canonical_rows() -> Iterable[dict[str, Any]]:
+        for key in sorted(streams):
+            candles = streams[key]
+            ordered = (
+                candles
+                if getattr(candles, "_topsignal_sorted_closed", False)
+                else sorted(
+                    candles,
+                    key=lambda candle: _as_utc(candle.candle_timestamp),
+                )
+            )
+            for row in ordered:
+                if bool(row.is_partial):
+                    continue
+                yield {
+                    "stream": key,
+                    "contract_id": str(row.contract_id),
+                    "live": bool(row.live),
+                    "unit": str(row.unit),
+                    "unit_number": int(row.unit_number),
+                    "timestamp": _as_utc(row.candle_timestamp).isoformat(),
+                    "open": str(row.open_price),
+                    "high": str(row.high_price),
+                    "low": str(row.low_price),
+                    "close": str(row.close_price),
+                    "volume": str(row.volume),
+                    "is_partial": bool(row.is_partial),
+                }
+
+    return _incremental_candle_fingerprint(canonical_rows())
+
+
+def _incremental_candle_fingerprint(rows: Iterable[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first = True
+    for row in rows:
+        if first:
+            first = False
+        else:
+            digest.update(b",")
+        digest.update(
+            json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
+    digest.update(b"]")
+    return digest.hexdigest()
 
 
 def _require_supported_strategy(strategy_type: str) -> None:
@@ -2871,6 +3361,62 @@ def _contract_is_allowed(config: BotConfig) -> bool:
     return bool(allowed.intersection(candidates))
 
 
+def _closed_candle_slice(
+    candles: list[ProjectXMarketCandle],
+    start: int,
+    end: int | None = None,
+) -> list[ProjectXMarketCandle]:
+    sliced = candles[start:end]
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        return _ClosedCandleList(sliced)
+    return sliced
+
+
+def _copy_closed_candle_metadata(
+    source: list[ProjectXMarketCandle],
+    target: _ClosedCandleList,
+) -> None:
+    physical_stream = getattr(source, "_topsignal_physical_stream", None)
+    physical_row_count = getattr(source, "_topsignal_physical_row_count", None)
+    if physical_stream is not None and physical_row_count is not None:
+        target._topsignal_physical_stream = physical_stream
+        target._topsignal_physical_row_count = int(physical_row_count)
+
+
+def _enforce_backtest_resource_budget(
+    *,
+    replay_rows: int,
+    execution_rows: int,
+) -> None:
+    budget = max(1, int(BACKTEST_MEMORY_BUDGET_BYTES))
+    estimated = (
+        max(0, int(replay_rows)) * ESTIMATED_REPLAY_CANDLE_BYTES
+        + max(0, int(execution_rows)) * ESTIMATED_EXECUTION_RESULT_BYTES
+    )
+    if estimated <= budget:
+        return
+    estimated_mib = math.ceil(estimated / (1024 * 1024))
+    budget_mib = max(1, budget // (1024 * 1024))
+    raise BacktestConfigurationError(
+        "backtest_resource_budget_exceeded: the complete resolved history requires "
+        f"an estimated {estimated_mib:,} MiB, above the configured {budget_mib:,} MiB "
+        "working-set budget; no partial result was saved"
+    )
+
+
+def _enforce_backtest_work_budget(estimated_evaluator_bar_visits: int) -> None:
+    budget = max(1, int(BACKTEST_EVALUATOR_WORK_BUDGET))
+    estimated = max(0, int(estimated_evaluator_bar_visits))
+    if estimated <= budget:
+        return
+    raise BacktestConfigurationError(
+        "backtest_computation_limit_exceeded: the complete resolved history and "
+        "strategy lookback require an estimated "
+        f"{estimated:,} evaluator bar-visits, above the configured {budget:,} "
+        "work budget; no partial result was saved"
+    )
+
+
 def _validate_settings(settings: BacktestSettings) -> BacktestSettings:
     normalized = BacktestSettings(
         start=_as_utc(settings.start),
@@ -2900,9 +3446,16 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    _copy_closed_candle_metadata(candles, closed)
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     for row in closed:
@@ -3447,11 +4000,11 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
         str(config.timeframe_unit), int(config.timeframe_unit_number)
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return rolling_limit
     if str(config.strategy_type) in _TRADING_DAY_VWAP_STRATEGIES:
         # A New York trading day spans 25 real hours across the fall DST change.
         session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(rolling_limit, session_capacity))
+        return max(rolling_limit, session_capacity)
     if str(config.strategy_type) == "orb_fibonacci_pullback":
         start = _parse_time(str(config.trading_start_time))
         end = _parse_time(str(config.trading_end_time))
@@ -3462,7 +4015,7 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
             duration += 24 * 60 * 60
         # Overnight configured windows can also cross a fall DST transition.
         session_capacity = math.ceil((duration + 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(1, session_capacity))
+        return max(1, session_capacity)
     return rolling_limit
 
 

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -2298,8 +2298,11 @@ def evaluate_sma_cross(
     slow_period: int,
 ) -> SignalResult:
     _validate_strategy_periods(fast_period, slow_period)
-    closed = [candle for candle in candles if not bool(candle.is_partial)]
-    closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = candles
+    else:
+        closed = [candle for candle in candles if not bool(candle.is_partial)]
+        closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
     if len(closed) < slow_period + 1:
         return SignalResult(
             action="HOLD",
@@ -8121,6 +8124,8 @@ def _serialize_pivot_level(level: PivotLevel) -> dict[str, Any]:
 
 
 def _closed_candles(candles: list[ProjectXMarketCandle]) -> list[ProjectXMarketCandle]:
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        return candles
     closed = [candle for candle in candles if not bool(candle.is_partial)]
     closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
     return closed

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -2010,3 +2012,774 @@ def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history
         .count()
         == 30
     )
+
+
+def test_prepared_sma_replay_exactly_matches_legacy_evaluator_path():
+    prices = [
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+    ]
+    candles = backtesting_module._ClosedCandleList(
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            open_price=price - 0.25,
+            high_price=price + 0.75,
+            low_price=price - 0.75,
+            close_price=price,
+        )
+        for index, price in enumerate(prices)
+    )
+    config = _config(
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=8,
+        max_trades_per_day=2,
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(candles))
+    run_options = {
+        "config": config,
+        "start": start,
+        "end": end,
+        "starting_balance": 25_000,
+        "commission_per_contract": 1.25,
+        "slippage_ticks": 1.5,
+        "tick_size": 0.25,
+        "tick_value": 0.50,
+    }
+
+    optimized = _run(candles, **run_options)
+    legacy_calls = 0
+
+    def legacy_evaluator(rows: list[ProjectXMarketCandle]) -> SignalResult:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return bot_service_module.evaluate_sma_cross(
+            rows,
+            fast_period=int(config.fast_period),
+            slow_period=int(config.slow_period),
+        )
+
+    legacy = _run(candles, evaluator=legacy_evaluator, **run_options)
+
+    assert legacy_calls == optimized["range"]["bar_count"]
+    assert optimized["trades"]
+    assert any(float(trade["commission"]) > 0 for trade in optimized["trades"])
+    assert any("max trades per day" in warning for warning in optimized["warnings"])
+    for key in (
+        "range",
+        "metrics",
+        "equity_curve",
+        "drawdown_series",
+        "daily_results",
+        "monthly_results",
+        "trades",
+        "warnings",
+    ):
+        assert optimized[key] == legacy[key]
+    assert optimized == legacy
+
+
+def test_incremental_fingerprints_match_legacy_canonical_json_for_unsorted_streams():
+    primary = [
+        _candle(BASE_TIME + timedelta(minutes=10), close_price=103.25),
+        _candle(BASE_TIME, close_price=101.25),
+        _candle(
+            BASE_TIME + timedelta(minutes=5),
+            close_price=102.25,
+            is_partial=True,
+        ),
+    ]
+    hourly = [
+        _candle(
+            BASE_TIME - timedelta(hours=1),
+            unit="hour",
+            unit_number=1,
+            close_price=99.5,
+        ),
+        _candle(
+            BASE_TIME - timedelta(hours=2),
+            unit="hour",
+            unit_number=1,
+            close_price=98.5,
+        ),
+    ]
+    streams = {"z-primary": primary, "a-hourly": hourly}
+
+    def canonical_row(
+        row: ProjectXMarketCandle,
+        *,
+        stream: str | None = None,
+    ) -> dict[str, Any]:
+        canonical = {
+            "contract_id": str(row.contract_id),
+            "live": bool(row.live),
+            "unit": str(row.unit),
+            "unit_number": int(row.unit_number),
+            "timestamp": _utc(row.candle_timestamp).isoformat(),
+            "open": str(row.open_price),
+            "high": str(row.high_price),
+            "low": str(row.low_price),
+            "close": str(row.close_price),
+            "volume": str(row.volume),
+            "is_partial": bool(row.is_partial),
+        }
+        if stream is not None:
+            canonical = {"stream": stream, **canonical}
+        return canonical
+
+    def legacy_digest(rows: list[dict[str, Any]]) -> str:
+        encoded = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return hashlib.sha256(encoded).hexdigest()
+
+    expected_primary = legacy_digest(
+        [
+            canonical_row(row)
+            for row in sorted(primary, key=lambda value: _utc(value.candle_timestamp))
+            if not bool(row.is_partial)
+        ]
+    )
+    expected_streams = legacy_digest(
+        [
+            canonical_row(row, stream=key)
+            for key in sorted(streams)
+            for row in sorted(
+                streams[key],
+                key=lambda value: _utc(value.candle_timestamp),
+            )
+            if not bool(row.is_partial)
+        ]
+    )
+
+    assert backtesting_module.candle_input_fingerprint(primary) == expected_primary
+    assert (
+        backtesting_module.candle_stream_input_fingerprint(streams)
+        == expected_streams
+    )
+
+
+def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
+    bar_count = backtesting_module.MAX_BACKTEST_BARS + 1
+    oldest = BASE_TIME - timedelta(days=400)
+    candles = backtesting_module._ClosedCandleList(
+        [
+            _candle(oldest, close_price=100),
+            *[
+                _candle(
+                    BASE_TIME + timedelta(minutes=5 * index),
+                    close_price=100 + (index % 3),
+                )
+                for index in range(bar_count - 1)
+            ],
+        ]
+    )
+
+    result = _run(candles, evaluator=_hold)
+
+    assert candles[-1].candle_timestamp - candles[0].candle_timestamp > timedelta(
+        days=366
+    )
+    assert result["range"]["bar_count"] == bar_count
+    assert result["range"]["start"] == oldest.isoformat()
+    assert len(result["equity_curve"]) == bar_count + 1
+    assert len(result["drawdown_series"]) == bar_count + 1
+    assert result["metrics"]["trade_count"] == 0
+
+
+def test_resource_budget_failure_occurs_before_backtest_persistence(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+            for index in range(6)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(backtesting_module, "BACKTEST_MEMORY_BUDGET_BYTES", 1)
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_resource_budget_exceeded.*no partial result was saved",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=int(config.id),
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=30),
+            ),
+            now=BASE_TIME + timedelta(minutes=35),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_projected_loader_avoids_candle_identities_and_matches_orm_replay(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=25,
+    )
+    prices = [100, 99, 98, 97, 98, 99, 100, 99, 98, 97, 98, 99]
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                open_price=price - 0.25,
+                close_price=price,
+            )
+            for index, price in enumerate(prices)
+        ]
+    )
+    db_session.commit()
+    config_id = int(config.id)
+    db_session.expunge_all()
+    loaded_config = db_session.query(BotConfig).filter(BotConfig.id == config_id).one()
+
+    projected = backtesting_module._load_primary_closed_candles(
+        db_session,
+        user_id=OWNER_ID,
+        config=loaded_config,
+        closed_by=BASE_TIME + timedelta(minutes=5 * len(prices)),
+    )
+
+    assert projected
+    assert all(type(row) is backtesting_module._ProjectedCandle for row in projected)
+    assert not any(
+        isinstance(value, ProjectXMarketCandle)
+        for value in db_session.identity_map.values()
+    )
+
+    orm_rows = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == OWNER_ID)
+        .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(prices))
+
+    assert backtesting_module.candle_input_fingerprint(
+        projected
+    ) == backtesting_module.candle_input_fingerprint(orm_rows)
+    assert _run(
+        projected,
+        config=loaded_config,
+        start=start,
+        end=end,
+    ) == _run(
+        orm_rows,
+        config=loaded_config,
+        start=start,
+        end=end,
+    )
+
+
+def test_topbot_cached_replay_exactly_matches_legacy_bisect_reference(
+    monkeypatch,
+):
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "support_resistance",
+                "liquidity_sweep_retest",
+            ],
+            "minimum_directional_votes": 1,
+            "minimum_score": 70,
+            "minimum_reward_risk": 1.5,
+        },
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="11:30",
+    )
+    primary = backtesting_module._ClosedCandleList(
+        _candle(
+            session_open + timedelta(minutes=5 * index),
+            open_price=100,
+            high_price=101,
+            low_price=99,
+            close_price=100,
+        )
+        for index in range(-30, 27)
+    )
+    one_hour = backtesting_module._ClosedCandleList(
+        _candle(
+            datetime(2026, 7, 6, hour, tzinfo=timezone.utc),
+            unit="hour",
+            unit_number=1,
+            close_price=100 + hour / 100,
+        )
+        for hour in range(10, 15)
+    )
+    four_hour = backtesting_module._ClosedCandleList(
+        _candle(
+            datetime(2026, 7, 6, hour, tzinfo=timezone.utc),
+            unit="hour",
+            unit_number=4,
+            close_price=100 + hour / 100,
+        )
+        for hour in (6, 10)
+    )
+    active_run = {"name": "optimized"}
+    dispatch_counts = {"optimized": 0, "reference": 0}
+    observed_slow_states: dict[str, set[tuple[datetime, datetime]]] = {
+        "optimized": set(),
+        "reference": set(),
+    }
+
+    def fake_dispatch(identifier, *args, **kwargs):
+        assert identifier in {"support_resistance", "liquidity_sweep_retest"}
+        higher = kwargs["higher_timeframe_candles"]
+        lower = kwargs["lower_timeframe_candles"]
+        latest_higher = _utc(higher[-1].candle_timestamp)
+        latest_lower = _utc(lower[-1].candle_timestamp)
+        run_name = active_run["name"]
+        dispatch_counts[run_name] += 1
+        observed_slow_states[run_name].add((latest_higher, latest_lower))
+        action = "BUY" if latest_lower.hour % 2 == 0 else "SELL"
+        payload = (
+            {"stop_loss": 90.0, "take_profit": 120.0}
+            if action == "BUY"
+            else {"stop_loss": 110.0, "take_profit": 80.0}
+        )
+        return SignalResult(
+            action=action,
+            reason=f"{identifier} synchronized {action.lower()}",
+            candle_timestamp=latest_lower,
+            price=100.0,
+            raw_payload=payload,
+        )
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "build_bot_market_analysis",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "build_signal_trade_evaluation",
+        lambda **_kwargs: {"total_score": 85},
+    )
+    run_options = {
+        "config": config,
+        "start": session_open - timedelta(minutes=10),
+        "end": session_open + timedelta(minutes=130),
+        "commission_per_contract": 1.25,
+        "slippage_ticks": 1,
+        "tick_size": 0.25,
+        "tick_value": 0.50,
+        "replay_streams": {
+            backtesting_module._topbot_asset_stream_key("hour", 1): one_hour,
+            backtesting_module._topbot_asset_stream_key("hour", 4): four_hour,
+        },
+    }
+
+    optimized = _run(primary, **run_options)
+    prepared_streams, _excluded = backtesting_module._prepare_topbot_replay_streams(
+        config,
+        primary_candles=primary,
+        replay_streams=run_options["replay_streams"],
+    )
+    in_session_events = [
+        backtesting_module._candle_close_time(row)
+        for row in primary
+        if run_options["start"] <= _utc(row.candle_timestamp)
+        and backtesting_module._candle_close_time(row) <= run_options["end"]
+        and backtesting_module._event_timestamp_is_in_configured_session(
+            config,
+            row.candle_timestamp,
+        )
+    ]
+    cached_evaluations = (
+        backtesting_module._topbot_cached_source_evaluation_counts(
+            config,
+            streams=prepared_streams,
+            event_times=in_session_events,
+            unavailable_sources={},
+        )
+    )
+    assert cached_evaluations == {
+        "support_resistance": 3,
+        "liquidity_sweep_retest": 3,
+    }
+    assert backtesting_module._estimate_topbot_evaluator_operations(
+        config,
+        execution_bars=len(in_session_events),
+        source_evaluations=cached_evaluations,
+        unavailable_sources={},
+    ) < backtesting_module._estimate_topbot_evaluator_operations(
+        config,
+        execution_bars=len(in_session_events),
+    )
+    optimized_signature = (
+        backtesting_module.BacktestEngine._topbot_source_cache_signature
+    )
+
+    def legacy_closed_count(self, key: str, event_time: datetime) -> int:
+        stream = self.topbot_streams.get(key)
+        if stream is None:
+            return 0
+        return backtesting_module.bisect_right(
+            stream.close_times,
+            _utc(event_time),
+        )
+
+    def legacy_stream_history(
+        self,
+        key: str,
+        *,
+        event_time: datetime,
+        limit: int,
+        not_before: datetime | None = None,
+    ) -> list[ProjectXMarketCandle]:
+        stream = self.topbot_streams.get(key)
+        if stream is None or not stream.candles:
+            raise ValueError(f"missing_stored_replay_stream:{key}")
+        end_index = backtesting_module.bisect_right(
+            stream.close_times,
+            _utc(event_time),
+        )
+        start_index = max(0, end_index - max(1, int(limit)))
+        if not_before is not None:
+            start_index = max(
+                start_index,
+                backtesting_module.bisect_left(
+                    stream.start_times,
+                    _utc(not_before),
+                ),
+            )
+        return backtesting_module._ClosedCandleList(
+            stream.candles[start_index:end_index]
+        )
+
+    def legacy_source_signature(
+        self,
+        source_strategy: str,
+        *,
+        source_params: dict[str, Any],
+        event_time: datetime,
+        event_timestamp: datetime,
+    ) -> tuple[Any, ...]:
+        signature = optimized_signature(
+            self,
+            source_strategy,
+            source_params=source_params,
+            event_time=event_time,
+            event_timestamp=event_timestamp,
+        )
+        return (*signature, ("uncached_primary_event", _utc(event_timestamp)))
+
+    def legacy_session_check(self, event_timestamp: datetime) -> bool:
+        return backtesting_module._event_timestamp_is_in_configured_session(
+            self.config,
+            event_timestamp,
+        )
+
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_closed_count",
+        legacy_closed_count,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_stream_history",
+        legacy_stream_history,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_source_cache_signature",
+        legacy_source_signature,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_event_in_configured_session",
+        legacy_session_check,
+    )
+    active_run["name"] = "reference"
+
+    reference = _run(primary, **run_options)
+
+    assert dispatch_counts == {"optimized": 6, "reference": 50}
+    assert len(observed_slow_states["optimized"]) == 3
+    assert observed_slow_states["optimized"] == observed_slow_states["reference"]
+    assert optimized["trades"]
+    assert optimized["metrics"]["total_commission"] > 0
+    assert optimized == reference
+
+
+def test_donchian_topbot_cache_signature_tracks_position_state():
+    engine = object.__new__(backtesting_module.BacktestEngine)
+    engine._topbot_source_keys = {"donchian_breakout": ()}
+    engine.position = None
+    signature_options = {
+        "source_strategy": "donchian_breakout",
+        "source_params": {},
+        "event_time": BASE_TIME,
+        "event_timestamp": BASE_TIME,
+    }
+
+    flat_signature = engine._topbot_source_cache_signature(**signature_options)
+    engine.position = backtesting_module._OpenTrade(
+        side="long",
+        quantity=2,
+        signal_timestamp=BASE_TIME - timedelta(minutes=5),
+        entry_timestamp=BASE_TIME,
+        entry_price=100,
+        entry_commission=2.50,
+        stop_loss=90,
+        take_profit=120,
+    )
+    long_signature = engine._topbot_source_cache_signature(**signature_options)
+    engine.position.stop_loss = 95
+    adjusted_signature = engine._topbot_source_cache_signature(**signature_options)
+
+    assert flat_signature[-1] == ("position", "flat")
+    assert long_signature[-1][:3] == ("position", "long", 2)
+    assert flat_signature != long_signature
+    assert long_signature != adjusted_signature
+
+
+def test_topbot_loader_shares_one_physical_benchmark_query_group(
+    db_session,
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+    benchmark_contract = "CON.F.US.MES.M26"
+    benchmark_rows = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id=benchmark_contract,
+            symbol="F.US.MES",
+            close_price=5000 + index,
+        )
+        for index in range(-80, 5)
+    ]
+    db_session.add_all(benchmark_rows)
+    db_session.commit()
+    db_session.expunge_all()
+    primary_rows = backtesting_module._ClosedCandleList(
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            close_price=20_000 + index,
+        )
+        for index in range(-25, 4)
+    )
+    projected_query_calls = 0
+    real_projected_query = backtesting_module._projected_candle_query
+
+    def projected_query_spy(db):
+        nonlocal projected_query_calls
+        projected_query_calls += 1
+        return real_projected_query(db)
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_projected_candle_query",
+        projected_query_spy,
+    )
+    start = BASE_TIME
+    end = BASE_TIME + timedelta(minutes=20)
+
+    streams = backtesting_module._load_topbot_replay_streams(
+        db_session,
+        user_id=OWNER_ID,
+        config=config,
+        start=start,
+        end=end,
+        primary_rows=primary_rows,
+    )
+
+    atr_key = backtesting_module._topbot_benchmark_stream_key(
+        "atr_adjusted_relative_strength"
+    )
+    relative_key = backtesting_module._topbot_benchmark_stream_key(
+        "relative_strength_spy"
+    )
+    specs = backtesting_module._topbot_stream_specs(config)
+    assert specs[atr_key].warmup_bars < specs[relative_key].warmup_bars
+    assert projected_query_calls == 1
+    assert streams[atr_key]._topsignal_physical_stream == (
+        "contract",
+        benchmark_contract,
+        "minute",
+        5,
+    )
+    assert (
+        streams[atr_key]._topsignal_physical_stream
+        == streams[relative_key]._topsignal_physical_stream
+    )
+    assert (
+        streams[atr_key]._topsignal_physical_row_count
+        == streams[relative_key]._topsignal_physical_row_count
+    )
+    assert streams[atr_key][-1] is streams[relative_key][-1]
+
+    stored_rows = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.contract_id == benchmark_contract)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    execution_rows = [
+        row
+        for row in stored_rows
+        if _utc(row.candle_timestamp) >= start
+        and _utc(row.candle_timestamp) <= end
+        and backtesting_module._candle_close_time(row) <= end
+    ]
+    max_warmup = max(specs[atr_key].warmup_bars, specs[relative_key].warmup_bars)
+    physical_warmup = [
+        row for row in stored_rows if _utc(row.candle_timestamp) < start
+    ][-(max_warmup + 1) :]
+
+    for key in (atr_key, relative_key):
+        expected = [
+            *physical_warmup[-(specs[key].warmup_bars + 1) :],
+            *execution_rows,
+        ]
+        assert [_utc(row.candle_timestamp) for row in streams[key]] == [
+            _utc(row.candle_timestamp) for row in expected
+        ]
+        assert backtesting_module.candle_input_fingerprint(
+            streams[key]
+        ) == backtesting_module.candle_input_fingerprint(expected)
+
+    assert len(streams[atr_key]) < len(streams[relative_key])
+    assert backtesting_module.candle_input_fingerprint(
+        streams[atr_key]
+    ) != backtesting_module.candle_input_fingerprint(streams[relative_key])
+
+
+def test_evaluator_work_budget_failure_occurs_before_backtest_persistence(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+            for index in range(6)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        backtesting_module,
+        "BACKTEST_EVALUATOR_WORK_BUDGET",
+        1,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_computation_limit_exceeded.*no partial result was saved",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=int(config.id),
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=30),
+            ),
+            now=BASE_TIME + timedelta(minutes=35),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_cache_coverage_budget_includes_retained_primary_rows(
+    db_session,
+    monkeypatch,
+):
+    db_session.add(
+        _candle(
+            BASE_TIME - timedelta(hours=1),
+            unit="hour",
+            unit_number=1,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        backtesting_module,
+        "BACKTEST_MEMORY_BUDGET_BYTES",
+        backtesting_module.ESTIMATED_REPLAY_CANDLE_BYTES,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_resource_budget_exceeded",
+    ):
+        backtesting_module._cached_replay_stream_covers(
+            db_session,
+            user_id=OWNER_ID,
+            contract_id=CONTRACT_ID,
+            unit="hour",
+            unit_number=1,
+            fetch_start=BASE_TIME - timedelta(hours=2),
+            requested_start=BASE_TIME,
+            first_event=BASE_TIME,
+            last_event=BASE_TIME,
+            warmup_bars=1,
+            reserved_replay_rows=1,
+        )

--- a/backend/tools/benchmark_backtesting.py
+++ b/backend/tools/benchmark_backtesting.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""Reproducible performance harness for TopSignal's backtest engine.
+
+The timed passes exclude synthetic candle construction, semantic hashing, and
+SQLite setup/seeding.  ``tracemalloc`` is deliberately run in a separate pass
+because its instrumentation materially changes wall-clock timings.
+
+Examples (run from the repository root):
+
+    python backend/tools/benchmark_backtesting.py
+    python backend/tools/benchmark_backtesting.py --bars 20000 50000 --repeats 5
+    python backend/tools/benchmark_backtesting.py --bars 20000 --lookback-bars 200 --fast-period 20 --slow-period 50
+    python backend/tools/benchmark_backtesting.py --bars 5000 --sqlite-public
+    python backend/tools/benchmark_backtesting.py --bars 100 --repeats 1 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import platform
+import statistics
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+BACKEND_ROOT = Path(
+    os.environ.get("TOPSIGNAL_BENCHMARK_BACKEND_ROOT")
+    or Path(__file__).resolve().parents[1]
+).resolve()
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+# App settings require a syntactically valid database URL at import time.  The
+# benchmark's optional database case still creates and owns a separate SQLite
+# engine; it never connects through this setting.
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+OWNER_ID = "11111111-1111-1111-1111-111111111111"
+CONTRACT_ID = "CON.F.US.MNQ.BENCH"
+SYMBOL = "MNQ"
+INTERVAL = timedelta(minutes=5)
+START = datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+FAST_PERIOD = 9
+SLOW_PERIOD = 21
+MINIMUM_BARS = SLOW_PERIOD + 2
+DEFAULT_BARS = 5_000
+DEFAULT_REPEATS = 3
+DEFAULT_WARMUPS = 1
+SEMANTIC_KEYS = (
+    "range",
+    "metrics",
+    "equity_curve",
+    "drawdown_series",
+    "daily_results",
+    "monthly_results",
+    "trades",
+    "warnings",
+)
+
+Result = dict[str, Any]
+Runner = Callable[[], Result]
+
+
+@dataclass(frozen=True)
+class AppApi:
+    """Late-bound application objects so ``--help`` needs only the stdlib."""
+
+    engine_version: str
+    Base: Any
+    BotBacktest: Any
+    BotBacktestIn: Any
+    BotConfig: Any
+    ProjectXMarketCandle: Any
+    SignalResult: Any
+    create_bot_backtest: Callable[..., Any]
+    run_backtest: Callable[..., Result]
+
+
+@dataclass(frozen=True)
+class Observation:
+    seconds: float
+    digest: str
+    output_bars: int
+    trade_count: int
+    warning_count: int
+
+
+@dataclass
+class SqlCounter:
+    """Count statements issued only while one public API sample is running."""
+
+    statements: int = 0
+    selects: int = 0
+    candle_selects: int = 0
+
+    def reset(self) -> None:
+        self.statements = 0
+        self.selects = 0
+        self.candle_selects = 0
+
+    def before_cursor_execute(
+        self,
+        _connection: Any,
+        _cursor: Any,
+        statement: str,
+        _parameters: Any,
+        _context: Any,
+        _executemany: bool,
+    ) -> None:
+        self.statements += 1
+        normalized = " ".join(str(statement).upper().split())
+        is_select = normalized.startswith("SELECT") or normalized.startswith("WITH")
+        if is_select:
+            self.selects += 1
+            if "PROJECTX_MARKET_CANDLES" in normalized:
+                self.candle_selects += 1
+
+    def snapshot(self) -> dict[str, int]:
+        return {
+            "statements": self.statements,
+            "selects": self.selects,
+            "candle_selects": self.candle_selects,
+        }
+
+
+def _load_app_api() -> AppApi:
+    from app.bot_schemas import BotBacktestIn
+    from app.db import Base
+    from app.models import BotBacktest, BotConfig, ProjectXMarketCandle
+    from app.services.bot_backtesting import (
+        BACKTEST_ENGINE_VERSION,
+        create_bot_backtest,
+        run_backtest,
+    )
+    from app.services.bot_service import SignalResult
+
+    return AppApi(
+        engine_version=BACKTEST_ENGINE_VERSION,
+        Base=Base,
+        BotBacktest=BotBacktest,
+        BotBacktestIn=BotBacktestIn,
+        BotConfig=BotConfig,
+        ProjectXMarketCandle=ProjectXMarketCandle,
+        SignalResult=SignalResult,
+        create_bot_backtest=create_bot_backtest,
+        run_backtest=run_backtest,
+    )
+
+
+def _positive_int(text: str) -> int:
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return value
+
+
+def _nonnegative_int(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark deterministic real-SMA and scripted-HOLD backtests. "
+            "Input construction and semantic hashing are excluded from wall timings."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--bars",
+        nargs="+",
+        type=_positive_int,
+        default=[DEFAULT_BARS],
+        metavar="N",
+        help=(
+            f"one or more synthetic input sizes (minimum {MINIMUM_BARS}); "
+            "use 20000 and/or 50000 for full-history scaling runs"
+        ),
+    )
+    parser.add_argument(
+        "--repeats",
+        type=_positive_int,
+        default=DEFAULT_REPEATS,
+        help="timed samples per case",
+    )
+    parser.add_argument(
+        "--warmups",
+        type=_nonnegative_int,
+        default=DEFAULT_WARMUPS,
+        help="untimed warmup passes per case",
+    )
+    parser.add_argument(
+        "--case",
+        choices=("all", "sma", "hold"),
+        default="all",
+        help="engine-only case selection",
+    )
+    parser.add_argument(
+        "--lookback-bars",
+        type=_positive_int,
+        default=25,
+        help="configured rolling evaluator history",
+    )
+    parser.add_argument(
+        "--fast-period",
+        type=_positive_int,
+        default=FAST_PERIOD,
+        help="SMA fast period",
+    )
+    parser.add_argument(
+        "--slow-period",
+        type=_positive_int,
+        default=SLOW_PERIOD,
+        help="SMA slow period",
+    )
+    parser.add_argument(
+        "--sqlite-public",
+        action="store_true",
+        help=(
+            "also exercise create_bot_backtest through an in-memory SQLite database "
+            "and report SQL/candle SELECT counts"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the text summary",
+    )
+    return parser
+
+
+def _config(
+    api: AppApi,
+    *,
+    persisted: bool,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> Any:
+    return api.BotConfig(
+        id=None if persisted else 1,
+        user_id=OWNER_ID,
+        account_id=9001,
+        name="Backtest benchmark",
+        provider="projectx",
+        enabled=False,
+        execution_mode="dry_run",
+        strategy_type="sma_cross",
+        strategy_params={},
+        contract_id=CONTRACT_ID,
+        symbol=SYMBOL,
+        timeframe_unit="minute",
+        timeframe_unit_number=5,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+        order_size=2,
+        max_contracts=10,
+        max_daily_loss=1_000_000,
+        max_trades_per_day=10_000,
+        max_open_position=10,
+        allowed_contracts=[CONTRACT_ID],
+        trading_start_time="00:00",
+        trading_end_time="23:59",
+        cooldown_seconds=0,
+        max_data_staleness_seconds=3_600,
+        allow_market_depth=False,
+    )
+
+
+def _generate_candles(api: AppApi, bar_count: int) -> list[Any]:
+    """Build tick-aligned candles using integer arithmetic only."""
+
+    candles: list[Any] = []
+    previous_close_ticks = 40_000
+    for index in range(bar_count):
+        phase = index % 80
+        triangle = phase if phase <= 40 else 80 - phase
+        wave_ticks = (triangle - 20) * 3
+        drift_ticks = (index // 240) % 20
+        close_ticks = 40_000 + wave_ticks + drift_ticks
+        open_ticks = previous_close_ticks + ((index % 3) - 1)
+        wick_ticks = 2 + (index % 4)
+        high_ticks = max(open_ticks, close_ticks) + wick_ticks
+        low_ticks = min(open_ticks, close_ticks) - wick_ticks
+        timestamp = START + INTERVAL * index
+        candles.append(
+            api.ProjectXMarketCandle(
+                user_id=OWNER_ID,
+                contract_id=CONTRACT_ID,
+                symbol=SYMBOL,
+                live=False,
+                unit="minute",
+                unit_number=5,
+                candle_timestamp=timestamp,
+                open_price=open_ticks * 0.25,
+                high_price=high_ticks * 0.25,
+                low_price=low_ticks * 0.25,
+                close_price=close_ticks * 0.25,
+                volume=100 + ((index * 37) % 900),
+                is_partial=False,
+                source="benchmark",
+                raw_payload=None,
+                fetched_at=timestamp + INTERVAL,
+            )
+        )
+        previous_close_ticks = close_ticks
+    return candles
+
+
+def _scripted_hold(api: AppApi) -> Callable[[list[Any]], Any]:
+    def evaluate(candles: list[Any]) -> Any:
+        latest = candles[-1]
+        timestamp = latest.candle_timestamp
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        else:
+            timestamp = timestamp.astimezone(timezone.utc)
+        return api.SignalResult(
+            action="HOLD",
+            reason="deterministic benchmark hold",
+            candle_timestamp=timestamp,
+            price=float(latest.close_price),
+            raw_payload={"benchmark_case": "scripted_hold"},
+        )
+
+    return evaluate
+
+
+def _direct_runner(
+    api: AppApi,
+    candles: list[Any],
+    *,
+    scripted_hold: bool,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> Runner:
+    config = _config(
+        api,
+        persisted=False,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+    )
+    start = candles[0].candle_timestamp
+    end = candles[-1].candle_timestamp + INTERVAL
+    evaluator = _scripted_hold(api) if scripted_hold else None
+
+    def run() -> Result:
+        return api.run_backtest(
+            config=config,
+            candles=candles,
+            start=start,
+            end=end,
+            starting_balance=50_000,
+            commission_per_contract=1.25,
+            slippage_ticks=1,
+            tick_size=0.25,
+            tick_value=0.50,
+            force_close_at_end=True,
+            signal_evaluator=evaluator,
+        )
+
+    return run
+
+
+def _semantic_json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        normalized = (
+            value.replace(tzinfo=timezone.utc)
+            if value.tzinfo is None
+            else value.astimezone(timezone.utc)
+        )
+        return normalized.isoformat()
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    raise TypeError(f"unsupported semantic value: {type(value).__name__}")
+
+
+def _semantic_digest(result: Result) -> str:
+    missing = [key for key in SEMANTIC_KEYS if key not in result]
+    if missing:
+        raise KeyError(f"backtest result is missing semantic fields: {', '.join(missing)}")
+    semantic = {key: result[key] for key in SEMANTIC_KEYS}
+    canonical = json.dumps(
+        semantic,
+        allow_nan=False,
+        default=_semantic_json_default,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _observe(result: Result, seconds: float) -> Observation:
+    result_range = result.get("range") if isinstance(result.get("range"), dict) else {}
+    metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+    warnings = result.get("warnings") if isinstance(result.get("warnings"), list) else []
+    return Observation(
+        seconds=seconds,
+        digest=_semantic_digest(result),
+        output_bars=int(result_range.get("bar_count", 0)),
+        trade_count=int(metrics.get("trade_count", 0)),
+        warning_count=len(warnings),
+    )
+
+
+def _assert_equivalent(name: str, observations: Sequence[Observation]) -> Observation:
+    if not observations:
+        raise RuntimeError(f"{name}: benchmark produced no observations")
+    reference = observations[0]
+    for observation in observations[1:]:
+        if observation.digest != reference.digest:
+            raise RuntimeError(
+                f"{name}: semantic hash changed between benchmark passes "
+                f"({reference.digest} != {observation.digest})"
+            )
+        if (
+            observation.output_bars,
+            observation.trade_count,
+            observation.warning_count,
+        ) != (
+            reference.output_bars,
+            reference.trade_count,
+            reference.warning_count,
+        ):
+            raise RuntimeError(f"{name}: result summary changed between benchmark passes")
+    return reference
+
+
+def _distribution(values: Sequence[float | int]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("cannot summarize an empty distribution")
+    return {
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def _benchmark_runner(
+    *,
+    name: str,
+    input_bars: int,
+    runner: Runner,
+    repeats: int,
+    warmups: int,
+    sql_counter: SqlCounter | None = None,
+) -> dict[str, Any]:
+    observations: list[Observation] = []
+    sql_samples: list[dict[str, int]] = []
+
+    for _ in range(warmups):
+        gc.collect()
+        if sql_counter is not None:
+            sql_counter.reset()
+        observations.append(_observe(runner(), seconds=0.0))
+
+    timed: list[Observation] = []
+    for _ in range(repeats):
+        gc.collect()
+        if sql_counter is not None:
+            sql_counter.reset()
+        started = time.perf_counter()
+        result = runner()
+        elapsed = time.perf_counter() - started
+        if sql_counter is not None:
+            sql_samples.append(sql_counter.snapshot())
+        observation = _observe(result, seconds=elapsed)
+        observations.append(observation)
+        timed.append(observation)
+
+    # This is intentionally not a timed sample.  Starting tracemalloc only
+    # after input construction reports incremental engine/public-path memory.
+    gc.collect()
+    if sql_counter is not None:
+        sql_counter.reset()
+    tracemalloc.start()
+    try:
+        memory_result = runner()
+        _current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    memory_sql = sql_counter.snapshot() if sql_counter is not None else None
+    memory_observation = _observe(memory_result, seconds=0.0)
+    observations.append(memory_observation)
+
+    reference = _assert_equivalent(name, observations)
+    wall_samples = [observation.seconds for observation in timed]
+    wall = _distribution(wall_samples)
+    output: dict[str, Any] = {
+        "name": name,
+        "input_bars": input_bars,
+        "output_bars": reference.output_bars,
+        "trade_count": reference.trade_count,
+        "warning_count": reference.warning_count,
+        "warmups": warmups,
+        "timed_repeats": repeats,
+        "wall_seconds": {
+            "median": round(float(wall["median"]), 9),
+            "min": round(float(wall["min"]), 9),
+            "max": round(float(wall["max"]), 9),
+            "samples": [round(value, 9) for value in wall_samples],
+        },
+        "median_seconds_per_1000_input_bars": round(
+            float(wall["median"]) * 1_000 / input_bars,
+            9,
+        ),
+        "tracemalloc_peak_bytes": peak_bytes,
+        "tracemalloc_peak_mib": round(peak_bytes / (1024 * 1024), 3),
+        "semantic_sha256": reference.digest,
+        "semantic_fields": list(SEMANTIC_KEYS),
+    }
+    if sql_counter is not None:
+        output["sql_counts"] = {
+            "timed_samples": sql_samples,
+            "statements": _distribution(
+                [sample["statements"] for sample in sql_samples]
+            ),
+            "selects": _distribution([sample["selects"] for sample in sql_samples]),
+            "candle_selects": _distribution(
+                [sample["candle_selects"] for sample in sql_samples]
+            ),
+            "memory_pass": memory_sql,
+        }
+    return output
+
+
+def _candle_mapping(candle: Any) -> dict[str, Any]:
+    return {
+        "user_id": candle.user_id,
+        "contract_id": candle.contract_id,
+        "symbol": candle.symbol,
+        "live": candle.live,
+        "unit": candle.unit,
+        "unit_number": candle.unit_number,
+        "candle_timestamp": candle.candle_timestamp,
+        "open_price": candle.open_price,
+        "high_price": candle.high_price,
+        "low_price": candle.low_price,
+        "close_price": candle.close_price,
+        "volume": candle.volume,
+        "is_partial": candle.is_partial,
+        "source": candle.source,
+        "raw_payload": candle.raw_payload,
+        "fetched_at": candle.fetched_at,
+    }
+
+
+def _sqlite_public_runner(
+    api: AppApi,
+    candles: list[Any],
+    *,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> tuple[Runner, SqlCounter, Callable[[], None]]:
+    """Create a seeded SQLite session; setup work is outside all samples."""
+
+    from sqlalchemy import create_engine, event
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [
+        api.BotConfig.__table__,
+        api.ProjectXMarketCandle.__table__,
+        api.BotBacktest.__table__,
+    ]
+    api.Base.metadata.create_all(bind=engine, tables=tables)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = SessionLocal()
+    config = _config(
+        api,
+        persisted=True,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+    )
+    session.add(config)
+    session.flush()
+    config_id = int(config.id)
+
+    insert_candle = api.ProjectXMarketCandle.__table__.insert()
+    chunk_size = 1_000
+    for offset in range(0, len(candles), chunk_size):
+        stop = min(len(candles), offset + chunk_size)
+        batch = [_candle_mapping(candles[index]) for index in range(offset, stop)]
+        session.execute(insert_candle, batch)
+    session.commit()
+
+    payload = api.BotBacktestIn(
+        starting_balance=50_000,
+        commission_per_contract=1.25,
+        slippage_ticks=1,
+        force_close_at_end=True,
+    )
+    captured_now = candles[-1].candle_timestamp + INTERVAL
+    counter = SqlCounter()
+    event.listen(engine, "before_cursor_execute", counter.before_cursor_execute)
+
+    def run() -> Result:
+        row = api.create_bot_backtest(
+            session,
+            user_id=OWNER_ID,
+            bot_config_id=config_id,
+            payload=payload,
+            now=captured_now,
+        )
+        return row.result_snapshot
+
+    def close() -> None:
+        event.remove(engine, "before_cursor_execute", counter.before_cursor_execute)
+        session.close()
+        api.Base.metadata.drop_all(bind=engine, tables=reversed(tables))
+        engine.dispose()
+
+    return run, counter, close
+
+
+def _unique_bar_counts(values: Sequence[int]) -> list[int]:
+    output: list[int] = []
+    for value in values:
+        if value not in output:
+            output.append(value)
+    return output
+
+
+def _run_benchmarks(args: argparse.Namespace) -> dict[str, Any]:
+    api = _load_app_api()
+    cases: list[dict[str, Any]] = []
+    bar_counts = _unique_bar_counts(args.bars)
+    for bar_count in bar_counts:
+        candles = _generate_candles(api, bar_count)
+        if args.case in {"all", "sma"}:
+            cases.append(
+                _benchmark_runner(
+                    name="direct_real_sma",
+                    input_bars=bar_count,
+                    runner=_direct_runner(
+                        api,
+                        candles,
+                        scripted_hold=False,
+                        lookback_bars=args.lookback_bars,
+                        fast_period=args.fast_period,
+                        slow_period=args.slow_period,
+                    ),
+                    repeats=args.repeats,
+                    warmups=args.warmups,
+                )
+            )
+        if args.case in {"all", "hold"}:
+            cases.append(
+                _benchmark_runner(
+                    name="direct_scripted_hold",
+                    input_bars=bar_count,
+                    runner=_direct_runner(
+                        api,
+                        candles,
+                        scripted_hold=True,
+                        lookback_bars=args.lookback_bars,
+                        fast_period=args.fast_period,
+                        slow_period=args.slow_period,
+                    ),
+                    repeats=args.repeats,
+                    warmups=args.warmups,
+                )
+            )
+        if args.sqlite_public:
+            runner, counter, close = _sqlite_public_runner(
+                api,
+                candles,
+                lookback_bars=args.lookback_bars,
+                fast_period=args.fast_period,
+                slow_period=args.slow_period,
+            )
+            try:
+                cases.append(
+                    _benchmark_runner(
+                        name="sqlite_public_create_bot_backtest_sma",
+                        input_bars=bar_count,
+                        runner=runner,
+                        repeats=args.repeats,
+                        warmups=args.warmups,
+                        sql_counter=counter,
+                    )
+                )
+            finally:
+                close()
+
+    return {
+        "benchmark": "topsignal_backtest_engine",
+        "backend_root": str(BACKEND_ROOT),
+        "engine_version": api.engine_version,
+        "python": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "timer": "time.perf_counter wall seconds",
+        "methodology": {
+            "deterministic_input": (
+                "five-minute tick-aligned triangular price series; integer construction"
+            ),
+            "excluded_from_wall_time": [
+                "synthetic candle generation",
+                "garbage collection immediately before each sample",
+                "semantic SHA256 serialization",
+                "SQLite schema creation and candle seeding",
+            ],
+            "memory": (
+                "separate tracemalloc pass; input candles and SQLite seed state pre-exist tracing"
+            ),
+            "semantic_sha256_fields": list(SEMANTIC_KEYS),
+            "strategy_parameters": {
+                "lookback_bars": args.lookback_bars,
+                "fast_period": args.fast_period,
+                "slow_period": args.slow_period,
+            },
+        },
+        "cases": cases,
+    }
+
+
+def _print_text(report: dict[str, Any]) -> None:
+    print("TopSignal backtest benchmark")
+    print(
+        f"engine={report['engine_version']} python={report['python']} "
+        f"implementation={report['python_implementation']}"
+    )
+    print(
+        "wall timings exclude input generation, pre-sample GC, semantic hashing, "
+        "and SQLite setup/seeding"
+    )
+    print("tracemalloc peak comes from a separate, untimed pass")
+    for case in report["cases"]:
+        wall = case["wall_seconds"]
+        print()
+        print(
+            f"{case['name']} bars={case['input_bars']} output_bars={case['output_bars']} "
+            f"trades={case['trade_count']} warnings={case['warning_count']}"
+        )
+        print(
+            "  wall_seconds "
+            f"median={wall['median']:.6f} min={wall['min']:.6f} max={wall['max']:.6f} "
+            f"samples={wall['samples']}"
+        )
+        print(
+            f"  tracemalloc_peak={case['tracemalloc_peak_mib']:.3f} MiB "
+            f"({case['tracemalloc_peak_bytes']} bytes)"
+        )
+        print(f"  semantic_sha256={case['semantic_sha256']}")
+        sql_counts = case.get("sql_counts")
+        if sql_counts is not None:
+            statements = sql_counts["statements"]
+            selects = sql_counts["selects"]
+            candle_selects = sql_counts["candle_selects"]
+            print(
+                "  SQL/sample "
+                f"statements median={statements['median']} min={statements['min']} "
+                f"max={statements['max']}; selects median={selects['median']}; "
+                f"candle_selects median={candle_selects['median']}"
+            )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.fast_period >= args.slow_period:
+        parser.error("--fast-period must be less than --slow-period")
+    minimum_bars = args.slow_period + 2
+    too_small = [value for value in args.bars if value < minimum_bars]
+    if too_small:
+        parser.error(
+            f"--bars must be at least {minimum_bars} for the real SMA warmup; "
+            f"received {', '.join(str(value) for value in too_small)}"
+        )
+    report = _run_benchmarks(args)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace ORM candle materialization with projected, chunked reads and cumulative resource checks
- precompute replay timestamps/session state, add exact SMA fast-path evaluation, and avoid repeated closed-candle sorting
- cache synchronized TopBot stream cursors/history/source results while preserving position-sensitive and session behavior
- remove remaining fixed 20,000-bar replay/evaluator clamps in favor of configurable memory and evaluator-work budgets
- stream candle fingerprints incrementally and add a reproducible benchmark harness

## Why

Full-history backtests repeatedly sorted and rescanned overlapping history, recomputed identical indicator inputs, materialized complete candle ORM entities, and rebuilt synchronized TopBot state on each primary event. That made long histories unnecessarily slow and memory-heavy. Fixed date/bar limits also rejected histories without reflecting their actual resource cost.

This change keeps the public backtest contracts and deterministic results unchanged while bounding memory and computation using measured resource estimates.

## Performance

Measured against `02a659cd61dce93d2a3c9ba74d9982cbafa76fd1` on Python 3.11/Windows with deterministic five-minute candles. Medians use five timed runs after two warmups; candle generation, semantic hashing, pre-sample GC, and SQLite setup are excluded.

| Case | Before | After | Improvement | Peak memory |
| --- | ---: | ---: | ---: | ---: |
| Public `create_bot_backtest`, 20k bars | 3.967s | 1.558s | 2.55x | 82.11 → 46.52 MiB |
| Direct SMA, 20k bars | 1.273s | 0.968s | 1.32x | 14.60 → 13.93 MiB |
| High-lookback SMA, 20k bars | 4.331s | 0.688s | 6.30x | 15.01 → 14.32 MiB |

The public benchmark retained the same four SQL statements, three SELECTs, and one candle SELECT. Before/after semantic SHA-256 values and all 499 trades were identical. A 50,000-bar optimized SMA replay completed in 1.874s with 34.9 MiB peak traced memory.

The TopBot equivalence regression reduced source dispatches from 50 to 6 while retaining an identical complete result.

## Result compatibility

Regression coverage compares the full optimized result against legacy evaluation paths, including:

- trades and fills
- commissions and slippage
- metrics, equity, and drawdown
- daily and monthly results
- warnings and risk blocks
- TopBot synchronized-stream/session behavior
- position-sensitive Donchian cache signatures
- canonical per-stream input fingerprints

Agent 4's contracts remain unchanged: optional paired dates, captured-now boundary, range resolution/provenance fields, exact configured contract/no-roll behavior, single-POST orchestration, fail-before-persist semantics, and no order routing.

## Validation

- `python -m pytest -q` — **489 passed**
- focused backtest suite — **65 passed**
- Python compilation and `git diff --check`
- independent read-only performance/correctness review found no remaining P1 issue

## Files

- `backend/app/services/bot_backtesting.py`
- `backend/app/services/bot_service.py`
- `backend/tests/test_bot_backtesting.py`
- `backend/tools/benchmark_backtesting.py`

## Remaining bottlenecks

Non-SMA evaluators still rebuild some indicator arrays when synchronized state advances. Very long histories also retain linear equity/drawdown result serialization costs, provider latency, and the required primary reload after TopBot auxiliary preparation.
