### PR TITLE
Integrate and harden bot performance improvements

### DIFF
--- a/backend/app/bot_schemas.py
+++ b/backend/app/bot_schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -434,15 +434,38 @@ class BotActivityOut(BaseModel):
 
 
 class BotBacktestIn(BaseModel):
-    start: datetime
-    end: datetime
+    start: datetime | None = None
+    end: datetime | None = None
     starting_balance: float = Field(default=50_000, gt=0, le=1_000_000_000)
     commission_per_contract: float = Field(default=0, ge=0, le=10_000)
     slippage_ticks: float = Field(default=0, ge=0, le=1_000)
     force_close_at_end: bool = True
 
+    @model_validator(mode="after")
+    def validate_optional_range(self):
+        if (self.start is None) != (self.end is None):
+            raise ValueError("backtest start and end must be provided together")
+        if self.start is not None and self.end is not None:
+            start = (
+                self.start.replace(tzinfo=timezone.utc)
+                if self.start.tzinfo is None
+                else self.start.astimezone(timezone.utc)
+            )
+            end = (
+                self.end.replace(tzinfo=timezone.utc)
+                if self.end.tzinfo is None
+                else self.end.astimezone(timezone.utc)
+            )
+            if end <= start:
+                raise ValueError("backtest end must be after start")
+        return self
+
 
 class BotBacktestRangeOut(BaseModel):
+    contract_id: str
+    symbol: str | None = None
+    timeframe_unit: TimeframeUnit
+    timeframe_unit_number: int = Field(gt=0)
     start: datetime
     end: datetime
     bar_count: int = Field(ge=1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -185,10 +185,9 @@ from .services.bot_service import (
     list_market_candles,
     list_bot_configs,
     market_candle_cache_covers_request,
+    market_candle_cache_integrity_report,
     market_candle_cache_needs_refresh,
     market_candle_rows_are_stale,
-    next_market_candle_fetch_start,
-    prune_market_candle_cache_range,
     resolve_market_contract,
     serialize_bot_config,
     serialize_bot_decision,
@@ -1122,11 +1121,11 @@ def get_projectx_market_candles(
     repair: bool = False,
     db: Session = Depends(get_db),
 ):
-    """Serve candles from the per-user cache, fetching from ProjectX when needed.
+    """Serve backend-validated candles, repairing the per-user cache as needed.
 
-    `refresh` forces a full re-fetch and prunes cached rows the provider no longer
-    returns. `repair` also forces a full-window fetch (so interior holes in the
-    cache get backfilled) but merges with existing cache instead of pruning.
+    Integrity repair is automatic. ``repair`` remains a compatibility flag that
+    forces a full-window audit/fetch, while ``refresh`` additionally treats the
+    provider's non-empty response as authoritative for pruning that window.
     """
     user_id = get_authenticated_user_id()
     end_utc = _as_utc(end) if end is not None else datetime.now(timezone.utc)
@@ -1146,11 +1145,21 @@ def get_projectx_market_candles(
             unit=unit,
             unit_number=unit_number,
             limit=limit,
-            include_partial_bar=include_partial_bar,
+            include_partial_bar=True,
         )
-        fallback_candles = cached_candles
-        cached_covers_request = market_candle_cache_covers_request(
+        cached_integrity = market_candle_cache_integrity_report(
             cached_candles,
+            start=start_utc,
+            end=end_utc,
+            unit=unit,
+            unit_number=unit_number,
+            limit=limit,
+            include_partial_bar=include_partial_bar,
+            symbol=requested_symbol,
+        )
+        fallback_candles = list(cached_integrity.valid_rows)
+        cached_covers_request = market_candle_cache_covers_request(
+            list(cached_integrity.valid_rows),
             start=start_utc,
             unit=unit,
             unit_number=unit_number,
@@ -1161,15 +1170,16 @@ def get_projectx_market_candles(
             and not refresh
             and not repair
             and cached_covers_request
+            and cached_integrity.is_complete
             and not market_candle_cache_needs_refresh(
-                cached_candles,
+                list(cached_integrity.valid_rows),
                 end=end_utc,
                 unit=unit,
                 unit_number=unit_number,
                 include_partial_bar=include_partial_bar,
             )
         ):
-            return [serialize_market_candle(row) for row in cached_candles]
+            return [serialize_market_candle(row) for row in cached_integrity.valid_rows]
 
         client = _projectx_client_for_user(db, user_id=user_id)
         resolved_contract_id, resolved_symbol = resolve_market_contract(
@@ -1189,12 +1199,22 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 limit=limit,
-                include_partial_bar=include_partial_bar,
+                include_partial_bar=True,
             )
-            if cached_candles:
-                fallback_candles = cached_candles
-            cached_covers_request = market_candle_cache_covers_request(
+            cached_integrity = market_candle_cache_integrity_report(
                 cached_candles,
+                start=start_utc,
+                end=end_utc,
+                unit=unit,
+                unit_number=unit_number,
+                limit=limit,
+                include_partial_bar=include_partial_bar,
+                symbol=resolved_symbol or requested_symbol,
+            )
+            if cached_integrity.valid_rows:
+                fallback_candles = list(cached_integrity.valid_rows)
+            cached_covers_request = market_candle_cache_covers_request(
+                list(cached_integrity.valid_rows),
                 start=start_utc,
                 unit=unit,
                 unit_number=unit_number,
@@ -1205,28 +1225,18 @@ def get_projectx_market_candles(
                 and not refresh
                 and not repair
                 and cached_covers_request
+                and cached_integrity.is_complete
                 and not market_candle_cache_needs_refresh(
-                    cached_candles,
+                    list(cached_integrity.valid_rows),
                     end=end_utc,
                     unit=unit,
                     unit_number=unit_number,
                     include_partial_bar=include_partial_bar,
                 )
             ):
-                return [serialize_market_candle(row) for row in cached_candles]
+                return [serialize_market_candle(row) for row in cached_integrity.valid_rows]
 
         fetch_start_utc = start_utc
-        # A repair request always fetches the full window so interior cache holes
-        # are refilled; the normal path only extends the cached tail.
-        if cached_candles and not refresh and not repair and cached_covers_request:
-            fetch_start_utc = next_market_candle_fetch_start(
-                cached_candles,
-                start=start_utc,
-                unit=unit,
-                unit_number=unit_number,
-            )
-            if fetch_start_utc > end_utc:
-                return [serialize_market_candle(row) for row in cached_candles]
 
         active_lookup_symbol = requested_symbol or resolved_symbol
         active_contract_fallback_attempted = False
@@ -1259,6 +1269,8 @@ def get_projectx_market_candles(
                 unit_number=unit_number,
                 limit=limit,
                 include_partial_bar=include_partial_bar,
+                force_refresh=refresh,
+                force_full_repair=repair,
             )
 
         if not candles:
@@ -1276,6 +1288,8 @@ def get_projectx_market_candles(
                     unit_number=unit_number,
                     limit=limit,
                     include_partial_bar=include_partial_bar,
+                    force_refresh=refresh,
+                    force_full_repair=repair,
                 )
             except ProjectXClientError:
                 active_contract_fallback_attempted = True
@@ -1294,6 +1308,8 @@ def get_projectx_market_candles(
                         unit_number=unit_number,
                         limit=limit,
                         include_partial_bar=include_partial_bar,
+                        force_refresh=refresh,
+                        force_full_repair=repair,
                     )
                 if not active_candles:
                     raise
@@ -1325,40 +1341,13 @@ def get_projectx_market_candles(
                 unit_number=unit_number,
                 limit=limit,
                 include_partial_bar=include_partial_bar,
+                force_refresh=refresh,
+                force_full_repair=repair,
             )
             if _market_candle_rows_have_newer_tail(active_candles, candles):
                 candles = active_candles
 
-        response_contract_id = str(candles[-1].contract_id) if candles else resolved_contract_id
-        if refresh and not include_partial_bar:
-            prune_contract_id = response_contract_id
-            prune_market_candle_cache_range(
-                db,
-                user_id=user_id,
-                contract_id=prune_contract_id,
-                live=live,
-                start=start_utc,
-                end=end_utc,
-                unit=unit,
-                unit_number=unit_number,
-                keep_timestamps=[row.candle_timestamp for row in candles],
-            )
         db.commit()
-        if cached_candles and not refresh:
-            combined_candles = list_market_candles(
-                db,
-                user_id=user_id,
-                contract_id=response_contract_id,
-                live=live,
-                start=start_utc,
-                end=end_utc,
-                unit=unit,
-                unit_number=unit_number,
-                limit=limit,
-                include_partial_bar=include_partial_bar,
-            )
-            if combined_candles:
-                return [serialize_market_candle(row) for row in combined_candles]
     except ProjectXClientError as exc:
         db.rollback()
         if fallback_candles:
@@ -1403,6 +1392,8 @@ def _fetch_active_symbol_market_candles(
     unit_number: int,
     limit: int,
     include_partial_bar: bool,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
 ) -> list[ProjectXMarketCandle]:
     normalized_symbol = str(lookup_symbol or "").strip()
     if not normalized_symbol or not _looks_like_projectx_contract_id(current_contract_id):
@@ -1441,6 +1432,8 @@ def _fetch_active_symbol_market_candles(
         unit_number=unit_number,
         limit=limit,
         include_partial_bar=include_partial_bar,
+        force_refresh=force_refresh,
+        force_full_repair=force_full_repair,
     )
 
 
@@ -1631,17 +1624,26 @@ def create_trading_bot_backtest(
     payload: BotBacktestIn,
     db: Session = Depends(get_db),
 ):
-    """Replay stored candles without fetching data or invoking any order path."""
+    """Repair stored candles when possible, then replay without any order path."""
 
     user_id = get_authenticated_user_id()
     if bot_config_id <= 0:
         raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
     try:
+        client: ProjectXClient | None = None
+        try:
+            client = _projectx_client_for_user(db, user_id=user_id)
+        except Exception as exc:
+            # A complete local snapshot remains replayable when credentials are
+            # temporarily unavailable. The replay validators still reject bad
+            # or insufficient cached data.
+            logger.warning("Backtest candle repair unavailable; using vetted cache: %s", exc)
         row = create_bot_backtest(
             db,
             user_id=user_id,
             bot_config_id=bot_config_id,
             payload=payload,
+            client=client,
         )
         db.commit()
     except LookupError as exc:
@@ -1656,6 +1658,9 @@ def create_trading_bot_backtest(
     except BacktestError as exc:
         db.rollback()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
     except Exception:
         db.rollback()
         raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1132,6 +1132,7 @@ def get_projectx_market_candles(
     end_utc = _as_utc(end) if end is not None else datetime.now(timezone.utc)
     start_utc = _as_utc(start) if start is not None else end_utc - timedelta(days=5)
     requested_symbol = symbol.strip() if isinstance(symbol, str) and symbol.strip() else None
+    session_symbol = requested_symbol or contract_id
     _validate_time_range(start=start_utc, end=end_utc)
 
     fallback_candles = []
@@ -1155,6 +1156,7 @@ def get_projectx_market_candles(
             unit=unit,
             unit_number=unit_number,
             limit=limit,
+            symbol=session_symbol,
         )
         if (
             cached_candles
@@ -1167,6 +1169,7 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 include_partial_bar=include_partial_bar,
+                symbol=session_symbol,
             )
         ):
             return [serialize_market_candle(row) for row in cached_candles]
@@ -1178,6 +1181,7 @@ def get_projectx_market_candles(
             symbol=requested_symbol,
             live=live,
         )
+        session_symbol = resolved_symbol or requested_symbol or resolved_contract_id
         if resolved_contract_id != contract_id:
             cached_candles = list_market_candles(
                 db,
@@ -1199,6 +1203,7 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 limit=limit,
+                symbol=session_symbol,
             )
             if (
                 cached_candles
@@ -1211,6 +1216,7 @@ def get_projectx_market_candles(
                     unit=unit,
                     unit_number=unit_number,
                     include_partial_bar=include_partial_bar,
+                    symbol=session_symbol,
                 )
             ):
                 return [serialize_market_candle(row) for row in cached_candles]
@@ -1243,6 +1249,7 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 include_partial_bar=include_partial_bar,
+                symbol=session_symbol,
             ),
         ):
             active_contract_lookup_attempted = True
@@ -1310,6 +1317,7 @@ def get_projectx_market_candles(
                 unit=unit,
                 unit_number=unit_number,
                 include_partial_bar=include_partial_bar,
+                symbol=session_symbol,
             )
         ):
             active_candles = _fetch_active_symbol_market_candles(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,6 +207,7 @@ from .services.bot_backtesting import (
     MalformedBacktestDataError,
     UnsupportedBacktestStrategyError,
     create_bot_backtest,
+    prepare_bot_backtest_data,
     serialize_bot_backtest,
 )
 from .services.bot_serialization import serialize_supported_bot_configs
@@ -1615,6 +1616,45 @@ def delete_trading_bot(
     except LookupError as exc:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+    return Response(status_code=204)
+
+
+@app.post(
+    "/api/bots/{bot_config_id}/backtests/prepare",
+    status_code=204,
+)
+def prepare_trading_bot_backtest_data(
+    bot_config_id: int,
+    payload: BotBacktestIn,
+    db: Session = Depends(get_db),
+):
+    """Cache every historical stream required by a deterministic TopBot replay."""
+
+    user_id = get_authenticated_user_id()
+    if bot_config_id <= 0:
+        raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
+    try:
+        client = _projectx_client_for_user(db, user_id=user_id)
+        prepare_bot_backtest_data(
+            db,
+            user_id=user_id,
+            bot_config_id=bot_config_id,
+            payload=payload,
+            client=client,
+        )
+        db.commit()
+    except LookupError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
+    except BacktestError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
         db.rollback()
         raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,7 +207,6 @@ from .services.bot_backtesting import (
     MalformedBacktestDataError,
     UnsupportedBacktestStrategyError,
     create_bot_backtest,
-    prepare_bot_backtest_data,
     serialize_bot_backtest,
 )
 from .services.bot_serialization import serialize_supported_bot_configs
@@ -1623,45 +1622,6 @@ def delete_trading_bot(
 
 
 @app.post(
-    "/api/bots/{bot_config_id}/backtests/prepare",
-    status_code=204,
-)
-def prepare_trading_bot_backtest_data(
-    bot_config_id: int,
-    payload: BotBacktestIn,
-    db: Session = Depends(get_db),
-):
-    """Cache every historical stream required by a deterministic TopBot replay."""
-
-    user_id = get_authenticated_user_id()
-    if bot_config_id <= 0:
-        raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
-    try:
-        client = _projectx_client_for_user(db, user_id=user_id)
-        prepare_bot_backtest_data(
-            db,
-            user_id=user_id,
-            bot_config_id=bot_config_id,
-            payload=payload,
-            client=client,
-        )
-        db.commit()
-    except LookupError as exc:
-        db.rollback()
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProjectXClientError as exc:
-        db.rollback()
-        raise _to_http_exception(exc) from exc
-    except BacktestError as exc:
-        db.rollback()
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception:
-        db.rollback()
-        raise
-    return Response(status_code=204)
-
-
-@app.post(
     "/api/bots/{bot_config_id}/backtests",
     response_model=BotBacktestOut,
     status_code=201,
@@ -1671,19 +1631,31 @@ def create_trading_bot_backtest(
     payload: BotBacktestIn,
     db: Session = Depends(get_db),
 ):
-    """Replay stored candles without fetching data or invoking any order path."""
+    """Prepare required TopBot history, then replay closed candles without routing orders."""
 
     user_id = get_authenticated_user_id()
     if bot_config_id <= 0:
         raise HTTPException(status_code=400, detail="bot_config_id must be a positive integer")
     try:
+        config = get_bot_config(db, user_id=user_id, bot_config_id=bot_config_id)
+        if config is None:
+            raise LookupError("bot_config_not_found")
+        client = (
+            _projectx_client_for_user(db, user_id=user_id)
+            if str(config.strategy_type) == "topbot_adaptive"
+            else None
+        )
         row = create_bot_backtest(
             db,
             user_id=user_id,
             bot_config_id=bot_config_id,
             payload=payload,
+            client=client,
         )
         db.commit()
+    except ProjectXClientError as exc:
+        db.rollback()
+        raise _to_http_exception(exc) from exc
     except LookupError as exc:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1126,8 +1126,8 @@ def get_projectx_market_candles(
     """Serve candles from the per-user cache, fetching from ProjectX when needed.
 
     `refresh` forces a full re-fetch and prunes cached rows the provider no longer
-    returns. `repair` also forces a full-window fetch (so interior holes in the
-    cache get backfilled) but merges with existing cache instead of pruning.
+    returns. Open-session holes are repaired automatically. `repair` remains an
+    explicit full-window merge for callers that want to revalidate every row.
     """
     user_id = get_authenticated_user_id()
     end_utc = _as_utc(end) if end is not None else datetime.now(timezone.utc)

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
-from itertools import islice
 from typing import Any, Callable, Iterable, Mapping
 
 from sqlalchemy import or_
@@ -342,7 +341,7 @@ class BacktestEngine:
                 self._event_in_configured_session(timestamp)
                 for timestamp in self.execution_start_times
             ]
-            if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY
+            if self.strategy_type == _TOPBOT_STRATEGY
             else [True] * len(self.execution_candles)
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
@@ -373,10 +372,14 @@ class BacktestEngine:
         )
         replay_row_count = len(self.all_candles)
         if self.topbot_streams:
+            primary_stream_key = _topbot_asset_stream_key(
+                str(config.timeframe_unit),
+                int(config.timeframe_unit_number),
+            )
             replay_row_count += sum(
                 len(stream.candles)
-                for stream in self.topbot_streams.values()
-                if stream.candles is not self.all_candles
+                for key, stream in self.topbot_streams.items()
+                if key != primary_stream_key
             )
         _enforce_backtest_resource_budget(
             replay_rows=replay_row_count,
@@ -431,7 +434,9 @@ class BacktestEngine:
         self.topbot_source_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 
     def run(self) -> dict[str, Any]:
-        closed_history: list[ProjectXMarketCandle] = _ClosedCandleList()
+        closed_history: list[ProjectXMarketCandle] = (
+            _ClosedCandleList() if self._uses_real_evaluator else []
+        )
         history_cursor = 0
         timeline = zip(
             self.execution_candles,
@@ -455,7 +460,7 @@ class BacktestEngine:
             if self.pending is not None:
                 pending = self.pending
                 self.pending = None
-                self._fill_pending_signal(pending, candle=candle, bar_index=index)
+                self._fill_pending_signal(pending, candle=candle)
 
             if self.position is not None:
                 self._current_bar_exposed = True
@@ -809,21 +814,14 @@ class BacktestEngine:
                 strategy_params=self.config.strategy_params,
             )
         event_time = _candle_close_time(primary_candles[-1])
-        topbot_params = bot_service_module._normalize_strategy_params(
-            _TOPBOT_STRATEGY,
-            self.config.strategy_params,
-        )
-        source_overrides = topbot_params.get("source_strategy_params") or {}
+        topbot_params = self._topbot_params
         source_results: list[dict[str, Any]] = []
         event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
             if source_strategy in self.topbot_unavailable_sources:
                 continue
-            source_params = bot_service_module._normalize_strategy_params(
-                source_strategy,
-                source_overrides.get(source_strategy, {}),
-            )
+            source_params = self._topbot_source_params[source_strategy]
             signature = self._topbot_source_cache_signature(
                 source_strategy,
                 source_params=source_params,
@@ -868,13 +866,8 @@ class BacktestEngine:
         event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
-        for key in _topbot_source_stream_keys(
-            self.config,
-            source_strategy,
-            source_params=source_params,
-        ):
-            stream = self.topbot_streams.get(key)
-            closed_count = bisect_right(stream.close_times, event_time) if stream is not None else 0
+        for key in self._topbot_source_keys[source_strategy]:
+            closed_count = self._topbot_closed_count(key, event_time)
             signature.append((key, closed_count))
         if source_strategy == "donchian_breakout":
             if self.position is None:
@@ -906,34 +899,18 @@ class BacktestEngine:
         event_time: datetime,
         event_timestamp: datetime,
     ) -> dict[str, Any]:
-        fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
-            source_strategy,
-            fast_period=int(self.config.fast_period),
-            slow_period=int(self.config.slow_period),
-        )
-        source_config = _SourceConfigView(
-            self.config,
-            strategy_type=source_strategy,
-            strategy_params=source_params,
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
-        bot_service_module._validate_strategy_configuration(
-            strategy_type=source_strategy,
-            timeframe_unit=str(source_config.timeframe_unit),
-            timeframe_unit_number=int(source_config.timeframe_unit_number),
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
+        static_error = self._topbot_source_static_errors.get(source_strategy)
+        if static_error is not None:
+            raise ValueError(static_error)
+        source_config = self._topbot_source_configs[source_strategy]
+        fast_period = int(source_config.fast_period)
+        slow_period = int(source_config.slow_period)
 
         primary_key = _topbot_asset_stream_key(
             str(self.config.timeframe_unit),
             int(self.config.timeframe_unit_number),
         )
-        primary_limit = _topbot_primary_source_history_limit(
-            self.config,
-            source_strategy,
-        )
+        primary_limit = self._topbot_primary_limits[source_strategy]
 
         if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
             source_candles = self._topbot_stream_history(
@@ -959,11 +936,7 @@ class BacktestEngine:
             signal = bot_service_module.dispatch_strategy_evaluator(
                 source_strategy,
                 source_candles,
-                **_generic_evaluator_arguments(
-                    source_strategy,
-                    config=source_config,
-                    strategy_params=source_params,
-                ),
+                **self._topbot_generic_args[source_strategy],
             )
         elif source_strategy == "donchian_breakout":
             source_candles = self._topbot_stream_history(
@@ -1006,10 +979,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -1019,7 +989,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     _topbot_asset_stream_key("minute", 1),
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit="minute",
+                        unit_number=1,
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -1047,10 +1021,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -1060,7 +1031,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     primary_key,
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit=str(self.config.timeframe_unit),
+                        unit_number=int(self.config.timeframe_unit_number),
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -1091,14 +1066,11 @@ class BacktestEngine:
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(self.config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            limit = max(
+                int(self.config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             source_candles = self._topbot_stream_history(
                 _topbot_asset_stream_key("minute", 5),
@@ -1258,21 +1230,49 @@ class BacktestEngine:
         stream = self.topbot_streams.get(key)
         if stream is None or not stream.candles:
             raise ValueError(f"missing_stored_replay_stream:{key}")
-        end_index = bisect_right(stream.close_times, _as_utc(event_time))
+        event_utc = _as_utc(event_time)
+        if self._topbot_history_event != event_utc:
+            self._topbot_history_event = event_utc
+            self._topbot_history_cache.clear()
+        normalized_not_before = _as_utc(not_before) if not_before is not None else None
+        cache_key = (key, max(1, int(limit)), normalized_not_before)
+        cached = self._topbot_history_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        end_index = self._topbot_closed_count(key, event_utc)
         start_index = max(0, end_index - max(1, int(limit)))
-        if not_before is not None:
+        if normalized_not_before is not None:
             start_index = max(
                 start_index,
-                bisect_left(stream.start_times, _as_utc(not_before)),
+                bisect_left(stream.start_times, normalized_not_before),
             )
-        return stream.candles[start_index:end_index]
+        history = _closed_candle_slice(stream.candles, start_index, end_index)
+        self._topbot_history_cache[cache_key] = history
+        return history
+
+    def _topbot_closed_count(self, key: str, event_time: datetime) -> int:
+        stream = self.topbot_streams.get(key)
+        if stream is None:
+            return 0
+        event_utc = _as_utc(event_time)
+        previous_event, count = self._topbot_cursor_state.get(
+            key,
+            (datetime.min.replace(tzinfo=timezone.utc), 0),
+        )
+        if event_utc < previous_event:
+            count = bisect_right(stream.close_times, event_utc)
+        elif event_utc > previous_event:
+            while count < len(stream.close_times) and stream.close_times[count] <= event_utc:
+                count += 1
+        self._topbot_cursor_state[key] = (event_utc, count)
+        return count
 
     def _fill_pending_signal(
         self,
         pending: _PendingSignal,
         *,
         candle: ProjectXMarketCandle,
-        bar_index: int,
     ) -> None:
         fill_time = _as_utc(candle.candle_timestamp)
         if not _signal_fill_is_in_same_session(
@@ -1288,7 +1288,7 @@ class BacktestEngine:
         is_exit_only = signal_category == "exit"
 
         if self.position is not None and self.position.side != desired_side:
-            self.exposed_bar_indexes.add(bar_index)
+            self._current_bar_exposed = True
             self._update_excursion(float(candle.open_price), float(candle.open_price))
             exit_reason = str(pending.payload.get("exit_reason") or "position_reversal")
             self._close_position(
@@ -1353,7 +1353,7 @@ class BacktestEngine:
             stop_loss=stop_loss,
             take_profit=take_profit,
         )
-        self.exposed_bar_indexes.add(bar_index)
+        self._current_bar_exposed = True
 
     def _can_enter(self, timestamp: datetime) -> bool:
         if not _contract_is_allowed(self.config):
@@ -1547,6 +1547,8 @@ class BacktestEngine:
         return float(raw + slip if action == "BUY" else raw - slip)
 
     def _record_equity(self, *, event_time: datetime, mark_price: float) -> None:
+        if self._current_bar_exposed:
+            self.exposed_bar_count += 1
         unrealized = 0.0
         if self.position is not None:
             unrealized = _price_pnl(
@@ -1580,18 +1582,13 @@ class BacktestEngine:
             self.equity_curve.append(point)
 
     def _add_data_quality_warnings(self) -> None:
-        warmup_count = sum(
-            1
-            for row in self.all_candles
-            if _as_utc(row.candle_timestamp) < self.settings.start
-            and _candle_close_time(row) <= _candle_close_time(self.execution_candles[0])
+        warmup_count = min(
+            bisect_left(self.all_start_times, self.settings.start),
+            bisect_right(self.all_close_times, self.execution_close_times[0]),
         )
-        requested_warmup = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(self.config.lookback_bars),
-                _strategy_history_bars(self.config, hard_minimum=False),
-            ),
+        requested_warmup = max(
+            int(self.config.lookback_bars),
+            _strategy_history_bars(self.config, hard_minimum=False),
         )
         if self.strategy_type == _TOPBOT_STRATEGY:
             primary_key = _topbot_asset_stream_key(
@@ -1614,8 +1611,8 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
-            actual_end = _candle_close_time(self.execution_candles[-1])
+            actual_start = self.execution_start_times[0]
+            actual_end = self.execution_close_times[-1]
             if _has_open_futures_interval(
                 self.settings.start,
                 actual_start,
@@ -1647,7 +1644,7 @@ class BacktestEngine:
                 str(self.config.timeframe_unit),
                 int(self.config.timeframe_unit_number),
             )
-            first_event = _candle_close_time(self.execution_candles[0])
+            first_event = self.execution_close_times[0]
             for key, spec in sorted(_topbot_stream_specs(self.config).items()):
                 if key == primary_key:
                     continue
@@ -1729,9 +1726,9 @@ def _topbot_primary_source_history_limit(config: BotConfig, source_strategy: str
         int(config.timeframe_unit_number),
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return limit
     session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-    return min(MAX_BACKTEST_BARS, max(limit, session_capacity))
+    return max(limit, session_capacity)
 
 
 def _topbot_configured_session_capacity(
@@ -1742,7 +1739,7 @@ def _topbot_configured_session_capacity(
 ) -> int:
     timeframe_seconds = _timeframe_seconds(unit, unit_number)
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return max(1, int(config.lookback_bars))
     start = _parse_time(str(config.trading_start_time))
     end = _parse_time(str(config.trading_end_time))
     start_seconds = start.hour * 3600 + start.minute * 60 + start.second
@@ -1750,26 +1747,20 @@ def _topbot_configured_session_capacity(
     duration = end_seconds - start_seconds
     if duration < 0:
         duration += 24 * 60 * 60
-    return min(
-        MAX_BACKTEST_BARS,
-        max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2),
-    )
+    return max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2)
 
 
 def _relative_strength_spy_history_limit(
     config: BotConfig,
     source_params: Mapping[str, Any],
 ) -> int:
-    return min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            int(source_params["comparison_bars"]) + 1,
-            int(source_params["pullback_lookback_bars"]) + 1,
-            int(source_params["relative_volume_period"]) + 1,
-            int(source_params["major_level_lookback_bars"]),
-            50,
-        ),
+    return max(
+        int(config.lookback_bars),
+        int(source_params["comparison_bars"]) + 1,
+        int(source_params["pullback_lookback_bars"]) + 1,
+        int(source_params["relative_volume_period"]) + 1,
+        int(source_params["major_level_lookback_bars"]),
+        50,
     )
 
 
@@ -1851,14 +1842,11 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            opening_limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            opening_limit = max(
+                int(config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             add_asset("minute", 5, opening_limit)
         elif source_strategy == "delayed_orb_confirmation":
@@ -2004,9 +1992,15 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     contract_ids: set[str] = set()
@@ -2162,14 +2156,11 @@ def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: 
         elif source == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_days = max(lookback_days + 14, 21)
-            per_event += min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            per_event += max(
+                int(config.lookback_bars),
+                (calendar_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
         elif source == "delayed_orb_confirmation":
             per_event += 1500
@@ -2227,13 +2218,38 @@ def _load_topbot_replay_streams(
         int(config.timeframe_unit_number),
     )
     streams: dict[str, list[ProjectXMarketCandle]] = {primary_key: primary_rows}
+    specs = _topbot_stream_specs(config)
     total_rows = len(primary_rows)
 
-    for key, spec in _topbot_stream_specs(config).items():
+    def stream_identity(spec: _TopBotReplayStreamSpec) -> tuple[str, str, str, int]:
+        if spec.contract_id is not None:
+            return ("contract", spec.contract_id, spec.unit, spec.unit_number)
+        return ("symbol", str(spec.symbol or ""), spec.unit, spec.unit_number)
+
+    max_warmup_by_identity: dict[tuple[str, str, str, int], int] = {}
+    for key, spec in specs.items():
         if key == primary_key:
             continue
+        identity = stream_identity(spec)
+        max_warmup_by_identity[identity] = max(
+            max_warmup_by_identity.get(identity, 0),
+            int(spec.warmup_bars),
+        )
+
+    rows_by_identity: dict[
+        tuple[str, str, str, int], list[ProjectXMarketCandle]
+    ] = {stream_identity(specs[primary_key]): primary_rows}
+
+    for key, spec in specs.items():
+        if key == primary_key:
+            continue
+        identity = stream_identity(spec)
+        cached_rows = rows_by_identity.get(identity)
+        if cached_rows is not None:
+            streams[key] = cached_rows
+            continue
         query = (
-            db.query(ProjectXMarketCandle)
+            _projected_candle_query(db)
             .filter(ProjectXMarketCandle.user_id == user_id)
             .filter(ProjectXMarketCandle.live.is_(False))
             .filter(ProjectXMarketCandle.unit == spec.unit)
@@ -2250,37 +2266,31 @@ def _load_topbot_replay_streams(
                 )
             )
 
-        execution_rows = (
+        execution_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp >= start)
             .filter(ProjectXMarketCandle.candle_timestamp <= end)
             .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-            .limit(MAX_TOPBOT_REPLAY_STREAM_BARS + 1)
-            .all()
         )
+        execution_rows = _collect_projected_candles(execution_query)
         execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-        if len(execution_rows) > MAX_TOPBOT_REPLAY_STREAM_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_stream_bar_limit_exceeded: "
-                f"{key} exceeds {MAX_TOPBOT_REPLAY_STREAM_BARS:,} bars; reduce the date range"
-            )
-        warmup_rows = (
+        warmup_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
             # One candle can start before the requested range while closing
             # after the first replay event. Overfetch it so the requested
             # number of genuinely closed warmup bars remains available.
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
-            .all()
+            .limit(max(1, max_warmup_by_identity[identity] + 1))
         )
+        warmup_rows = _collect_projected_candles(warmup_query)
         warmup_rows.reverse()
         rows = [*warmup_rows, *execution_rows]
+        rows_by_identity[identity] = rows
         streams[key] = rows
         total_rows += len(rows)
-        if total_rows > MAX_TOPBOT_REPLAY_TOTAL_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_total_bar_limit_exceeded: synchronized streams contain "
-                f"more than {MAX_TOPBOT_REPLAY_TOTAL_BARS:,} bars; reduce the date range"
-            )
+        _enforce_backtest_resource_budget(
+            replay_rows=total_rows,
+            execution_rows=len(primary_rows),
+        )
 
     return streams
 
@@ -2477,8 +2487,8 @@ def _cached_replay_stream_covers(
     interval_seconds = _timeframe_seconds(unit, unit_number)
     if interval_seconds is None:
         return False
-    rows = (
-        db.query(ProjectXMarketCandle)
+    query = (
+        _projected_candle_query(db)
         .filter(ProjectXMarketCandle.user_id == user_id)
         .filter(ProjectXMarketCandle.contract_id == contract_id)
         .filter(ProjectXMarketCandle.live.is_(False))
@@ -2488,23 +2498,24 @@ def _cached_replay_stream_covers(
         .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
         .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
         .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
     )
+    rows = _collect_projected_candles(query)
     if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
         return False
     if _candle_stream_has_overlaps(rows):
         return False
-    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
-    warmup_count = sum(
-        _as_utc(row.candle_timestamp) < requested_start
-        for row in closed_by_first
-    )
+    close_times = [_candle_close_time(row) for row in rows]
+    start_times = [_as_utc(row.candle_timestamp) for row in rows]
+    first_end = bisect_right(close_times, first_event)
+    last_end = bisect_right(close_times, last_event)
+    closed_by_first = rows[:first_end]
+    warmup_count = min(first_end, bisect_left(start_times, requested_start))
     if warmup_count < max(1, int(warmup_bars)):
         return False
 
     for event, candidates in (
         (first_event, closed_by_first),
-        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+        (last_event, rows[:last_end]),
     ):
         if not candidates:
             return False
@@ -2553,6 +2564,40 @@ def run_backtest(
     ).run()
 
 
+def _projected_candle_query(db: Session):
+    """Select only replay fields, avoiding ORM identity-map materialization."""
+
+    return db.query(
+        ProjectXMarketCandle.user_id,
+        ProjectXMarketCandle.contract_id,
+        ProjectXMarketCandle.symbol,
+        ProjectXMarketCandle.live,
+        ProjectXMarketCandle.unit,
+        ProjectXMarketCandle.unit_number,
+        ProjectXMarketCandle.candle_timestamp,
+        ProjectXMarketCandle.open_price,
+        ProjectXMarketCandle.high_price,
+        ProjectXMarketCandle.low_price,
+        ProjectXMarketCandle.close_price,
+        ProjectXMarketCandle.volume,
+        ProjectXMarketCandle.is_partial,
+        ProjectXMarketCandle.raw_payload,
+        ProjectXMarketCandle.fetched_at,
+    )
+
+
+def _collect_projected_candles(query: Any) -> list[ProjectXMarketCandle]:
+    rows: list[ProjectXMarketCandle] = []
+    for values in query.yield_per(CANDLE_QUERY_CHUNK_SIZE):
+        rows.append(_ProjectedCandle(*values))
+        if len(rows) % CANDLE_QUERY_CHUNK_SIZE == 0:
+            _enforce_backtest_resource_budget(
+                replay_rows=len(rows),
+                execution_rows=0,
+            )
+    return rows
+
+
 def _load_primary_closed_candles(
     db: Session,
     *,
@@ -2563,8 +2608,8 @@ def _load_primary_closed_candles(
     """Load every eligible primary bar without rolling across futures deliveries."""
 
     cutoff = _as_utc(closed_by)
-    rows = (
-        db.query(ProjectXMarketCandle)
+    query = (
+        _projected_candle_query(db)
         .filter(ProjectXMarketCandle.user_id == user_id)
         .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
         .filter(ProjectXMarketCandle.live.is_(False))
@@ -2573,14 +2618,14 @@ def _load_primary_closed_candles(
         .filter(ProjectXMarketCandle.is_partial.is_(False))
         .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
         .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
     )
-    return [
+    rows = _collect_projected_candles(query)
+    return _ClosedCandleList(
         row
         for row in rows
         if not _cached_candle_is_effectively_partial(row)
         and _candle_close_time(row) <= cutoff
-    ]
+    )
 
 
 def _requested_backtest_bounds(payload: Any) -> tuple[datetime, datetime] | None:
@@ -2878,19 +2923,21 @@ def create_bot_backtest(
         )
         window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
 
-    execution_rows = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) >= window.start
-        and _candle_close_time(row) <= window.end
+    primary_start_times = [
+        _as_utc(row.candle_timestamp) for row in primary_rows
     ]
+    primary_close_times = [_candle_close_time(row) for row in primary_rows]
+    execution_start_index = bisect_left(primary_start_times, window.start)
+    execution_end_index = bisect_right(primary_close_times, window.end)
+    execution_rows = _closed_candle_slice(
+        primary_rows,
+        execution_start_index,
+        execution_end_index,
+    )
 
-    rolling_warmup_limit = min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            _strategy_history_bars(config, hard_minimum=False),
-        ),
+    rolling_warmup_limit = max(
+        int(config.lookback_bars),
+        _strategy_history_bars(config, hard_minimum=False),
     )
     if is_topbot:
         primary_key = _topbot_asset_stream_key(
@@ -2898,21 +2945,22 @@ def create_bot_backtest(
             int(config.timeframe_unit_number),
         )
         primary_spec = _topbot_stream_specs(config)[primary_key]
-        rolling_warmup_limit = min(
-            MAX_BACKTEST_BARS,
-            max(rolling_warmup_limit, primary_spec.warmup_bars),
+        rolling_warmup_limit = max(
+            rolling_warmup_limit,
+            primary_spec.warmup_bars,
         )
     warmup_limit = _max_evaluator_input_bars(
         config,
         rolling_limit=rolling_warmup_limit,
     )
-    warmup_candidates = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) < window.start
-    ]
-    warmup_rows = warmup_candidates[-warmup_limit:]
-    replay_rows = [*warmup_rows, *execution_rows]
+    warmup_start_index = max(0, execution_start_index - warmup_limit)
+    warmup_rows = _closed_candle_slice(
+        primary_rows,
+        warmup_start_index,
+        execution_start_index,
+    )
+    replay_rows = _ClosedCandleList(warmup_rows)
+    replay_rows.extend(execution_rows)
     replay_streams: dict[str, list[ProjectXMarketCandle]] | None = None
     if is_topbot:
         replay_streams = _load_topbot_replay_streams(
@@ -2989,7 +3037,12 @@ def serialize_bot_backtest(row: BotBacktest) -> dict[str, Any]:
 
 
 def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
-    canonical = [
+    ordered = (
+        candles
+        if getattr(candles, "_topsignal_sorted_closed", False)
+        else sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+    )
+    return _incremental_candle_fingerprint(
         {
             "contract_id": str(row.contract_id),
             "live": bool(row.live),
@@ -3003,37 +3056,60 @@ def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
             "volume": str(row.volume),
             "is_partial": bool(row.is_partial),
         }
-        for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+        for row in ordered
         if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    )
 
 
 def candle_stream_input_fingerprint(
     streams: Mapping[str, list[ProjectXMarketCandle]],
 ) -> str:
-    canonical = [
-        {
-            "stream": key,
-            "contract_id": str(row.contract_id),
-            "live": bool(row.live),
-            "unit": str(row.unit),
-            "unit_number": int(row.unit_number),
-            "timestamp": _as_utc(row.candle_timestamp).isoformat(),
-            "open": str(row.open_price),
-            "high": str(row.high_price),
-            "low": str(row.low_price),
-            "close": str(row.close_price),
-            "volume": str(row.volume),
-            "is_partial": bool(row.is_partial),
-        }
-        for key in sorted(streams)
-        for row in sorted(streams[key], key=lambda candle: _as_utc(candle.candle_timestamp))
-        if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    def canonical_rows() -> Iterable[dict[str, Any]]:
+        for key in sorted(streams):
+            candles = streams[key]
+            ordered = (
+                candles
+                if getattr(candles, "_topsignal_sorted_closed", False)
+                else sorted(
+                    candles,
+                    key=lambda candle: _as_utc(candle.candle_timestamp),
+                )
+            )
+            for row in ordered:
+                if bool(row.is_partial):
+                    continue
+                yield {
+                    "stream": key,
+                    "contract_id": str(row.contract_id),
+                    "live": bool(row.live),
+                    "unit": str(row.unit),
+                    "unit_number": int(row.unit_number),
+                    "timestamp": _as_utc(row.candle_timestamp).isoformat(),
+                    "open": str(row.open_price),
+                    "high": str(row.high_price),
+                    "low": str(row.low_price),
+                    "close": str(row.close_price),
+                    "volume": str(row.volume),
+                    "is_partial": bool(row.is_partial),
+                }
+
+    return _incremental_candle_fingerprint(canonical_rows())
+
+
+def _incremental_candle_fingerprint(rows: Iterable[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first = True
+    for row in rows:
+        if first:
+            first = False
+        else:
+            digest.update(b",")
+        digest.update(
+            json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
+    digest.update(b"]")
+    return digest.hexdigest()
 
 
 def _require_supported_strategy(strategy_type: str) -> None:
@@ -3088,6 +3164,38 @@ def _contract_is_allowed(config: BotConfig) -> bool:
     return bool(allowed.intersection(candidates))
 
 
+def _closed_candle_slice(
+    candles: list[ProjectXMarketCandle],
+    start: int,
+    end: int | None = None,
+) -> list[ProjectXMarketCandle]:
+    sliced = candles[start:end]
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        return _ClosedCandleList(sliced)
+    return sliced
+
+
+def _enforce_backtest_resource_budget(
+    *,
+    replay_rows: int,
+    execution_rows: int,
+) -> None:
+    budget = max(1, int(BACKTEST_MEMORY_BUDGET_BYTES))
+    estimated = (
+        max(0, int(replay_rows)) * ESTIMATED_REPLAY_CANDLE_BYTES
+        + max(0, int(execution_rows)) * ESTIMATED_EXECUTION_RESULT_BYTES
+    )
+    if estimated <= budget:
+        return
+    estimated_mib = math.ceil(estimated / (1024 * 1024))
+    budget_mib = max(1, budget // (1024 * 1024))
+    raise BacktestConfigurationError(
+        "backtest_resource_budget_exceeded: the complete resolved history requires "
+        f"an estimated {estimated_mib:,} MiB, above the configured {budget_mib:,} MiB "
+        "working-set budget; no partial result was saved"
+    )
+
+
 def _validate_settings(settings: BacktestSettings) -> BacktestSettings:
     normalized = BacktestSettings(
         start=_as_utc(settings.start),
@@ -3117,9 +3225,15 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     for row in closed:
@@ -3664,11 +3778,11 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
         str(config.timeframe_unit), int(config.timeframe_unit_number)
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return rolling_limit
     if str(config.strategy_type) in _TRADING_DAY_VWAP_STRATEGIES:
         # A New York trading day spans 25 real hours across the fall DST change.
         session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(rolling_limit, session_capacity))
+        return max(rolling_limit, session_capacity)
     if str(config.strategy_type) == "orb_fibonacci_pullback":
         start = _parse_time(str(config.trading_start_time))
         end = _parse_time(str(config.trading_end_time))
@@ -3679,7 +3793,7 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
             duration += 24 * 60 * 60
         # Overnight configured windows can also cross a fall DST transition.
         session_capacity = math.ceil((duration + 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(1, session_capacity))
+        return max(1, session_capacity)
     return rolling_limit
 
 

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -46,12 +47,40 @@ from .trading_day import (
 
 
 BACKTEST_ENGINE_VERSION = "1.3.0"
+# Retained as a compatibility constant for callers/tests that display the old
+# limit. It is deliberately not used to truncate or reject replay history.
 MAX_BACKTEST_BARS = 20_000
-MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
-MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
-MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
-MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
 MAX_PROVIDER_FETCH_BARS = 20_000
+CANDLE_QUERY_CHUNK_SIZE = 8_192
+_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES = 1_536 * 1024 * 1024
+# cProfile showed CPU time scaling with evaluator-visible candle visits.  This
+# configurable ceiling replaces date/bar caps while rejecting pathological
+# repeated-indicator workloads before replay or persistence.
+_DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET = 500_000_000
+try:
+    BACKTEST_MEMORY_BUDGET_BYTES = int(
+        os.getenv(
+            "TOPSIGNAL_BACKTEST_MEMORY_BUDGET_BYTES",
+            str(_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES),
+        )
+    )
+except ValueError:
+    BACKTEST_MEMORY_BUDGET_BYTES = _DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES
+try:
+    BACKTEST_EVALUATOR_WORK_BUDGET = int(
+        os.getenv(
+            "TOPSIGNAL_BACKTEST_EVALUATOR_WORK_BUDGET",
+            str(_DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET),
+        )
+    )
+except ValueError:
+    BACKTEST_EVALUATOR_WORK_BUDGET = _DEFAULT_BACKTEST_EVALUATOR_WORK_BUDGET
+
+# Calibrated with tracemalloc and the projected-row benchmark. These estimates
+# intentionally include Python container overhead and the two per-bar result
+# series, not only raw OHLCV payload bytes.
+ESTIMATED_REPLAY_CANDLE_BYTES = 640
+ESTIMATED_EXECUTION_RESULT_BYTES = 704
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -170,6 +199,42 @@ class _PreparedReplayStream:
     close_times: list[datetime]
 
 
+class _ClosedCandleList(list[ProjectXMarketCandle]):
+    """Internal proof that a replay window is already closed and ordered."""
+
+    _topsignal_sorted_closed = True
+    _topsignal_physical_stream: tuple[str, str, str, int] | None = None
+    _topsignal_physical_row_count: int | None = None
+
+
+class _PhysicalReplayList(list[ProjectXMarketCandle]):
+    """Projected rows that share one physical query but still need validation."""
+
+    _topsignal_physical_stream: tuple[str, str, str, int] | None = None
+    _topsignal_physical_row_count: int | None = None
+
+
+@dataclass(slots=True)
+class _ProjectedCandle:
+    """Lightweight query result with the candle attribute contract evaluators use."""
+
+    user_id: Any
+    contract_id: str
+    symbol: str | None
+    live: bool
+    unit: str
+    unit_number: int
+    candle_timestamp: datetime
+    open_price: Any
+    high_price: Any
+    low_price: Any
+    close_price: Any
+    volume: Any
+    is_partial: bool
+    raw_payload: Any
+    fetched_at: datetime | None
+
+
 @dataclass(frozen=True)
 class _PendingSignal:
     action: str
@@ -215,11 +280,38 @@ class BacktestEngine:
         _require_supported_strategy(self.strategy_type)
         _validate_replay_configuration(config)
         uses_real_evaluator = signal_evaluator is None
+        self._uses_real_evaluator = uses_real_evaluator
         self.signal_evaluator = signal_evaluator or self._evaluate_real_strategy
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
+        self.all_start_times = [
+            _as_utc(candle.candle_timestamp) for candle in self.all_candles
+        ]
+        self.all_close_times = [
+            _candle_close_time(candle) for candle in self.all_candles
+        ]
+        self._sma_close_values = (
+            [float(candle.close_price) for candle in self.all_candles]
+            if uses_real_evaluator
+            and self.strategy_type == "sma_cross"
+            and evaluate_sma_cross is bot_service_module.evaluate_sma_cross
+            else None
+        )
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
         self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
+        self._topbot_params: dict[str, Any] = {}
+        self._topbot_source_params: dict[str, dict[str, Any]] = {}
+        self._topbot_source_keys: dict[str, tuple[str, ...]] = {}
+        self._topbot_source_configs: dict[str, _SourceConfigView] = {}
+        self._topbot_cursor_state: dict[str, tuple[datetime, int]] = {}
+        self._topbot_history_event: datetime | None = None
+        self._topbot_history_cache: dict[
+            tuple[str, int, datetime | None], list[ProjectXMarketCandle]
+        ] = {}
+        self._current_event_timestamp: datetime | None = None
+        self._current_event_in_session = False
+        self._configured_session_start = _parse_time(str(config.trading_start_time))
+        self._configured_session_end = _parse_time(str(config.trading_end_time))
         auxiliary_excluded_partial = 0
         deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
@@ -231,12 +323,13 @@ class BacktestEngine:
                 primary_candles=self.all_candles,
                 replay_streams=replay_streams,
             )
-        self.execution_candles = [
-            candle
-            for candle in self.all_candles
-            if _as_utc(candle.candle_timestamp) >= self.settings.start
-            and _candle_close_time(candle) <= self.settings.end
-        ]
+            self._prepare_topbot_runtime()
+
+        execution_start = bisect_left(self.all_start_times, self.settings.start)
+        execution_end = bisect_right(self.all_close_times, self.settings.end)
+        self.execution_candles = self.all_candles[execution_start:execution_end]
+        self.execution_start_times = self.all_start_times[execution_start:execution_end]
+        self.execution_close_times = self.all_close_times[execution_start:execution_end]
         if len(self.execution_candles) < MIN_EXECUTION_BARS:
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: at least 2 closed execution bars are required "
@@ -244,76 +337,128 @@ class BacktestEngine:
             )
         if uses_real_evaluator and self.strategy_type != "orb_fibonacci_pullback":
             hard_minimum = _strategy_history_bars(config, hard_minimum=True)
-            first_event = _candle_close_time(self.execution_candles[0])
-            closed_by_first_event = sum(
-                1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
-            )
+            first_event = self.execution_close_times[0]
+            closed_by_first_event = bisect_right(self.all_close_times, first_event)
             if closed_by_first_event < hard_minimum:
                 deferred_execution_bars = hard_minimum - closed_by_first_event
                 self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                self.execution_start_times = self.execution_start_times[
+                    deferred_execution_bars:
+                ]
+                self.execution_close_times = self.execution_close_times[
+                    deferred_execution_bars:
+                ]
                 if len(self.execution_candles) < MIN_EXECUTION_BARS:
-                    available_closed_bars = sum(
-                        1
-                        for candle in self.all_candles
-                        if _candle_close_time(candle) <= self.settings.end
+                    available_closed_bars = bisect_right(
+                        self.all_close_times,
+                        self.settings.end,
                     )
                     raise InsufficientBacktestDataError(
                         "insufficient_backtest_data: insufficient_strategy_warmup: "
                         f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
                         f"only {available_closed_bars} were available"
                     )
-        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            session_execution_candles = [
-                candle
-                for candle in self.execution_candles
-                if _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
-                )
+        self.execution_in_session = (
+            [
+                self._event_in_configured_session(timestamp)
+                for timestamp in self.execution_start_times
             ]
-            coverage_candles = session_execution_candles or self.execution_candles
+            if self.strategy_type == _TOPBOT_STRATEGY
+            else [True] * len(self.execution_candles)
+        )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            in_session_indexes = [
+                index
+                for index, inside in enumerate(self.execution_in_session)
+                if inside
+            ]
+            first_coverage_index = in_session_indexes[0] if in_session_indexes else 0
+            last_coverage_index = (
+                in_session_indexes[-1]
+                if in_session_indexes
+                else len(self.execution_candles) - 1
+            )
             self.topbot_unavailable_sources = _topbot_unavailable_sources(
                 config,
                 streams=self.topbot_streams,
-                first_event=_candle_close_time(coverage_candles[0]),
-                last_event=_candle_close_time(coverage_candles[-1]),
+                first_event=self.execution_close_times[first_coverage_index],
+                last_event=self.execution_close_times[last_coverage_index],
             )
-        self.evaluator_history_limit = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(config.lookback_bars),
-                _strategy_history_bars(config, hard_minimum=False),
-            ),
+        self.evaluator_history_limit = max(
+            int(config.lookback_bars),
+            _strategy_history_bars(config, hard_minimum=False),
         )
         self.max_evaluator_input_bars = _max_evaluator_input_bars(
             config,
             rolling_limit=self.evaluator_history_limit,
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            signal_evaluation_bars = sum(
-                _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
+            in_session_event_times = [
+                event_time
+                for event_time, inside_session in zip(
+                    self.execution_close_times,
+                    self.execution_in_session,
                 )
-                for candle in self.execution_candles
-            )
-            estimated_operations = _estimate_topbot_evaluator_operations(
+                if inside_session
+            ]
+            source_evaluations = _topbot_cached_source_evaluation_counts(
                 config,
-                execution_bars=signal_evaluation_bars,
+                streams=self.topbot_streams,
+                event_times=in_session_event_times,
+                unavailable_sources=self.topbot_unavailable_sources,
             )
-            operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
+            estimated_evaluator_work = _estimate_topbot_evaluator_operations(
+                config,
+                execution_bars=len(in_session_event_times),
+                source_evaluations=source_evaluations,
+                unavailable_sources=self.topbot_unavailable_sources,
+            )
+        elif self._sma_close_values is not None:
+            estimated_evaluator_work = len(self.execution_candles) * (
+                2 * int(config.fast_period) + 2 * int(config.slow_period)
+            )
         else:
-            estimated_operations = len(self.execution_candles) * min(
-                len(self.all_candles), self.max_evaluator_input_bars
+            estimated_evaluator_work = len(self.execution_candles) * min(
+                len(self.all_candles),
+                self.max_evaluator_input_bars,
             )
-            operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
-        if estimated_operations > operation_limit:
-            raise BacktestConfigurationError(
-                "backtest_computation_limit_exceeded: the complete resolved history and bot "
-                "lookback exceed the current replay resource budget; no partial result was saved; "
-                f"estimated evaluator bar-visits {estimated_operations:,} exceed "
-                f"{operation_limit:,}"
+        _enforce_backtest_work_budget(estimated_evaluator_work)
+
+        replay_row_count = len(self.all_candles)
+        if self.topbot_streams:
+            primary_stream_key = _topbot_asset_stream_key(
+                str(config.timeframe_unit),
+                int(config.timeframe_unit_number),
             )
+            physical_stream_rows: dict[tuple[str, str, str, int], int] = {}
+            logical_stream_rows = 0
+            for key, stream in self.topbot_streams.items():
+                if key == primary_stream_key:
+                    continue
+                physical_stream = getattr(
+                    stream.candles,
+                    "_topsignal_physical_stream",
+                    None,
+                )
+                physical_row_count = getattr(
+                    stream.candles,
+                    "_topsignal_physical_row_count",
+                    None,
+                )
+                if physical_stream is None or physical_row_count is None:
+                    logical_stream_rows += len(stream.candles)
+                    continue
+                physical_stream_rows[physical_stream] = max(
+                    physical_stream_rows.get(physical_stream, 0),
+                    int(physical_row_count),
+                )
+            replay_row_count += logical_stream_rows + sum(
+                physical_stream_rows.values()
+            )
+        _enforce_backtest_resource_budget(
+            replay_rows=replay_row_count,
+            execution_rows=len(self.execution_candles),
+        )
 
         self.warnings: list[str] = []
         if excluded_partial:
@@ -351,7 +496,8 @@ class BacktestEngine:
                 "unrealized_pnl": 0.0,
             }
         ]
-        self.exposed_bar_indexes: set[int] = set()
+        self.exposed_bar_count = 0
+        self._current_bar_exposed = False
         self.daily_entry_counts: dict[Any, int] = defaultdict(int)
         self.daily_net_activity: dict[Any, float] = defaultdict(float)
         self.last_loss_at: datetime | None = None
@@ -362,45 +508,53 @@ class BacktestEngine:
         self.topbot_source_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 
     def run(self) -> dict[str, Any]:
-        closed_history: list[ProjectXMarketCandle] = []
+        closed_history: list[ProjectXMarketCandle] = (
+            _ClosedCandleList() if self._uses_real_evaluator else []
+        )
         history_cursor = 0
-        for index, candle in enumerate(self.execution_candles):
-            candle_start = _as_utc(candle.candle_timestamp)
-            event_time = _candle_close_time(candle)
+        timeline = zip(
+            self.execution_candles,
+            self.execution_start_times,
+            self.execution_close_times,
+            self.execution_in_session,
+        )
+        for index, (candle, candle_start, event_time, inside_session) in enumerate(
+            timeline
+        ):
+            self._current_bar_exposed = False
+            self._current_event_timestamp = candle_start
+            self._current_event_in_session = inside_session
 
             counted_position = self.position
             if counted_position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 counted_position.bars_held += 1
                 self._process_open_gap(candle)
 
             if self.pending is not None:
                 pending = self.pending
                 self.pending = None
-                self._fill_pending_signal(pending, candle=candle, bar_index=index)
+                self._fill_pending_signal(pending, candle=candle)
 
             if self.position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 if self.position is not counted_position:
                     self.position.bars_held += 1
                 self._process_intrabar_bracket(candle)
 
             while (
                 history_cursor < len(self.all_candles)
-                and _candle_close_time(self.all_candles[history_cursor]) <= event_time
+                and self.all_close_times[history_cursor] <= event_time
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
-            if (
-                self.strategy_type == _TOPBOT_STRATEGY
-                and not _event_timestamp_is_in_configured_session(
-                    self.config,
-                    candle_start,
-                )
-            ):
+            if self.strategy_type == _TOPBOT_STRATEGY and not inside_session:
                 self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
                 continue
-            signal = self.signal_evaluator(self._evaluator_input(closed_history))
+            if self._sma_close_values is not None:
+                signal = self._evaluate_prepared_sma(history_cursor)
+            else:
+                signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
             if signal.action in {"BUY", "SELL"}:
@@ -431,7 +585,7 @@ class BacktestEngine:
 
         if self.position is not None and self.settings.force_close_at_end:
             final_candle = self.execution_candles[-1]
-            final_time = _candle_close_time(final_candle)
+            final_time = self.execution_close_times[-1]
             self._update_excursion(float(final_candle.close_price), float(final_candle.close_price))
             self._close_position(
                 raw_exit_price=float(final_candle.close_price),
@@ -450,12 +604,14 @@ class BacktestEngine:
             self.trades,
             equity_curve=self.equity_curve,
             drawdown_series=drawdown_series,
-            exposure_percent=(len(self.exposed_bar_indexes) / len(self.execution_candles) * 100.0),
+            exposure_percent=(
+                self.exposed_bar_count / len(self.execution_candles) * 100.0
+            ),
         )
         return {
             "range": {
-                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
-                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
+                "start": self.execution_start_times[0].isoformat(),
+                "end": self.execution_close_times[-1].isoformat(),
                 "bar_count": len(self.execution_candles),
                 "contract_id": str(self.execution_candles[0].contract_id),
                 "symbol": self.execution_candles[0].symbol or self.config.symbol,
@@ -473,6 +629,142 @@ class BacktestEngine:
             "warnings": self.warnings,
         }
 
+    def _prepare_topbot_runtime(self) -> None:
+        self._topbot_params = bot_service_module._normalize_strategy_params(
+            _TOPBOT_STRATEGY,
+            self.config.strategy_params,
+        )
+        source_overrides = self._topbot_params.get("source_strategy_params") or {}
+        self._topbot_source_static_errors: dict[str, str] = {}
+        self._topbot_generic_args: dict[str, dict[str, Any]] = {}
+        self._topbot_primary_limits: dict[str, int] = {}
+        for source_strategy in self._topbot_params["source_strategies"]:
+            source_params = bot_service_module._normalize_strategy_params(
+                source_strategy,
+                source_overrides.get(source_strategy, {}),
+            )
+            self._topbot_source_params[source_strategy] = source_params
+            self._topbot_source_keys[source_strategy] = tuple(
+                _topbot_source_stream_keys(
+                    self.config,
+                    source_strategy,
+                    source_params=source_params,
+                )
+            )
+            fast_period, slow_period = (
+                bot_service_module._normalized_strategy_period_values(
+                    source_strategy,
+                    fast_period=int(self.config.fast_period),
+                    slow_period=int(self.config.slow_period),
+                )
+            )
+            source_config = _SourceConfigView(
+                self.config,
+                strategy_type=source_strategy,
+                strategy_params=source_params,
+                fast_period=fast_period,
+                slow_period=slow_period,
+            )
+            self._topbot_source_configs[source_strategy] = source_config
+            self._topbot_primary_limits[source_strategy] = (
+                _topbot_primary_source_history_limit(
+                    self.config,
+                    source_strategy,
+                )
+            )
+            if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
+                self._topbot_generic_args[source_strategy] = (
+                    _generic_evaluator_arguments(
+                        source_strategy,
+                        config=source_config,
+                        strategy_params=source_params,
+                    )
+                )
+            try:
+                bot_service_module._validate_strategy_configuration(
+                    strategy_type=source_strategy,
+                    timeframe_unit=str(source_config.timeframe_unit),
+                    timeframe_unit_number=int(source_config.timeframe_unit_number),
+                    fast_period=fast_period,
+                    slow_period=slow_period,
+                )
+            except Exception as exc:
+                self._topbot_source_static_errors[source_strategy] = str(exc)
+
+    def _event_in_configured_session(self, event_timestamp: datetime) -> bool:
+        timestamp = _as_utc(event_timestamp)
+        if self._current_event_timestamp == timestamp:
+            return self._current_event_in_session
+        if not futures_session_is_open(timestamp):
+            return False
+        local_time = timestamp.astimezone(TRADING_TZ).time().replace(tzinfo=None)
+        start = self._configured_session_start
+        end = self._configured_session_end
+        if start <= end:
+            return start <= local_time <= end
+        return local_time >= start or local_time <= end
+
+    def _evaluate_prepared_sma(self, closed_count: int) -> SignalResult:
+        closes = self._sma_close_values
+        assert closes is not None
+        fast_period = int(self.config.fast_period)
+        slow_period = int(self.config.slow_period)
+        visible_count = min(closed_count, self.evaluator_history_limit)
+        latest_index = closed_count - 1
+        latest = self.all_candles[latest_index]
+        if visible_count < slow_period + 1:
+            return SignalResult(
+                action="HOLD",
+                reason=(
+                    f"Need at least {slow_period + 1} closed candles; "
+                    f"found {visible_count}."
+                ),
+                candle_timestamp=self.all_start_times[latest_index],
+                price=float(latest.close_price),
+                raw_payload={
+                    "fast_period": fast_period,
+                    "slow_period": slow_period,
+                    "closed_count": visible_count,
+                },
+            )
+
+        previous_fast = bot_service_module._average(
+            closes[closed_count - fast_period - 1 : closed_count - 1]
+        )
+        previous_slow = bot_service_module._average(
+            closes[closed_count - slow_period - 1 : closed_count - 1]
+        )
+        current_fast = bot_service_module._average(
+            closes[closed_count - fast_period : closed_count]
+        )
+        current_slow = bot_service_module._average(
+            closes[closed_count - slow_period : closed_count]
+        )
+        action = "HOLD"
+        if previous_fast <= previous_slow and current_fast > current_slow:
+            action = "BUY"
+        elif previous_fast >= previous_slow and current_fast < current_slow:
+            action = "SELL"
+        reason = (
+            "No SMA crossover on the latest closed candle."
+            if action == "HOLD"
+            else f"{fast_period}/{slow_period} SMA crossover generated {action}."
+        )
+        return SignalResult(
+            action=action,
+            reason=reason,
+            candle_timestamp=self.all_start_times[latest_index],
+            price=float(latest.close_price),
+            raw_payload={
+                "fast_period": fast_period,
+                "slow_period": slow_period,
+                "previous_fast": previous_fast,
+                "previous_slow": previous_slow,
+                "current_fast": current_fast,
+                "current_slow": current_slow,
+            },
+        )
+
     def _record_topbot_source_failures(self, signal: SignalResult) -> None:
         payload = signal.raw_payload if isinstance(signal.raw_payload, dict) else {}
         ensemble = payload.get("ensemble") if isinstance(payload.get("ensemble"), dict) else {}
@@ -489,7 +781,7 @@ class BacktestEngine:
         closed_history: list[ProjectXMarketCandle],
     ) -> list[ProjectXMarketCandle]:
         if not closed_history:
-            return []
+            return _ClosedCandleList()
         latest_timestamp = _as_utc(closed_history[-1].candle_timestamp)
         rolling_start = max(0, len(closed_history) - self.evaluator_history_limit)
 
@@ -500,11 +792,11 @@ class BacktestEngine:
                 end_text=str(self.config.trading_end_time),
             )
             if latest_timestamp < session_start:
-                return []
+                return _ClosedCandleList()
             if latest_timestamp > session_end:
-                return []
+                return _ClosedCandleList()
             session_start_index = _first_index_at_or_after(closed_history, session_start)
-            session_rows = closed_history[session_start_index:]
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
                 session_rows,
                 expected_start=session_start,
@@ -525,8 +817,9 @@ class BacktestEngine:
                 trading_day_date(latest_timestamp)
             )
             session_start_index = _first_index_at_or_after(closed_history, session_start)
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
-                closed_history[session_start_index:],
+                session_rows,
                 expected_start=session_start,
                 strategy_type=self.strategy_type,
                 enforce=_is_intraday_timeframe(self.config),
@@ -535,9 +828,12 @@ class BacktestEngine:
                     int(self.config.timeframe_unit_number),
                 ),
             )
-            return closed_history[min(rolling_start, session_start_index) :]
+            return _closed_candle_slice(
+                closed_history,
+                min(rolling_start, session_start_index),
+            )
 
-        return closed_history[rolling_start:]
+        return _closed_candle_slice(closed_history, rolling_start)
 
     def _evaluate_real_strategy(self, candles: list[ProjectXMarketCandle]) -> SignalResult:
         params = self.config.strategy_params
@@ -592,21 +888,14 @@ class BacktestEngine:
                 strategy_params=self.config.strategy_params,
             )
         event_time = _candle_close_time(primary_candles[-1])
-        topbot_params = bot_service_module._normalize_strategy_params(
-            _TOPBOT_STRATEGY,
-            self.config.strategy_params,
-        )
-        source_overrides = topbot_params.get("source_strategy_params") or {}
+        topbot_params = self._topbot_params
         source_results: list[dict[str, Any]] = []
         event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
             if source_strategy in self.topbot_unavailable_sources:
                 continue
-            source_params = bot_service_module._normalize_strategy_params(
-                source_strategy,
-                source_overrides.get(source_strategy, {}),
-            )
+            source_params = self._topbot_source_params[source_strategy]
             signature = self._topbot_source_cache_signature(
                 source_strategy,
                 source_params=source_params,
@@ -651,13 +940,8 @@ class BacktestEngine:
         event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
-        for key in _topbot_source_stream_keys(
-            self.config,
-            source_strategy,
-            source_params=source_params,
-        ):
-            stream = self.topbot_streams.get(key)
-            closed_count = bisect_right(stream.close_times, event_time) if stream is not None else 0
+        for key in self._topbot_source_keys[source_strategy]:
+            closed_count = self._topbot_closed_count(key, event_time)
             signature.append((key, closed_count))
         if source_strategy == "donchian_breakout":
             if self.position is None:
@@ -689,34 +973,18 @@ class BacktestEngine:
         event_time: datetime,
         event_timestamp: datetime,
     ) -> dict[str, Any]:
-        fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
-            source_strategy,
-            fast_period=int(self.config.fast_period),
-            slow_period=int(self.config.slow_period),
-        )
-        source_config = _SourceConfigView(
-            self.config,
-            strategy_type=source_strategy,
-            strategy_params=source_params,
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
-        bot_service_module._validate_strategy_configuration(
-            strategy_type=source_strategy,
-            timeframe_unit=str(source_config.timeframe_unit),
-            timeframe_unit_number=int(source_config.timeframe_unit_number),
-            fast_period=fast_period,
-            slow_period=slow_period,
-        )
+        static_error = self._topbot_source_static_errors.get(source_strategy)
+        if static_error is not None:
+            raise ValueError(static_error)
+        source_config = self._topbot_source_configs[source_strategy]
+        fast_period = int(source_config.fast_period)
+        slow_period = int(source_config.slow_period)
 
         primary_key = _topbot_asset_stream_key(
             str(self.config.timeframe_unit),
             int(self.config.timeframe_unit_number),
         )
-        primary_limit = _topbot_primary_source_history_limit(
-            self.config,
-            source_strategy,
-        )
+        primary_limit = self._topbot_primary_limits[source_strategy]
 
         if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
             source_candles = self._topbot_stream_history(
@@ -742,11 +1010,7 @@ class BacktestEngine:
             signal = bot_service_module.dispatch_strategy_evaluator(
                 source_strategy,
                 source_candles,
-                **_generic_evaluator_arguments(
-                    source_strategy,
-                    config=source_config,
-                    strategy_params=source_params,
-                ),
+                **self._topbot_generic_args[source_strategy],
             )
         elif source_strategy == "donchian_breakout":
             source_candles = self._topbot_stream_history(
@@ -789,10 +1053,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -802,7 +1063,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     _topbot_asset_stream_key("minute", 1),
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit="minute",
+                        unit_number=1,
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -830,10 +1095,7 @@ class BacktestEngine:
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            if not _event_timestamp_is_in_configured_session(
-                self.config,
-                event_timestamp,
-            ):
+            if not self._event_in_configured_session(event_timestamp):
                 source_candles = []
                 signal = _topbot_outside_session_signal(
                     source_strategy,
@@ -843,7 +1105,11 @@ class BacktestEngine:
                 source_candles = self._topbot_stream_history(
                     primary_key,
                     event_time=event_time,
-                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    limit=_topbot_configured_session_capacity(
+                        self.config,
+                        unit=str(self.config.timeframe_unit),
+                        unit_number=int(self.config.timeframe_unit_number),
+                    ),
                     not_before=session_start,
                 )
                 _require_complete_session_prefix(
@@ -874,14 +1140,11 @@ class BacktestEngine:
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(self.config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            limit = max(
+                int(self.config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             source_candles = self._topbot_stream_history(
                 _topbot_asset_stream_key("minute", 5),
@@ -1041,21 +1304,49 @@ class BacktestEngine:
         stream = self.topbot_streams.get(key)
         if stream is None or not stream.candles:
             raise ValueError(f"missing_stored_replay_stream:{key}")
-        end_index = bisect_right(stream.close_times, _as_utc(event_time))
+        event_utc = _as_utc(event_time)
+        if self._topbot_history_event != event_utc:
+            self._topbot_history_event = event_utc
+            self._topbot_history_cache.clear()
+        normalized_not_before = _as_utc(not_before) if not_before is not None else None
+        cache_key = (key, max(1, int(limit)), normalized_not_before)
+        cached = self._topbot_history_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        end_index = self._topbot_closed_count(key, event_utc)
         start_index = max(0, end_index - max(1, int(limit)))
-        if not_before is not None:
+        if normalized_not_before is not None:
             start_index = max(
                 start_index,
-                bisect_left(stream.start_times, _as_utc(not_before)),
+                bisect_left(stream.start_times, normalized_not_before),
             )
-        return stream.candles[start_index:end_index]
+        history = _closed_candle_slice(stream.candles, start_index, end_index)
+        self._topbot_history_cache[cache_key] = history
+        return history
+
+    def _topbot_closed_count(self, key: str, event_time: datetime) -> int:
+        stream = self.topbot_streams.get(key)
+        if stream is None:
+            return 0
+        event_utc = _as_utc(event_time)
+        previous_event, count = self._topbot_cursor_state.get(
+            key,
+            (datetime.min.replace(tzinfo=timezone.utc), 0),
+        )
+        if event_utc < previous_event:
+            count = bisect_right(stream.close_times, event_utc)
+        elif event_utc > previous_event:
+            while count < len(stream.close_times) and stream.close_times[count] <= event_utc:
+                count += 1
+        self._topbot_cursor_state[key] = (event_utc, count)
+        return count
 
     def _fill_pending_signal(
         self,
         pending: _PendingSignal,
         *,
         candle: ProjectXMarketCandle,
-        bar_index: int,
     ) -> None:
         fill_time = _as_utc(candle.candle_timestamp)
         if not _signal_fill_is_in_same_session(
@@ -1071,7 +1362,7 @@ class BacktestEngine:
         is_exit_only = signal_category == "exit"
 
         if self.position is not None and self.position.side != desired_side:
-            self.exposed_bar_indexes.add(bar_index)
+            self._current_bar_exposed = True
             self._update_excursion(float(candle.open_price), float(candle.open_price))
             exit_reason = str(pending.payload.get("exit_reason") or "position_reversal")
             self._close_position(
@@ -1136,7 +1427,7 @@ class BacktestEngine:
             stop_loss=stop_loss,
             take_profit=take_profit,
         )
-        self.exposed_bar_indexes.add(bar_index)
+        self._current_bar_exposed = True
 
     def _can_enter(self, timestamp: datetime) -> bool:
         if not _contract_is_allowed(self.config):
@@ -1330,6 +1621,8 @@ class BacktestEngine:
         return float(raw + slip if action == "BUY" else raw - slip)
 
     def _record_equity(self, *, event_time: datetime, mark_price: float) -> None:
+        if self._current_bar_exposed:
+            self.exposed_bar_count += 1
         unrealized = 0.0
         if self.position is not None:
             unrealized = _price_pnl(
@@ -1363,18 +1656,13 @@ class BacktestEngine:
             self.equity_curve.append(point)
 
     def _add_data_quality_warnings(self) -> None:
-        warmup_count = sum(
-            1
-            for row in self.all_candles
-            if _as_utc(row.candle_timestamp) < self.settings.start
-            and _candle_close_time(row) <= _candle_close_time(self.execution_candles[0])
+        warmup_count = min(
+            bisect_left(self.all_start_times, self.settings.start),
+            bisect_right(self.all_close_times, self.execution_close_times[0]),
         )
-        requested_warmup = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(self.config.lookback_bars),
-                _strategy_history_bars(self.config, hard_minimum=False),
-            ),
+        requested_warmup = max(
+            int(self.config.lookback_bars),
+            _strategy_history_bars(self.config, hard_minimum=False),
         )
         if self.strategy_type == _TOPBOT_STRATEGY:
             primary_key = _topbot_asset_stream_key(
@@ -1397,8 +1685,8 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
-            actual_end = _candle_close_time(self.execution_candles[-1])
+            actual_start = self.execution_start_times[0]
+            actual_end = self.execution_close_times[-1]
             if _has_open_futures_interval(
                 self.settings.start,
                 actual_start,
@@ -1430,7 +1718,7 @@ class BacktestEngine:
                 str(self.config.timeframe_unit),
                 int(self.config.timeframe_unit_number),
             )
-            first_event = _candle_close_time(self.execution_candles[0])
+            first_event = self.execution_close_times[0]
             for key, spec in sorted(_topbot_stream_specs(self.config).items()):
                 if key == primary_key:
                     continue
@@ -1512,9 +1800,9 @@ def _topbot_primary_source_history_limit(config: BotConfig, source_strategy: str
         int(config.timeframe_unit_number),
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return limit
     session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-    return min(MAX_BACKTEST_BARS, max(limit, session_capacity))
+    return max(limit, session_capacity)
 
 
 def _topbot_configured_session_capacity(
@@ -1525,7 +1813,7 @@ def _topbot_configured_session_capacity(
 ) -> int:
     timeframe_seconds = _timeframe_seconds(unit, unit_number)
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return max(1, int(config.lookback_bars))
     start = _parse_time(str(config.trading_start_time))
     end = _parse_time(str(config.trading_end_time))
     start_seconds = start.hour * 3600 + start.minute * 60 + start.second
@@ -1533,26 +1821,20 @@ def _topbot_configured_session_capacity(
     duration = end_seconds - start_seconds
     if duration < 0:
         duration += 24 * 60 * 60
-    return min(
-        MAX_BACKTEST_BARS,
-        max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2),
-    )
+    return max(1, math.ceil((duration + 60 * 60) / timeframe_seconds) + 2)
 
 
 def _relative_strength_spy_history_limit(
     config: BotConfig,
     source_params: Mapping[str, Any],
 ) -> int:
-    return min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            int(source_params["comparison_bars"]) + 1,
-            int(source_params["pullback_lookback_bars"]) + 1,
-            int(source_params["relative_volume_period"]) + 1,
-            int(source_params["major_level_lookback_bars"]),
-            50,
-        ),
+    return max(
+        int(config.lookback_bars),
+        int(source_params["comparison_bars"]) + 1,
+        int(source_params["pullback_lookback_bars"]) + 1,
+        int(source_params["relative_volume_period"]) + 1,
+        int(source_params["major_level_lookback_bars"]),
+        50,
     )
 
 
@@ -1634,14 +1916,11 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
-            opening_limit = min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_lookback_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            opening_limit = max(
+                int(config.lookback_bars),
+                (calendar_lookback_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
             add_asset("minute", 5, opening_limit)
         elif source_strategy == "delayed_orb_confirmation":
@@ -1787,9 +2066,16 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    _copy_closed_candle_metadata(candles, closed)
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     contract_ids: set[str] = set()
@@ -1926,46 +2212,112 @@ def _prepared_stream_covers_replay_window(
     return True
 
 
-def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: int) -> int:
+def _topbot_cached_source_evaluation_counts(
+    config: BotConfig,
+    *,
+    streams: Mapping[str, _PreparedReplayStream],
+    event_times: list[datetime],
+    unavailable_sources: Mapping[str, tuple[str, ...]],
+) -> dict[str, int]:
+    """Count source evaluations after unchanged synchronized states are cached."""
+
+    if not event_times:
+        return {}
     params = bot_service_module._normalize_strategy_params(
         _TOPBOT_STRATEGY,
         config.strategy_params,
     )
     overrides = params.get("source_strategy_params") or {}
-    per_event = 0
+    counts_by_keys: dict[tuple[str, ...], int] = {}
+    source_counts: dict[str, int] = {}
     for source in params["source_strategies"]:
+        if source in unavailable_sources:
+            continue
         source_params = bot_service_module._normalize_strategy_params(
             source,
             overrides.get(source, {}),
         )
+        if source in {"delayed_orb_confirmation", "donchian_breakout"}:
+            # These signatures include the primary event or mutable position.
+            source_counts[source] = len(event_times)
+            continue
+        keys = _topbot_source_stream_keys(
+            config,
+            source,
+            source_params=source_params,
+        )
+        cached_count = counts_by_keys.get(keys)
+        if cached_count is None:
+            cursors = [0] * len(keys)
+            previous_signature: tuple[int, ...] | None = None
+            cached_count = 0
+            for event_time in event_times:
+                signature: list[int] = []
+                for index, key in enumerate(keys):
+                    stream = streams.get(key)
+                    close_times = stream.close_times if stream is not None else []
+                    cursor = cursors[index]
+                    while cursor < len(close_times) and close_times[cursor] <= event_time:
+                        cursor += 1
+                    cursors[index] = cursor
+                    signature.append(cursor)
+                current_signature = tuple(signature)
+                if current_signature != previous_signature:
+                    cached_count += 1
+                    previous_signature = current_signature
+            counts_by_keys[keys] = cached_count
+        source_counts[source] = cached_count
+    return source_counts
+
+
+def _estimate_topbot_evaluator_operations(
+    config: BotConfig,
+    *,
+    execution_bars: int,
+    source_evaluations: Mapping[str, int] | None = None,
+    unavailable_sources: Mapping[str, tuple[str, ...]] | None = None,
+) -> int:
+    params = bot_service_module._normalize_strategy_params(
+        _TOPBOT_STRATEGY,
+        config.strategy_params,
+    )
+    overrides = params.get("source_strategy_params") or {}
+    # The ensemble vote still runs on every in-session primary event, even
+    # when every source result is cached or unavailable.
+    estimated = max(0, execution_bars) * max(1, len(params["source_strategies"]))
+    for source in params["source_strategies"]:
+        if unavailable_sources is not None and source in unavailable_sources:
+            continue
+        source_params = bot_service_module._normalize_strategy_params(
+            source,
+            overrides.get(source, {}),
+        )
+        source_cost = 0
         if source in _TOPBOT_SHARED_CONFIGURED_STRATEGIES or source == "donchian_breakout":
-            per_event += _topbot_primary_source_history_limit(config, source)
+            source_cost += _topbot_primary_source_history_limit(config, source)
         elif source in _TOPBOT_LEVEL_STRATEGIES:
-            per_event += int(source_params["bars_per_timeframe"]) * 2
+            source_cost += int(source_params["bars_per_timeframe"]) * 2
         elif source == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_days = max(lookback_days + 14, 21)
-            per_event += min(
-                MAX_BACKTEST_BARS,
-                max(
-                    int(config.lookback_bars),
-                    (calendar_days + 1) * ((24 * 60) // 5),
-                    int(source_params["atr_period"]) * 20,
-                    500,
-                ),
+            source_cost += max(
+                int(config.lookback_bars),
+                (calendar_days + 1) * ((24 * 60) // 5),
+                int(source_params["atr_period"]) * 20,
+                500,
             )
         elif source == "delayed_orb_confirmation":
-            per_event += 1500
+            source_cost += 1500
         elif source == "orb_fibonacci_pullback":
             timeframe_seconds = _timeframe_seconds(
                 str(config.timeframe_unit),
                 int(config.timeframe_unit_number),
             ) or 60
-            per_event += max(1, math.ceil((25 * 60 * 60) / timeframe_seconds))
+            source_cost += max(1, math.ceil((25 * 60 * 60) / timeframe_seconds))
         elif source == "vwap_gap_retrace":
-            per_event += int(source_params["bars_to_fetch"])
+            source_cost += int(source_params["bars_to_fetch"])
         elif source == "supertrend_pivot":
-            per_event += max(
+            source_cost += max(
                 int(config.lookback_bars),
                 int(source_params["supertrend_period"])
                 + int(source_params["chop_lookback_bars"])
@@ -1983,17 +2335,29 @@ def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: 
             ) or 1
             structure_seconds = _timeframe_seconds(unit, unit_number) or 1
             ratio = max(1, int(round(base_seconds / structure_seconds)))
-            per_event += fvg_limit + min(5000, max(fvg_limit * ratio, fvg_limit + 25))
+            source_cost += fvg_limit + min(
+                5000,
+                max(fvg_limit * ratio, fvg_limit + 25),
+            )
         elif source == "atr_adjusted_relative_strength":
-            per_event += _topbot_primary_source_history_limit(
+            source_cost += _topbot_primary_source_history_limit(
                 config,
                 source,
             ) + max(25, int(config.lookback_bars))
         elif source == "relative_strength_spy":
-            per_event += _relative_strength_spy_history_limit(config, source_params) * 2
+            source_cost += _relative_strength_spy_history_limit(
+                config,
+                source_params,
+            ) * 2
         else:
-            per_event += _topbot_primary_source_history_limit(config, source)
-    return execution_bars * max(1, per_event)
+            source_cost += _topbot_primary_source_history_limit(config, source)
+        evaluation_count = (
+            int(source_evaluations.get(source, execution_bars))
+            if source_evaluations is not None
+            else execution_bars
+        )
+        estimated += max(0, evaluation_count) * max(1, source_cost)
+    return estimated
 
 
 def _load_topbot_replay_streams(
@@ -2010,13 +2374,42 @@ def _load_topbot_replay_streams(
         int(config.timeframe_unit_number),
     )
     streams: dict[str, list[ProjectXMarketCandle]] = {primary_key: primary_rows}
+    specs = _topbot_stream_specs(config)
     total_rows = len(primary_rows)
+    replay_start = _as_utc(start)
+    replay_end = _as_utc(end)
+    primary_execution_count = 0
+    primary_index = _first_index_at_or_after(primary_rows, replay_start)
+    while (
+        primary_index < len(primary_rows)
+        and _candle_close_time(primary_rows[primary_index]) <= replay_end
+    ):
+        primary_execution_count += 1
+        primary_index += 1
 
-    for key, spec in _topbot_stream_specs(config).items():
+    def stream_identity(spec: _TopBotReplayStreamSpec) -> tuple[str, str, str, int]:
+        if spec.contract_id is not None:
+            return ("contract", spec.contract_id, spec.unit, spec.unit_number)
+        return ("symbol", str(spec.symbol or ""), spec.unit, spec.unit_number)
+
+    specs_by_identity: dict[
+        tuple[str, str, str, int],
+        list[tuple[str, _TopBotReplayStreamSpec]],
+    ] = {}
+    for key, spec in specs.items():
         if key == primary_key:
             continue
+        identity = stream_identity(spec)
+        specs_by_identity.setdefault(identity, []).append((key, spec))
+
+    for identity, grouped_specs in specs_by_identity.items():
+        spec = grouped_specs[0][1]
+        max_warmup_bars = max(
+            int(grouped_spec.warmup_bars)
+            for _grouped_key, grouped_spec in grouped_specs
+        )
         query = (
-            db.query(ProjectXMarketCandle)
+            _projected_candle_query(db)
             .filter(ProjectXMarketCandle.user_id == user_id)
             .filter(ProjectXMarketCandle.live.is_(False))
             .filter(ProjectXMarketCandle.unit == spec.unit)
@@ -2033,37 +2426,49 @@ def _load_topbot_replay_streams(
                 )
             )
 
-        execution_rows = (
+        execution_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp >= start)
             .filter(ProjectXMarketCandle.candle_timestamp <= end)
             .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-            .limit(MAX_TOPBOT_REPLAY_STREAM_BARS + 1)
-            .all()
+        )
+        execution_rows = _collect_projected_candles(
+            execution_query,
+            reserved_replay_rows=total_rows,
+            reserved_execution_rows=primary_execution_count,
         )
         execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-        if len(execution_rows) > MAX_TOPBOT_REPLAY_STREAM_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_stream_bar_limit_exceeded: "
-                f"{key} exceeds {MAX_TOPBOT_REPLAY_STREAM_BARS:,} bars; reduce the date range"
-            )
-        warmup_rows = (
+        warmup_query = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
             # One candle can start before the requested range while closing
             # after the first replay event. Overfetch it so the requested
             # number of genuinely closed warmup bars remains available.
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
-            .all()
+            .limit(max(1, max_warmup_bars + 1))
+        )
+        warmup_rows = _collect_projected_candles(
+            warmup_query,
+            reserved_replay_rows=total_rows + len(execution_rows),
+            reserved_execution_rows=primary_execution_count,
         )
         warmup_rows.reverse()
-        rows = [*warmup_rows, *execution_rows]
-        streams[key] = rows
-        total_rows += len(rows)
-        if total_rows > MAX_TOPBOT_REPLAY_TOTAL_BARS:
-            raise BacktestConfigurationError(
-                "topbot_replay_total_bar_limit_exceeded: synchronized streams contain "
-                f"more than {MAX_TOPBOT_REPLAY_TOTAL_BARS:,} bars; reduce the date range"
+        physical_row_count = len(warmup_rows) + len(execution_rows)
+        total_rows += physical_row_count
+        _enforce_backtest_resource_budget(
+            replay_rows=total_rows,
+            execution_rows=primary_execution_count,
+        )
+
+        # Query one physical stream once, but preserve the historical per-key
+        # warmup window.  That keeps persisted fingerprints byte-for-byte
+        # compatible while sharing the projected candle objects in memory.
+        for key, grouped_spec in grouped_specs:
+            requested_warmup = max(1, int(grouped_spec.warmup_bars) + 1)
+            rows = _PhysicalReplayList(
+                [*warmup_rows[-requested_warmup:], *execution_rows]
             )
+            rows._topsignal_physical_stream = identity
+            rows._topsignal_physical_row_count = physical_row_count
+            streams[key] = rows
 
     return streams
 
@@ -2126,22 +2531,13 @@ def prepare_bot_backtest_data(
         elif int(spec.warmup_bars) > existing[2]:
             requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
 
-    primary_execution_rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    primary_execution_rows = _load_primary_candle_range(
+        db,
+        user_id=user_id,
+        config=config,
+        start_at=start,
+        closed_by=fetch_end,
     )
-    primary_execution_rows = [
-        row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
-    ]
     first_event = (
         _candle_close_time(primary_execution_rows[0])
         if primary_execution_rows
@@ -2192,6 +2588,7 @@ def prepare_bot_backtest_data(
             first_event=first_event,
             last_event=last_event,
             warmup_bars=warmup_bars,
+            reserved_replay_rows=len(primary_execution_rows),
         ):
             continue
         cursor = fetch_start
@@ -2221,22 +2618,13 @@ def prepare_bot_backtest_data(
         prepared_count += 1
 
         if identity == primary_identity:
-            primary_execution_rows = (
-                db.query(ProjectXMarketCandle)
-                .filter(ProjectXMarketCandle.user_id == user_id)
-                .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-                .filter(ProjectXMarketCandle.live.is_(False))
-                .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-                .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-                .filter(ProjectXMarketCandle.is_partial.is_(False))
-                .filter(ProjectXMarketCandle.candle_timestamp >= start)
-                .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
-                .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-                .all()
+            primary_execution_rows = _load_primary_candle_range(
+                db,
+                user_id=user_id,
+                config=config,
+                start_at=start,
+                closed_by=fetch_end,
             )
-            primary_execution_rows = [
-                row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
-            ]
             if primary_execution_rows:
                 first_event = _candle_close_time(primary_execution_rows[0])
                 last_event = _candle_close_time(primary_execution_rows[-1])
@@ -2256,12 +2644,13 @@ def _cached_replay_stream_covers(
     first_event: datetime,
     last_event: datetime,
     warmup_bars: int,
+    reserved_replay_rows: int = 0,
 ) -> bool:
     interval_seconds = _timeframe_seconds(unit, unit_number)
     if interval_seconds is None:
         return False
-    rows = (
-        db.query(ProjectXMarketCandle)
+    query = (
+        _projected_candle_query(db)
         .filter(ProjectXMarketCandle.user_id == user_id)
         .filter(ProjectXMarketCandle.contract_id == contract_id)
         .filter(ProjectXMarketCandle.live.is_(False))
@@ -2271,23 +2660,27 @@ def _cached_replay_stream_covers(
         .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
         .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
         .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    )
+    rows = _collect_projected_candles(
+        query,
+        reserved_replay_rows=reserved_replay_rows,
     )
     if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
         return False
     if _candle_stream_has_overlaps(rows):
         return False
-    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
-    warmup_count = sum(
-        _as_utc(row.candle_timestamp) < requested_start
-        for row in closed_by_first
-    )
+    close_times = [_candle_close_time(row) for row in rows]
+    start_times = [_as_utc(row.candle_timestamp) for row in rows]
+    first_end = bisect_right(close_times, first_event)
+    last_end = bisect_right(close_times, last_event)
+    closed_by_first = rows[:first_end]
+    warmup_count = min(first_end, bisect_left(start_times, requested_start))
     if warmup_count < max(1, int(warmup_bars)):
         return False
 
     for event, candidates in (
         (first_event, closed_by_first),
-        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+        (last_event, rows[:last_end]),
     ):
         if not candidates:
             return False
@@ -2336,6 +2729,85 @@ def run_backtest(
     ).run()
 
 
+def _projected_candle_query(db: Session):
+    """Select only replay fields, avoiding ORM identity-map materialization."""
+
+    return db.query(
+        ProjectXMarketCandle.user_id,
+        ProjectXMarketCandle.contract_id,
+        ProjectXMarketCandle.symbol,
+        ProjectXMarketCandle.live,
+        ProjectXMarketCandle.unit,
+        ProjectXMarketCandle.unit_number,
+        ProjectXMarketCandle.candle_timestamp,
+        ProjectXMarketCandle.open_price,
+        ProjectXMarketCandle.high_price,
+        ProjectXMarketCandle.low_price,
+        ProjectXMarketCandle.close_price,
+        ProjectXMarketCandle.volume,
+        ProjectXMarketCandle.is_partial,
+        ProjectXMarketCandle.raw_payload,
+        ProjectXMarketCandle.fetched_at,
+    )
+
+
+def _collect_projected_candles(
+    query: Any,
+    *,
+    reserved_replay_rows: int = 0,
+    reserved_execution_rows: int = 0,
+) -> list[ProjectXMarketCandle]:
+    rows: list[ProjectXMarketCandle] = []
+    for values in query.yield_per(CANDLE_QUERY_CHUNK_SIZE):
+        rows.append(_ProjectedCandle(*values))
+        if len(rows) % CANDLE_QUERY_CHUNK_SIZE == 0:
+            _enforce_backtest_resource_budget(
+                replay_rows=reserved_replay_rows + len(rows),
+                execution_rows=reserved_execution_rows,
+            )
+    # Enforce the final partial chunk too.  This is also the only check for
+    # small queries, which must not allocate on top of an exhausted budget.
+    _enforce_backtest_resource_budget(
+        replay_rows=reserved_replay_rows + len(rows),
+        execution_rows=reserved_execution_rows,
+    )
+    return rows
+
+
+def _load_primary_candle_range(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    closed_by: datetime,
+    start_at: datetime | None = None,
+) -> _ClosedCandleList:
+    cutoff = _as_utc(closed_by)
+    query = (
+        _projected_candle_query(db)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
+    )
+    if start_at is not None:
+        query = query.filter(
+            ProjectXMarketCandle.candle_timestamp >= _as_utc(start_at)
+        )
+    rows = _collect_projected_candles(
+        query.order_by(ProjectXMarketCandle.candle_timestamp.asc())
+    )
+    return _ClosedCandleList(
+        row
+        for row in rows
+        if not _cached_candle_is_effectively_partial(row)
+        and _candle_close_time(row) <= cutoff
+    )
+
+
 def _load_primary_closed_candles(
     db: Session,
     *,
@@ -2345,25 +2817,12 @@ def _load_primary_closed_candles(
 ) -> list[ProjectXMarketCandle]:
     """Load every eligible primary bar without rolling across futures deliveries."""
 
-    cutoff = _as_utc(closed_by)
-    rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .all()
+    return _load_primary_candle_range(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=closed_by,
     )
-    return [
-        row
-        for row in rows
-        if not _cached_candle_is_effectively_partial(row)
-        and _candle_close_time(row) <= cutoff
-    ]
 
 
 def _requested_backtest_bounds(payload: Any) -> tuple[datetime, datetime] | None:
@@ -2661,19 +3120,21 @@ def create_bot_backtest(
         )
         window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
 
-    execution_rows = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) >= window.start
-        and _candle_close_time(row) <= window.end
+    primary_start_times = [
+        _as_utc(row.candle_timestamp) for row in primary_rows
     ]
+    primary_close_times = [_candle_close_time(row) for row in primary_rows]
+    execution_start_index = bisect_left(primary_start_times, window.start)
+    execution_end_index = bisect_right(primary_close_times, window.end)
+    execution_rows = _closed_candle_slice(
+        primary_rows,
+        execution_start_index,
+        execution_end_index,
+    )
 
-    rolling_warmup_limit = min(
-        MAX_BACKTEST_BARS,
-        max(
-            int(config.lookback_bars),
-            _strategy_history_bars(config, hard_minimum=False),
-        ),
+    rolling_warmup_limit = max(
+        int(config.lookback_bars),
+        _strategy_history_bars(config, hard_minimum=False),
     )
     if is_topbot:
         primary_key = _topbot_asset_stream_key(
@@ -2681,21 +3142,22 @@ def create_bot_backtest(
             int(config.timeframe_unit_number),
         )
         primary_spec = _topbot_stream_specs(config)[primary_key]
-        rolling_warmup_limit = min(
-            MAX_BACKTEST_BARS,
-            max(rolling_warmup_limit, primary_spec.warmup_bars),
+        rolling_warmup_limit = max(
+            rolling_warmup_limit,
+            primary_spec.warmup_bars,
         )
     warmup_limit = _max_evaluator_input_bars(
         config,
         rolling_limit=rolling_warmup_limit,
     )
-    warmup_candidates = [
-        row
-        for row in primary_rows
-        if _as_utc(row.candle_timestamp) < window.start
-    ]
-    warmup_rows = warmup_candidates[-warmup_limit:]
-    replay_rows = [*warmup_rows, *execution_rows]
+    warmup_start_index = max(0, execution_start_index - warmup_limit)
+    warmup_rows = _closed_candle_slice(
+        primary_rows,
+        warmup_start_index,
+        execution_start_index,
+    )
+    replay_rows = _ClosedCandleList(warmup_rows)
+    replay_rows.extend(execution_rows)
     replay_streams: dict[str, list[ProjectXMarketCandle]] | None = None
     if is_topbot:
         replay_streams = _load_topbot_replay_streams(
@@ -2772,7 +3234,12 @@ def serialize_bot_backtest(row: BotBacktest) -> dict[str, Any]:
 
 
 def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
-    canonical = [
+    ordered = (
+        candles
+        if getattr(candles, "_topsignal_sorted_closed", False)
+        else sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+    )
+    return _incremental_candle_fingerprint(
         {
             "contract_id": str(row.contract_id),
             "live": bool(row.live),
@@ -2786,37 +3253,60 @@ def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
             "volume": str(row.volume),
             "is_partial": bool(row.is_partial),
         }
-        for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
+        for row in ordered
         if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    )
 
 
 def candle_stream_input_fingerprint(
     streams: Mapping[str, list[ProjectXMarketCandle]],
 ) -> str:
-    canonical = [
-        {
-            "stream": key,
-            "contract_id": str(row.contract_id),
-            "live": bool(row.live),
-            "unit": str(row.unit),
-            "unit_number": int(row.unit_number),
-            "timestamp": _as_utc(row.candle_timestamp).isoformat(),
-            "open": str(row.open_price),
-            "high": str(row.high_price),
-            "low": str(row.low_price),
-            "close": str(row.close_price),
-            "volume": str(row.volume),
-            "is_partial": bool(row.is_partial),
-        }
-        for key in sorted(streams)
-        for row in sorted(streams[key], key=lambda candle: _as_utc(candle.candle_timestamp))
-        if not bool(row.is_partial)
-    ]
-    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    def canonical_rows() -> Iterable[dict[str, Any]]:
+        for key in sorted(streams):
+            candles = streams[key]
+            ordered = (
+                candles
+                if getattr(candles, "_topsignal_sorted_closed", False)
+                else sorted(
+                    candles,
+                    key=lambda candle: _as_utc(candle.candle_timestamp),
+                )
+            )
+            for row in ordered:
+                if bool(row.is_partial):
+                    continue
+                yield {
+                    "stream": key,
+                    "contract_id": str(row.contract_id),
+                    "live": bool(row.live),
+                    "unit": str(row.unit),
+                    "unit_number": int(row.unit_number),
+                    "timestamp": _as_utc(row.candle_timestamp).isoformat(),
+                    "open": str(row.open_price),
+                    "high": str(row.high_price),
+                    "low": str(row.low_price),
+                    "close": str(row.close_price),
+                    "volume": str(row.volume),
+                    "is_partial": bool(row.is_partial),
+                }
+
+    return _incremental_candle_fingerprint(canonical_rows())
+
+
+def _incremental_candle_fingerprint(rows: Iterable[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first = True
+    for row in rows:
+        if first:
+            first = False
+        else:
+            digest.update(b",")
+        digest.update(
+            json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
+    digest.update(b"]")
+    return digest.hexdigest()
 
 
 def _require_supported_strategy(strategy_type: str) -> None:
@@ -2871,6 +3361,62 @@ def _contract_is_allowed(config: BotConfig) -> bool:
     return bool(allowed.intersection(candidates))
 
 
+def _closed_candle_slice(
+    candles: list[ProjectXMarketCandle],
+    start: int,
+    end: int | None = None,
+) -> list[ProjectXMarketCandle]:
+    sliced = candles[start:end]
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        return _ClosedCandleList(sliced)
+    return sliced
+
+
+def _copy_closed_candle_metadata(
+    source: list[ProjectXMarketCandle],
+    target: _ClosedCandleList,
+) -> None:
+    physical_stream = getattr(source, "_topsignal_physical_stream", None)
+    physical_row_count = getattr(source, "_topsignal_physical_row_count", None)
+    if physical_stream is not None and physical_row_count is not None:
+        target._topsignal_physical_stream = physical_stream
+        target._topsignal_physical_row_count = int(physical_row_count)
+
+
+def _enforce_backtest_resource_budget(
+    *,
+    replay_rows: int,
+    execution_rows: int,
+) -> None:
+    budget = max(1, int(BACKTEST_MEMORY_BUDGET_BYTES))
+    estimated = (
+        max(0, int(replay_rows)) * ESTIMATED_REPLAY_CANDLE_BYTES
+        + max(0, int(execution_rows)) * ESTIMATED_EXECUTION_RESULT_BYTES
+    )
+    if estimated <= budget:
+        return
+    estimated_mib = math.ceil(estimated / (1024 * 1024))
+    budget_mib = max(1, budget // (1024 * 1024))
+    raise BacktestConfigurationError(
+        "backtest_resource_budget_exceeded: the complete resolved history requires "
+        f"an estimated {estimated_mib:,} MiB, above the configured {budget_mib:,} MiB "
+        "working-set budget; no partial result was saved"
+    )
+
+
+def _enforce_backtest_work_budget(estimated_evaluator_bar_visits: int) -> None:
+    budget = max(1, int(BACKTEST_EVALUATOR_WORK_BUDGET))
+    estimated = max(0, int(estimated_evaluator_bar_visits))
+    if estimated <= budget:
+        return
+    raise BacktestConfigurationError(
+        "backtest_computation_limit_exceeded: the complete resolved history and "
+        "strategy lookback require an estimated "
+        f"{estimated:,} evaluator bar-visits, above the configured {budget:,} "
+        "work budget; no partial result was saved"
+    )
+
+
 def _validate_settings(settings: BacktestSettings) -> BacktestSettings:
     normalized = BacktestSettings(
         start=_as_utc(settings.start),
@@ -2900,9 +3446,16 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
-    excluded_partial = len(candles) - len(closed)
-    closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = _ClosedCandleList(candles)
+        excluded_partial = 0
+    else:
+        closed = _ClosedCandleList(
+            row for row in candles if not _cached_candle_is_effectively_partial(row)
+        )
+        excluded_partial = len(candles) - len(closed)
+        closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    _copy_closed_candle_metadata(candles, closed)
     seen: set[datetime] = set()
     previous_close_time: datetime | None = None
     for row in closed:
@@ -3447,11 +4000,11 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
         str(config.timeframe_unit), int(config.timeframe_unit_number)
     )
     if timeframe_seconds is None or timeframe_seconds <= 0:
-        return MAX_BACKTEST_BARS
+        return rolling_limit
     if str(config.strategy_type) in _TRADING_DAY_VWAP_STRATEGIES:
         # A New York trading day spans 25 real hours across the fall DST change.
         session_capacity = math.ceil((25 * 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(rolling_limit, session_capacity))
+        return max(rolling_limit, session_capacity)
     if str(config.strategy_type) == "orb_fibonacci_pullback":
         start = _parse_time(str(config.trading_start_time))
         end = _parse_time(str(config.trading_end_time))
@@ -3462,7 +4015,7 @@ def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
             duration += 24 * 60 * 60
         # Overnight configured windows can also cross a fall DST transition.
         session_capacity = math.ceil((duration + 60 * 60) / timeframe_seconds) + 2
-        return min(MAX_BACKTEST_BARS, max(1, session_capacity))
+        return max(1, session_capacity)
     return rolling_limit
 
 

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -2001,9 +2001,35 @@ def _load_topbot_replay_streams(
     )
     streams: dict[str, list[ProjectXMarketCandle]] = {primary_key: primary_rows}
     total_rows = len(primary_rows)
+    specs = _topbot_stream_specs(config)
 
-    for key, spec in _topbot_stream_specs(config).items():
+    def stream_identity(spec: _TopBotReplayStreamSpec) -> tuple[str, str, int]:
+        return (
+            str(spec.contract_id or spec.symbol),
+            str(spec.unit),
+            int(spec.unit_number),
+        )
+
+    max_warmup_by_identity: dict[tuple[str, str, int], int] = {}
+    for spec in specs.values():
+        identity = stream_identity(spec)
+        max_warmup_by_identity[identity] = max(
+            max_warmup_by_identity.get(identity, 0),
+            int(spec.warmup_bars),
+        )
+
+    primary_spec = specs[primary_key]
+    rows_by_identity: dict[
+        tuple[str, str, int], list[ProjectXMarketCandle]
+    ] = {stream_identity(primary_spec): primary_rows}
+
+    for key, spec in specs.items():
         if key == primary_key:
+            continue
+        identity = stream_identity(spec)
+        cached_rows = rows_by_identity.get(identity)
+        if cached_rows is not None:
+            streams[key] = cached_rows
             continue
         query = (
             db.query(ProjectXMarketCandle)
@@ -2042,11 +2068,17 @@ def _load_topbot_replay_streams(
             # One candle can start before the requested range while closing
             # after the first replay event. Overfetch it so the requested
             # number of genuinely closed warmup bars remains available.
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
+            .limit(
+                min(
+                    MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    max(1, max_warmup_by_identity[identity] + 1),
+                )
+            )
             .all()
         )
         warmup_rows.reverse()
         rows = [*warmup_rows, *execution_rows]
+        rows_by_identity[identity] = rows
         streams[key] = rows
         total_rows += len(rows)
         if total_rows > MAX_TOPBOT_REPLAY_TOTAL_BARS:
@@ -2147,14 +2179,20 @@ def prepare_bot_backtest_data(
         interval_seconds = _timeframe_seconds(unit, unit_number)
         assert interval_seconds is not None
         identity = (contract_id, unit, unit_number)
-        primary_cache_is_clean = not any(
-            _cached_candle_was_fetched_before_nominal_close(row)
-            for row in primary_execution_rows
-        ) and not _candle_stream_has_overlaps(primary_execution_rows)
         if (
             identity == primary_identity
-            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
-            and primary_cache_is_clean
+            and _cached_primary_stream_covers(
+                db,
+                user_id=user_id,
+                contract_id=contract_id,
+                unit=unit,
+                unit_number=unit_number,
+                fetch_start=fetch_start,
+                requested_start=start,
+                requested_end=fetch_end,
+                warmup_bars=warmup_bars,
+                execution_rows=primary_execution_rows,
+            )
         ):
             continue
         if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
@@ -2220,6 +2258,61 @@ def prepare_bot_backtest_data(
     return prepared_count
 
 
+def _cached_primary_stream_covers(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    unit: str,
+    unit_number: int,
+    fetch_start: datetime,
+    requested_start: datetime,
+    requested_end: datetime,
+    warmup_bars: int,
+    execution_rows: list[ProjectXMarketCandle],
+) -> bool:
+    interval_seconds = _timeframe_seconds(unit, unit_number)
+    if interval_seconds is None or len(execution_rows) < MIN_EXECUTION_BARS:
+        return False
+    if any(_cached_candle_is_effectively_partial(row) for row in execution_rows):
+        return False
+    if _candle_stream_has_overlaps(execution_rows):
+        return False
+    if _count_futures_session_gaps(
+        execution_rows,
+        interval_seconds=interval_seconds,
+    ):
+        return False
+
+    first_start = _as_utc(execution_rows[0].candle_timestamp)
+    last_close = _candle_close_time(execution_rows[-1])
+    if _has_missing_boundary_slot(
+        requested_start,
+        first_start,
+        interval_seconds=interval_seconds,
+    ):
+        return False
+    if _has_missing_boundary_slot(
+        last_close,
+        requested_end,
+        interval_seconds=interval_seconds,
+    ):
+        return False
+
+    return _cached_replay_stream_covers(
+        db,
+        user_id=user_id,
+        contract_id=contract_id,
+        unit=unit,
+        unit_number=unit_number,
+        fetch_start=fetch_start,
+        requested_start=requested_start,
+        first_event=_candle_close_time(execution_rows[0]),
+        last_event=last_close,
+        warmup_bars=warmup_bars,
+    )
+
+
 def _cached_replay_stream_covers(
     db: Session,
     *,
@@ -2236,6 +2329,10 @@ def _cached_replay_stream_covers(
     interval_seconds = _timeframe_seconds(unit, unit_number)
     if interval_seconds is None:
         return False
+    fetch_start_utc = _as_utc(fetch_start)
+    requested_start_utc = _as_utc(requested_start)
+    first_event_utc = _as_utc(first_event)
+    last_event_utc = _as_utc(last_event)
     rows = (
         db.query(ProjectXMarketCandle)
         .filter(ProjectXMarketCandle.user_id == user_id)
@@ -2244,8 +2341,8 @@ def _cached_replay_stream_covers(
         .filter(ProjectXMarketCandle.unit == unit)
         .filter(ProjectXMarketCandle.unit_number == unit_number)
         .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
+        .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start_utc)
+        .filter(ProjectXMarketCandle.candle_timestamp <= last_event_utc)
         .order_by(ProjectXMarketCandle.candle_timestamp.asc())
         .all()
     )
@@ -2253,17 +2350,24 @@ def _cached_replay_stream_covers(
         return False
     if _candle_stream_has_overlaps(rows):
         return False
-    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
+    if _count_futures_session_gaps(rows, interval_seconds=interval_seconds):
+        return False
+    closed_by_first = [
+        row for row in rows if _candle_close_time(row) <= first_event_utc
+    ]
     warmup_count = sum(
-        _as_utc(row.candle_timestamp) < requested_start
+        _as_utc(row.candle_timestamp) < requested_start_utc
         for row in closed_by_first
     )
     if warmup_count < max(1, int(warmup_bars)):
         return False
 
     for event, candidates in (
-        (first_event, closed_by_first),
-        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+        (first_event_utc, closed_by_first),
+        (
+            last_event_utc,
+            [row for row in rows if _candle_close_time(row) <= last_event_utc],
+        ),
     ):
         if not candidates:
             return False
@@ -2493,7 +2597,7 @@ def candle_input_fingerprint(candles: list[ProjectXMarketCandle]) -> str:
             "is_partial": bool(row.is_partial),
         }
         for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp))
-        if not bool(row.is_partial)
+        if not _cached_candle_is_effectively_partial(row)
     ]
     encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
@@ -2519,7 +2623,7 @@ def candle_stream_input_fingerprint(
         }
         for key in sorted(streams)
         for row in sorted(streams[key], key=lambda candle: _as_utc(candle.candle_timestamp))
-        if not bool(row.is_partial)
+        if not _cached_candle_is_effectively_partial(row)
     ]
     encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
@@ -3126,6 +3230,23 @@ def _has_open_futures_interval(
         return False
     return _contains_open_futures_timestamp(
         cursor + timedelta(seconds=interval_seconds),
+        end_utc,
+        step_seconds=interval_seconds,
+    )
+
+
+def _has_missing_boundary_slot(
+    start: datetime,
+    end: datetime,
+    *,
+    interval_seconds: int,
+) -> bool:
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc - start_utc < timedelta(seconds=interval_seconds):
+        return False
+    return _contains_open_futures_timestamp(
+        start_utc,
         end_utc,
         step_seconds=interval_seconds,
     )

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
-from typing import Any, Callable, Mapping
+from itertools import islice
+from typing import Any, Callable, Iterable, Mapping
 
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -46,12 +48,27 @@ from .trading_day import (
 
 
 BACKTEST_ENGINE_VERSION = "1.3.0"
+# Retained as a compatibility constant for callers/tests that display the old
+# limit. It is deliberately not used to truncate or reject replay history.
 MAX_BACKTEST_BARS = 20_000
-MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
-MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
-MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
-MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
 MAX_PROVIDER_FETCH_BARS = 20_000
+CANDLE_QUERY_CHUNK_SIZE = 8_192
+_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES = 1_536 * 1024 * 1024
+try:
+    BACKTEST_MEMORY_BUDGET_BYTES = int(
+        os.getenv(
+            "TOPSIGNAL_BACKTEST_MEMORY_BUDGET_BYTES",
+            str(_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES),
+        )
+    )
+except ValueError:
+    BACKTEST_MEMORY_BUDGET_BYTES = _DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES
+
+# Calibrated with tracemalloc and the projected-row benchmark. These estimates
+# intentionally include Python container overhead and the two per-bar result
+# series, not only raw OHLCV payload bytes.
+ESTIMATED_REPLAY_CANDLE_BYTES = 640
+ESTIMATED_EXECUTION_RESULT_BYTES = 704
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -170,6 +187,33 @@ class _PreparedReplayStream:
     close_times: list[datetime]
 
 
+class _ClosedCandleList(list[ProjectXMarketCandle]):
+    """Internal proof that a replay window is already closed and ordered."""
+
+    _topsignal_sorted_closed = True
+
+
+@dataclass(slots=True)
+class _ProjectedCandle:
+    """Lightweight query result with the candle attribute contract evaluators use."""
+
+    user_id: Any
+    contract_id: str
+    symbol: str | None
+    live: bool
+    unit: str
+    unit_number: int
+    candle_timestamp: datetime
+    open_price: Any
+    high_price: Any
+    low_price: Any
+    close_price: Any
+    volume: Any
+    is_partial: bool
+    raw_payload: Any
+    fetched_at: datetime | None
+
+
 @dataclass(frozen=True)
 class _PendingSignal:
     action: str
@@ -215,11 +259,38 @@ class BacktestEngine:
         _require_supported_strategy(self.strategy_type)
         _validate_replay_configuration(config)
         uses_real_evaluator = signal_evaluator is None
+        self._uses_real_evaluator = uses_real_evaluator
         self.signal_evaluator = signal_evaluator or self._evaluate_real_strategy
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
+        self.all_start_times = [
+            _as_utc(candle.candle_timestamp) for candle in self.all_candles
+        ]
+        self.all_close_times = [
+            _candle_close_time(candle) for candle in self.all_candles
+        ]
+        self._sma_close_values = (
+            [float(candle.close_price) for candle in self.all_candles]
+            if uses_real_evaluator
+            and self.strategy_type == "sma_cross"
+            and evaluate_sma_cross is bot_service_module.evaluate_sma_cross
+            else None
+        )
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
         self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
+        self._topbot_params: dict[str, Any] = {}
+        self._topbot_source_params: dict[str, dict[str, Any]] = {}
+        self._topbot_source_keys: dict[str, tuple[str, ...]] = {}
+        self._topbot_source_configs: dict[str, _SourceConfigView] = {}
+        self._topbot_cursor_state: dict[str, tuple[datetime, int]] = {}
+        self._topbot_history_event: datetime | None = None
+        self._topbot_history_cache: dict[
+            tuple[str, int, datetime | None], list[ProjectXMarketCandle]
+        ] = {}
+        self._current_event_timestamp: datetime | None = None
+        self._current_event_in_session = False
+        self._configured_session_start = _parse_time(str(config.trading_start_time))
+        self._configured_session_end = _parse_time(str(config.trading_end_time))
         auxiliary_excluded_partial = 0
         deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
@@ -231,12 +302,13 @@ class BacktestEngine:
                 primary_candles=self.all_candles,
                 replay_streams=replay_streams,
             )
-        self.execution_candles = [
-            candle
-            for candle in self.all_candles
-            if _as_utc(candle.candle_timestamp) >= self.settings.start
-            and _candle_close_time(candle) <= self.settings.end
-        ]
+            self._prepare_topbot_runtime()
+
+        execution_start = bisect_left(self.all_start_times, self.settings.start)
+        execution_end = bisect_right(self.all_close_times, self.settings.end)
+        self.execution_candles = self.all_candles[execution_start:execution_end]
+        self.execution_start_times = self.all_start_times[execution_start:execution_end]
+        self.execution_close_times = self.all_close_times[execution_start:execution_end]
         if len(self.execution_candles) < MIN_EXECUTION_BARS:
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: at least 2 closed execution bars are required "
@@ -244,76 +316,72 @@ class BacktestEngine:
             )
         if uses_real_evaluator and self.strategy_type != "orb_fibonacci_pullback":
             hard_minimum = _strategy_history_bars(config, hard_minimum=True)
-            first_event = _candle_close_time(self.execution_candles[0])
-            closed_by_first_event = sum(
-                1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
-            )
+            first_event = self.execution_close_times[0]
+            closed_by_first_event = bisect_right(self.all_close_times, first_event)
             if closed_by_first_event < hard_minimum:
                 deferred_execution_bars = hard_minimum - closed_by_first_event
                 self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                self.execution_start_times = self.execution_start_times[
+                    deferred_execution_bars:
+                ]
+                self.execution_close_times = self.execution_close_times[
+                    deferred_execution_bars:
+                ]
                 if len(self.execution_candles) < MIN_EXECUTION_BARS:
-                    available_closed_bars = sum(
-                        1
-                        for candle in self.all_candles
-                        if _candle_close_time(candle) <= self.settings.end
+                    available_closed_bars = bisect_right(
+                        self.all_close_times,
+                        self.settings.end,
                     )
                     raise InsufficientBacktestDataError(
                         "insufficient_backtest_data: insufficient_strategy_warmup: "
                         f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
                         f"only {available_closed_bars} were available"
                     )
-        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            session_execution_candles = [
-                candle
-                for candle in self.execution_candles
-                if _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
-                )
+        self.execution_in_session = (
+            [
+                self._event_in_configured_session(timestamp)
+                for timestamp in self.execution_start_times
             ]
-            coverage_candles = session_execution_candles or self.execution_candles
+            if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY
+            else [True] * len(self.execution_candles)
+        )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            in_session_indexes = [
+                index
+                for index, inside in enumerate(self.execution_in_session)
+                if inside
+            ]
+            first_coverage_index = in_session_indexes[0] if in_session_indexes else 0
+            last_coverage_index = (
+                in_session_indexes[-1]
+                if in_session_indexes
+                else len(self.execution_candles) - 1
+            )
             self.topbot_unavailable_sources = _topbot_unavailable_sources(
                 config,
                 streams=self.topbot_streams,
-                first_event=_candle_close_time(coverage_candles[0]),
-                last_event=_candle_close_time(coverage_candles[-1]),
+                first_event=self.execution_close_times[first_coverage_index],
+                last_event=self.execution_close_times[last_coverage_index],
             )
-        self.evaluator_history_limit = min(
-            MAX_BACKTEST_BARS,
-            max(
-                int(config.lookback_bars),
-                _strategy_history_bars(config, hard_minimum=False),
-            ),
+        self.evaluator_history_limit = max(
+            int(config.lookback_bars),
+            _strategy_history_bars(config, hard_minimum=False),
         )
         self.max_evaluator_input_bars = _max_evaluator_input_bars(
             config,
             rolling_limit=self.evaluator_history_limit,
         )
-        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            signal_evaluation_bars = sum(
-                _event_timestamp_is_in_configured_session(
-                    config,
-                    _as_utc(candle.candle_timestamp),
-                )
-                for candle in self.execution_candles
+        replay_row_count = len(self.all_candles)
+        if self.topbot_streams:
+            replay_row_count += sum(
+                len(stream.candles)
+                for stream in self.topbot_streams.values()
+                if stream.candles is not self.all_candles
             )
-            estimated_operations = _estimate_topbot_evaluator_operations(
-                config,
-                execution_bars=signal_evaluation_bars,
-            )
-            operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
-        else:
-            estimated_operations = len(self.execution_candles) * min(
-                len(self.all_candles), self.max_evaluator_input_bars
-            )
-            operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
-        if estimated_operations > operation_limit:
-            raise BacktestConfigurationError(
-                "backtest_computation_limit_exceeded: the complete resolved history and bot "
-                "lookback exceed the current replay resource budget; no partial result was saved; "
-                f"estimated evaluator bar-visits {estimated_operations:,} exceed "
-                f"{operation_limit:,}"
-            )
+        _enforce_backtest_resource_budget(
+            replay_rows=replay_row_count,
+            execution_rows=len(self.execution_candles),
+        )
 
         self.warnings: list[str] = []
         if excluded_partial:
@@ -351,7 +419,8 @@ class BacktestEngine:
                 "unrealized_pnl": 0.0,
             }
         ]
-        self.exposed_bar_indexes: set[int] = set()
+        self.exposed_bar_count = 0
+        self._current_bar_exposed = False
         self.daily_entry_counts: dict[Any, int] = defaultdict(int)
         self.daily_net_activity: dict[Any, float] = defaultdict(float)
         self.last_loss_at: datetime | None = None
@@ -362,15 +431,24 @@ class BacktestEngine:
         self.topbot_source_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 
     def run(self) -> dict[str, Any]:
-        closed_history: list[ProjectXMarketCandle] = []
+        closed_history: list[ProjectXMarketCandle] = _ClosedCandleList()
         history_cursor = 0
-        for index, candle in enumerate(self.execution_candles):
-            candle_start = _as_utc(candle.candle_timestamp)
-            event_time = _candle_close_time(candle)
+        timeline = zip(
+            self.execution_candles,
+            self.execution_start_times,
+            self.execution_close_times,
+            self.execution_in_session,
+        )
+        for index, (candle, candle_start, event_time, inside_session) in enumerate(
+            timeline
+        ):
+            self._current_bar_exposed = False
+            self._current_event_timestamp = candle_start
+            self._current_event_in_session = inside_session
 
             counted_position = self.position
             if counted_position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 counted_position.bars_held += 1
                 self._process_open_gap(candle)
 
@@ -380,27 +458,24 @@ class BacktestEngine:
                 self._fill_pending_signal(pending, candle=candle, bar_index=index)
 
             if self.position is not None:
-                self.exposed_bar_indexes.add(index)
+                self._current_bar_exposed = True
                 if self.position is not counted_position:
                     self.position.bars_held += 1
                 self._process_intrabar_bracket(candle)
 
             while (
                 history_cursor < len(self.all_candles)
-                and _candle_close_time(self.all_candles[history_cursor]) <= event_time
+                and self.all_close_times[history_cursor] <= event_time
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
-            if (
-                self.strategy_type == _TOPBOT_STRATEGY
-                and not _event_timestamp_is_in_configured_session(
-                    self.config,
-                    candle_start,
-                )
-            ):
+            if self.strategy_type == _TOPBOT_STRATEGY and not inside_session:
                 self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
                 continue
-            signal = self.signal_evaluator(self._evaluator_input(closed_history))
+            if self._sma_close_values is not None:
+                signal = self._evaluate_prepared_sma(history_cursor)
+            else:
+                signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
             if signal.action in {"BUY", "SELL"}:
@@ -431,7 +506,7 @@ class BacktestEngine:
 
         if self.position is not None and self.settings.force_close_at_end:
             final_candle = self.execution_candles[-1]
-            final_time = _candle_close_time(final_candle)
+            final_time = self.execution_close_times[-1]
             self._update_excursion(float(final_candle.close_price), float(final_candle.close_price))
             self._close_position(
                 raw_exit_price=float(final_candle.close_price),
@@ -450,12 +525,14 @@ class BacktestEngine:
             self.trades,
             equity_curve=self.equity_curve,
             drawdown_series=drawdown_series,
-            exposure_percent=(len(self.exposed_bar_indexes) / len(self.execution_candles) * 100.0),
+            exposure_percent=(
+                self.exposed_bar_count / len(self.execution_candles) * 100.0
+            ),
         )
         return {
             "range": {
-                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
-                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
+                "start": self.execution_start_times[0].isoformat(),
+                "end": self.execution_close_times[-1].isoformat(),
                 "bar_count": len(self.execution_candles),
                 "contract_id": str(self.execution_candles[0].contract_id),
                 "symbol": self.execution_candles[0].symbol or self.config.symbol,
@@ -473,6 +550,142 @@ class BacktestEngine:
             "warnings": self.warnings,
         }
 
+    def _prepare_topbot_runtime(self) -> None:
+        self._topbot_params = bot_service_module._normalize_strategy_params(
+            _TOPBOT_STRATEGY,
+            self.config.strategy_params,
+        )
+        source_overrides = self._topbot_params.get("source_strategy_params") or {}
+        self._topbot_source_static_errors: dict[str, str] = {}
+        self._topbot_generic_args: dict[str, dict[str, Any]] = {}
+        self._topbot_primary_limits: dict[str, int] = {}
+        for source_strategy in self._topbot_params["source_strategies"]:
+            source_params = bot_service_module._normalize_strategy_params(
+                source_strategy,
+                source_overrides.get(source_strategy, {}),
+            )
+            self._topbot_source_params[source_strategy] = source_params
+            self._topbot_source_keys[source_strategy] = tuple(
+                _topbot_source_stream_keys(
+                    self.config,
+                    source_strategy,
+                    source_params=source_params,
+                )
+            )
+            fast_period, slow_period = (
+                bot_service_module._normalized_strategy_period_values(
+                    source_strategy,
+                    fast_period=int(self.config.fast_period),
+                    slow_period=int(self.config.slow_period),
+                )
+            )
+            source_config = _SourceConfigView(
+                self.config,
+                strategy_type=source_strategy,
+                strategy_params=source_params,
+                fast_period=fast_period,
+                slow_period=slow_period,
+            )
+            self._topbot_source_configs[source_strategy] = source_config
+            self._topbot_primary_limits[source_strategy] = (
+                _topbot_primary_source_history_limit(
+                    self.config,
+                    source_strategy,
+                )
+            )
+            if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
+                self._topbot_generic_args[source_strategy] = (
+                    _generic_evaluator_arguments(
+                        source_strategy,
+                        config=source_config,
+                        strategy_params=source_params,
+                    )
+                )
+            try:
+                bot_service_module._validate_strategy_configuration(
+                    strategy_type=source_strategy,
+                    timeframe_unit=str(source_config.timeframe_unit),
+                    timeframe_unit_number=int(source_config.timeframe_unit_number),
+                    fast_period=fast_period,
+                    slow_period=slow_period,
+                )
+            except Exception as exc:
+                self._topbot_source_static_errors[source_strategy] = str(exc)
+
+    def _event_in_configured_session(self, event_timestamp: datetime) -> bool:
+        timestamp = _as_utc(event_timestamp)
+        if self._current_event_timestamp == timestamp:
+            return self._current_event_in_session
+        if not futures_session_is_open(timestamp):
+            return False
+        local_time = timestamp.astimezone(TRADING_TZ).time().replace(tzinfo=None)
+        start = self._configured_session_start
+        end = self._configured_session_end
+        if start <= end:
+            return start <= local_time <= end
+        return local_time >= start or local_time <= end
+
+    def _evaluate_prepared_sma(self, closed_count: int) -> SignalResult:
+        closes = self._sma_close_values
+        assert closes is not None
+        fast_period = int(self.config.fast_period)
+        slow_period = int(self.config.slow_period)
+        visible_count = min(closed_count, self.evaluator_history_limit)
+        latest_index = closed_count - 1
+        latest = self.all_candles[latest_index]
+        if visible_count < slow_period + 1:
+            return SignalResult(
+                action="HOLD",
+                reason=(
+                    f"Need at least {slow_period + 1} closed candles; "
+                    f"found {visible_count}."
+                ),
+                candle_timestamp=self.all_start_times[latest_index],
+                price=float(latest.close_price),
+                raw_payload={
+                    "fast_period": fast_period,
+                    "slow_period": slow_period,
+                    "closed_count": visible_count,
+                },
+            )
+
+        previous_fast = bot_service_module._average(
+            closes[closed_count - fast_period - 1 : closed_count - 1]
+        )
+        previous_slow = bot_service_module._average(
+            closes[closed_count - slow_period - 1 : closed_count - 1]
+        )
+        current_fast = bot_service_module._average(
+            closes[closed_count - fast_period : closed_count]
+        )
+        current_slow = bot_service_module._average(
+            closes[closed_count - slow_period : closed_count]
+        )
+        action = "HOLD"
+        if previous_fast <= previous_slow and current_fast > current_slow:
+            action = "BUY"
+        elif previous_fast >= previous_slow and current_fast < current_slow:
+            action = "SELL"
+        reason = (
+            "No SMA crossover on the latest closed candle."
+            if action == "HOLD"
+            else f"{fast_period}/{slow_period} SMA crossover generated {action}."
+        )
+        return SignalResult(
+            action=action,
+            reason=reason,
+            candle_timestamp=self.all_start_times[latest_index],
+            price=float(latest.close_price),
+            raw_payload={
+                "fast_period": fast_period,
+                "slow_period": slow_period,
+                "previous_fast": previous_fast,
+                "previous_slow": previous_slow,
+                "current_fast": current_fast,
+                "current_slow": current_slow,
+            },
+        )
+
     def _record_topbot_source_failures(self, signal: SignalResult) -> None:
         payload = signal.raw_payload if isinstance(signal.raw_payload, dict) else {}
         ensemble = payload.get("ensemble") if isinstance(payload.get("ensemble"), dict) else {}
@@ -489,7 +702,7 @@ class BacktestEngine:
         closed_history: list[ProjectXMarketCandle],
     ) -> list[ProjectXMarketCandle]:
         if not closed_history:
-            return []
+            return _ClosedCandleList()
         latest_timestamp = _as_utc(closed_history[-1].candle_timestamp)
         rolling_start = max(0, len(closed_history) - self.evaluator_history_limit)
 
@@ -500,11 +713,11 @@ class BacktestEngine:
                 end_text=str(self.config.trading_end_time),
             )
             if latest_timestamp < session_start:
-                return []
+                return _ClosedCandleList()
             if latest_timestamp > session_end:
-                return []
+                return _ClosedCandleList()
             session_start_index = _first_index_at_or_after(closed_history, session_start)
-            session_rows = closed_history[session_start_index:]
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
                 session_rows,
                 expected_start=session_start,
@@ -525,8 +738,9 @@ class BacktestEngine:
                 trading_day_date(latest_timestamp)
             )
             session_start_index = _first_index_at_or_after(closed_history, session_start)
+            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
-                closed_history[session_start_index:],
+                session_rows,
                 expected_start=session_start,
                 strategy_type=self.strategy_type,
                 enforce=_is_intraday_timeframe(self.config),
@@ -535,9 +749,12 @@ class BacktestEngine:
                     int(self.config.timeframe_unit_number),
                 ),
             )
-            return closed_history[min(rolling_start, session_start_index) :]
+            return _closed_candle_slice(
+                closed_history,
+                min(rolling_start, session_start_index),
+            )
 
-        return closed_history[rolling_start:]
+        return _closed_candle_slice(closed_history, rolling_start)
 
     def _evaluate_real_strategy(self, candles: list[ProjectXMarketCandle]) -> SignalResult:
         params = self.config.strategy_params

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -36,7 +36,12 @@ from .bot_strategy_registry import (
     BACKTEST_SUPPORTED_STRATEGY_IDENTIFIERS,
     get_strategy_definition,
 )
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    is_expected_futures_candle,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
 BACKTEST_ENGINE_VERSION = "1.1.0"
@@ -1293,11 +1298,11 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            gaps = 0
-            for previous, current in zip(self.execution_candles, self.execution_candles[1:]):
-                delta = (_as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)).total_seconds()
-                if delta > expected_seconds * 1.5:
-                    gaps += 1
+            gaps = _count_futures_session_gaps(
+                self.execution_candles,
+                expected_seconds=expected_seconds,
+                symbol=self.config.symbol,
+            )
             if gaps:
                 self.warnings.append(
                     f"Detected {gaps} candle gap(s); the engine used the next available bar without interpolation."
@@ -1334,14 +1339,10 @@ class BacktestEngine:
                     if _as_utc(row.candle_timestamp) >= self.settings.start
                     and _candle_close_time(row) <= self.settings.end
                 ]
-                gaps = sum(
-                    1
-                    for previous, current in zip(execution_rows, execution_rows[1:])
-                    if (
-                        _as_utc(current.candle_timestamp)
-                        - _as_utc(previous.candle_timestamp)
-                    ).total_seconds()
-                    > expected * 1.5
+                gaps = _count_futures_session_gaps(
+                    execution_rows,
+                    expected_seconds=expected,
+                    symbol=spec.symbol or self.config.symbol,
                 )
                 if gaps:
                     self.warnings.append(
@@ -1899,12 +1900,160 @@ def run_backtest(
     ).run()
 
 
+def _ensure_backtest_candle_integrity(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: Any,
+    start: datetime,
+    end: datetime,
+    primary_warmup_bars: int,
+) -> None:
+    """Repair every stored stream before the pure replay reads its snapshot."""
+
+    primary_unit = str(config.timeframe_unit)
+    primary_unit_number = int(config.timeframe_unit_number)
+    primary_start = _cached_backtest_repair_start(
+        db,
+        user_id=user_id,
+        contract_id=str(config.contract_id),
+        symbol=config.symbol,
+        unit=primary_unit,
+        unit_number=primary_unit_number,
+        start=start,
+        warmup_bars=primary_warmup_bars,
+        minimum_warmup_bars=max(
+            0,
+            _strategy_history_bars(config, hard_minimum=True) - 1,
+        ),
+    )
+    try:
+        bot_service_module.ensure_market_candles(
+            db,
+            user_id=user_id,
+            client=client,
+            contract_id=str(config.contract_id),
+            symbol=config.symbol,
+            live=False,
+            start=primary_start,
+            end=end,
+            unit=primary_unit,
+            unit_number=primary_unit_number,
+            limit=MAX_BACKTEST_BARS,
+            include_partial_bar=False,
+            strict_integrity=True,
+        )
+
+        if str(config.strategy_type) != _TOPBOT_STRATEGY:
+            return
+        primary_key = _topbot_asset_stream_key(primary_unit, primary_unit_number)
+        for key, stream_spec in _topbot_stream_specs(config).items():
+            if key == primary_key:
+                continue
+            identifier = stream_spec.contract_id or stream_spec.symbol
+            if identifier is None:
+                raise InsufficientBacktestDataError(
+                    f"candle_integrity_unresolved:{key}: missing contract or symbol"
+                )
+            stream_start = _cached_backtest_repair_start(
+                db,
+                user_id=user_id,
+                contract_id=stream_spec.contract_id,
+                symbol=stream_spec.symbol,
+                unit=stream_spec.unit,
+                unit_number=stream_spec.unit_number,
+                start=start,
+                warmup_bars=stream_spec.warmup_bars,
+                minimum_warmup_bars=stream_spec.warmup_bars,
+            )
+            bot_service_module.ensure_market_candles(
+                db,
+                user_id=user_id,
+                client=client,
+                contract_id=identifier,
+                symbol=stream_spec.symbol,
+                live=False,
+                start=stream_start,
+                end=end,
+                unit=stream_spec.unit,
+                unit_number=stream_spec.unit_number,
+                limit=min(MAX_TOPBOT_REPLAY_STREAM_BARS, MAX_BACKTEST_BARS),
+                include_partial_bar=False,
+                strict_integrity=True,
+            )
+    except bot_service_module.CandleIntegrityError as exc:
+        raise InsufficientBacktestDataError(str(exc)) from exc
+
+
+def _backtest_repair_start(
+    start: datetime,
+    *,
+    unit: str,
+    unit_number: int,
+    warmup_bars: int,
+) -> datetime:
+    seconds = _timeframe_seconds(unit, unit_number)
+    if seconds is None:
+        seconds = 31 * 24 * 60 * 60 * max(1, int(unit_number))
+    lookback = timedelta(seconds=seconds * max(1, int(warmup_bars)) * 3)
+    if unit in {"second", "minute", "hour"}:
+        lookback = max(lookback, timedelta(days=7))
+    return _as_utc(start) - lookback
+
+
+def _cached_backtest_repair_start(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str | None,
+    symbol: str | None,
+    unit: str,
+    unit_number: int,
+    start: datetime,
+    warmup_bars: int,
+    minimum_warmup_bars: int,
+) -> datetime:
+    query = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.candle_timestamp < start)
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+    )
+    if contract_id is not None:
+        query = query.filter(ProjectXMarketCandle.contract_id == contract_id)
+    elif symbol is not None:
+        query = query.filter(
+            or_(
+                ProjectXMarketCandle.contract_id == symbol,
+                ProjectXMarketCandle.symbol == symbol,
+            )
+        )
+    cached = (
+        query.order_by(ProjectXMarketCandle.candle_timestamp.desc())
+        .limit(max(1, int(warmup_bars)))
+        .all()
+    )
+    if len(cached) >= max(0, int(minimum_warmup_bars)) and cached:
+        return min(_as_utc(row.candle_timestamp) for row in cached)
+    return _backtest_repair_start(
+        start,
+        unit=unit,
+        unit_number=unit_number,
+        warmup_bars=warmup_bars,
+    )
+
+
 def create_bot_backtest(
     db: Session,
     *,
     user_id: str,
     bot_config_id: int,
     payload: Any,
+    client: Any | None = None,
 ) -> BotBacktest:
     config = (
         db.query(BotConfig)
@@ -1933,26 +2082,6 @@ def create_bot_backtest(
             f"instrument_metadata_missing:{symbol_key or config.contract_id}"
         )
 
-    execution_query = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .limit(MAX_BACKTEST_BARS + 1)
-    )
-    execution_rows = execution_query.all()
-    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-    if len(execution_rows) > MAX_BACKTEST_BARS:
-        raise BacktestConfigurationError(
-            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
-        )
-
     rolling_warmup_limit = min(
         MAX_BACKTEST_BARS,
         max(
@@ -1974,6 +2103,38 @@ def create_bot_backtest(
         config,
         rolling_limit=rolling_warmup_limit,
     )
+
+    if client is not None:
+        _ensure_backtest_candle_integrity(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=start,
+            end=end,
+            primary_warmup_bars=warmup_limit,
+        )
+
+    execution_query = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .limit(MAX_BACKTEST_BARS + 1)
+    )
+    execution_rows = execution_query.all()
+    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
+    if len(execution_rows) > MAX_BACKTEST_BARS:
+        raise BacktestConfigurationError(
+            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
+        )
+
     warmup_rows = (
         db.query(ProjectXMarketCandle)
         .filter(ProjectXMarketCandle.user_id == user_id)
@@ -2632,7 +2793,7 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
         "slippage_rule": "configured_ticks_are_applied_adversely_to_every_entry_and_exit_fill",
         "pnl_rule": "price_delta_divided_by_tick_size_times_tick_value_times_quantity",
         "metric_basis": "profit_factor_expectancy_average_win_and_average_loss_use_net_trade_pnl",
-        "market_data": "stored_user_scoped_non_live_closed_candles_only; no_provider_fetch",
+        "market_data": "backend_repaired_user_scoped_non_live_closed_candles; replay_has_no_provider_access",
         "live_order_routing": "disabled_by_architecture",
         "timezone": str(getattr(TRADING_TZ, "key", "America/New_York")),
         "commission_per_contract": _clean(settings.commission_per_contract),
@@ -2647,6 +2808,41 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
 def _timeframe_seconds(unit: str, unit_number: int) -> int | None:
     seconds = _UNIT_SECONDS.get(unit)
     return seconds * unit_number if seconds is not None else None
+
+
+def _range_contains_expected_futures_gap(
+    previous_timestamp: datetime,
+    current_timestamp: datetime,
+    *,
+    expected_seconds: int,
+    symbol: str | None,
+) -> bool:
+    interval = timedelta(seconds=max(1, int(expected_seconds)))
+    missing_start = _as_utc(previous_timestamp) + interval
+    missing_end = _as_utc(current_timestamp)
+    return missing_start < missing_end and is_expected_futures_candle(
+        missing_start,
+        missing_end,
+        symbol=symbol,
+    )
+
+
+def _count_futures_session_gaps(
+    candles: list[ProjectXMarketCandle],
+    *,
+    expected_seconds: int,
+    symbol: str | None,
+) -> int:
+    return sum(
+        1
+        for previous, current in zip(candles, candles[1:])
+        if _range_contains_expected_futures_gap(
+            _as_utc(previous.candle_timestamp),
+            _as_utc(current.candle_timestamp),
+            expected_seconds=expected_seconds,
+            symbol=symbol or getattr(previous, "symbol", None),
+        )
+    )
 
 
 def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
@@ -2711,7 +2907,12 @@ def _require_complete_session_prefix(
         delta = (
             _as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)
         ).total_seconds()
-        if delta != expected_interval_seconds:
+        if delta != expected_interval_seconds and _range_contains_expected_futures_gap(
+            _as_utc(previous.candle_timestamp),
+            _as_utc(current.candle_timestamp),
+            expected_seconds=expected_interval_seconds,
+            symbol=getattr(previous, "symbol", None),
+        ):
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: incomplete_session_history: "
                 f"{strategy_type} has a missing session candle after "

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -32,20 +32,27 @@ from .bot_service import (
     _session_window_utc_for_reference,
 )
 from .instruments import load_instrument_specs, normalize_symbol_key
+from .projectx_client import ProjectXClient
 from .bot_strategy_registry import (
     BACKTEST_SUPPORTED_STRATEGY_IDENTIFIERS,
     get_strategy_definition,
 )
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    futures_session_is_open,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
-BACKTEST_ENGINE_VERSION = "1.1.0"
+BACKTEST_ENGINE_VERSION = "1.2.0"
 MAX_BACKTEST_BARS = 20_000
 MAX_BACKTEST_RANGE_DAYS = 366
 MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
 MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
 MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
 MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
+MAX_PROVIDER_FETCH_BARS = 20_000
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -62,7 +69,7 @@ UNSUPPORTED_BACKTEST_STRATEGY_REASONS: dict[str, str] = {
     "supertrend_pivot": "requires synchronized signal-timeframe and closed daily candles",
     "fvg_sweep_mss": "requires synchronized FVG and lower-timeframe structure streams",
     "atr_adjusted_relative_strength": "requires an exactly aligned benchmark candle stream",
-    "relative_strength_spy": "requires an exactly aligned SPY candle stream",
+    "relative_strength_spy": "requires an exactly aligned MES benchmark candle stream",
     "vwap_gap_retrace": "requires fixed 1-minute data and alternative exit-path replay",
     "donchian_breakout": "requires stateful channel, trailing-stop, sizing, and entry-plan replay",
     "ema_scalping": "requires exact strong-opposite-candle exit replay",
@@ -202,13 +209,13 @@ class BacktestEngine:
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
+        self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
         auxiliary_excluded_partial = 0
-        missing_replay_streams: list[str] = []
+        deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
             (
                 self.topbot_streams,
                 auxiliary_excluded_partial,
-                missing_replay_streams,
             ) = _prepare_topbot_replay_streams(
                 config,
                 primary_candles=self.all_candles,
@@ -232,11 +239,35 @@ class BacktestEngine:
                 1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
             )
             if closed_by_first_event < hard_minimum:
-                raise InsufficientBacktestDataError(
-                    "insufficient_backtest_data: insufficient_strategy_warmup: "
-                    f"{self.strategy_type} requires at least {hard_minimum} bars closed by the "
-                    f"first replay event; found {closed_by_first_event}"
+                deferred_execution_bars = hard_minimum - closed_by_first_event
+                self.execution_candles = self.execution_candles[deferred_execution_bars:]
+                if len(self.execution_candles) < MIN_EXECUTION_BARS:
+                    available_closed_bars = sum(
+                        1
+                        for candle in self.all_candles
+                        if _candle_close_time(candle) <= self.settings.end
+                    )
+                    raise InsufficientBacktestDataError(
+                        "insufficient_backtest_data: insufficient_strategy_warmup: "
+                        f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
+                        f"only {available_closed_bars} were available"
+                    )
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            session_execution_candles = [
+                candle
+                for candle in self.execution_candles
+                if _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
                 )
+            ]
+            coverage_candles = session_execution_candles or self.execution_candles
+            self.topbot_unavailable_sources = _topbot_unavailable_sources(
+                config,
+                streams=self.topbot_streams,
+                first_event=_candle_close_time(coverage_candles[0]),
+                last_event=_candle_close_time(coverage_candles[-1]),
+            )
         if len(self.execution_candles) > MAX_BACKTEST_BARS:
             raise BacktestConfigurationError(
                 f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}; "
@@ -254,9 +285,16 @@ class BacktestEngine:
             rolling_limit=self.evaluator_history_limit,
         )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            signal_evaluation_bars = sum(
+                _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
+                )
+                for candle in self.execution_candles
+            )
             estimated_operations = _estimate_topbot_evaluator_operations(
                 config,
-                execution_bars=len(self.execution_candles),
+                execution_bars=signal_evaluation_bars,
             )
             operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
         else:
@@ -278,11 +316,20 @@ class BacktestEngine:
             self.warnings.append(
                 f"Excluded {auxiliary_excluded_partial} partial auxiliary candle(s); only closed bars were replayed."
             )
-        if missing_replay_streams:
+        if deferred_execution_bars:
             self.warnings.append(
-                "TopBot source data was unavailable for stored replay stream(s): "
-                + ", ".join(sorted(missing_replay_streams))
-                + ". Affected sources were recorded as failed for ensemble voting."
+                f"Deferred replay by {deferred_execution_bars} candle(s) so the strategy had "
+                "its required closed-bar warmup before the first evaluation."
+            )
+        if self.topbot_unavailable_sources:
+            excluded = "; ".join(
+                f"{source} ({', '.join(keys)})"
+                for source, keys in sorted(self.topbot_unavailable_sources.items())
+            )
+            self.warnings.append(
+                "TopBot excluded source(s) whose required stored replay data was unavailable: "
+                + excluded
+                + ". Vote thresholds were unchanged."
             )
         self._add_data_quality_warnings()
 
@@ -338,6 +385,15 @@ class BacktestEngine:
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
+            if (
+                self.strategy_type == _TOPBOT_STRATEGY
+                and not _event_timestamp_is_in_configured_session(
+                    self.config,
+                    candle_start,
+                )
+            ):
+                self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
+                continue
             signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
@@ -392,8 +448,8 @@ class BacktestEngine:
         )
         return {
             "range": {
-                "start": self.settings.start.isoformat(),
-                "end": self.settings.end.isoformat(),
+                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
+                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
             },
             "config_snapshot": _config_snapshot(self.config),
@@ -532,8 +588,11 @@ class BacktestEngine:
         )
         source_overrides = topbot_params.get("source_strategy_params") or {}
         source_results: list[dict[str, Any]] = []
+        event_timestamp = _as_utc(primary_candles[-1].candle_timestamp)
 
         for source_strategy in topbot_params["source_strategies"]:
+            if source_strategy in self.topbot_unavailable_sources:
+                continue
             source_params = bot_service_module._normalize_strategy_params(
                 source_strategy,
                 source_overrides.get(source_strategy, {}),
@@ -542,6 +601,7 @@ class BacktestEngine:
                 source_strategy,
                 source_params=source_params,
                 event_time=event_time,
+                event_timestamp=event_timestamp,
             )
             cached = self._topbot_source_cache.get(source_strategy)
             if cached is not None and cached[0] == signature:
@@ -552,6 +612,7 @@ class BacktestEngine:
                     source_strategy,
                     source_params=source_params,
                     event_time=event_time,
+                    event_timestamp=event_timestamp,
                 )
             except Exception as exc:
                 result = {
@@ -577,6 +638,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> tuple[Any, ...]:
         signature: list[Any] = []
         for key in _topbot_source_stream_keys(
@@ -602,6 +664,11 @@ class BacktestEngine:
                         self.position.take_profit,
                     )
                 )
+        if source_strategy == "delayed_orb_confirmation":
+            # A one-minute stream must advance through every primary event.
+            # Including the event prevents a stale final minute from being
+            # cached and reused across the rest of a session or a later day.
+            signature.append(("primary_event", _as_utc(event_timestamp)))
         return tuple(signature)
 
     def _evaluate_topbot_source(
@@ -610,6 +677,7 @@ class BacktestEngine:
         *,
         source_params: dict[str, Any],
         event_time: datetime,
+        event_timestamp: datetime,
     ) -> dict[str, Any]:
         fast_period, slow_period = bot_service_module._normalized_strategy_period_values(
             source_strategy,
@@ -706,67 +774,93 @@ class BacktestEngine:
                 base_order_size=float(self.config.order_size),
             )
         elif source_strategy == "delayed_orb_confirmation":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                _topbot_asset_stream_key("minute", 1),
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:delayed_orb_confirmation",
-                enforce=True,
-                expected_interval_seconds=60,
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                candles=source_candles,
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    _topbot_asset_stream_key("minute", 1),
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                    enforce=True,
+                    expected_interval_seconds=60,
+                )
+                _require_stream_current_through_event(
+                    source_candles,
+                    event_time=event_time,
+                    interval_seconds=60,
+                    strategy_type="topbot:delayed_orb_confirmation",
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    candles=source_candles,
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                )
         elif source_strategy == "orb_fibonacci_pullback":
-            session_start, _session_end = _session_window_utc_for_reference(
-                event_time,
+            session_start, session_end = _session_window_utc_for_reference(
+                event_timestamp,
                 start_text=str(self.config.trading_start_time),
                 end_text=str(self.config.trading_end_time),
             )
-            source_candles = self._topbot_stream_history(
-                primary_key,
-                event_time=event_time,
-                limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
-                not_before=session_start,
-            )
-            _require_complete_session_prefix(
-                source_candles,
-                expected_start=session_start,
-                strategy_type="topbot:orb_fibonacci_pullback",
-                enforce=True,
-                expected_interval_seconds=_timeframe_seconds(
-                    str(self.config.timeframe_unit),
-                    int(self.config.timeframe_unit_number),
-                ),
-            )
-            _require_complete_orb_opening_range(
-                source_candles,
-                config=source_config,
-                session_start=session_start,
-                latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
-            )
-            signal = bot_service_module.dispatch_strategy_evaluator(
-                source_strategy,
-                source_candles,
-                timeframe_unit=str(self.config.timeframe_unit),
-                timeframe_unit_number=int(self.config.timeframe_unit_number),
-                strategy_params=source_params,
-                session_start_time=str(self.config.trading_start_time),
-                session_end_time=str(self.config.trading_end_time),
-            )
+            if not _event_timestamp_is_in_configured_session(
+                self.config,
+                event_timestamp,
+            ):
+                source_candles = []
+                signal = _topbot_outside_session_signal(
+                    source_strategy,
+                    event_timestamp=event_timestamp,
+                )
+            else:
+                source_candles = self._topbot_stream_history(
+                    primary_key,
+                    event_time=event_time,
+                    limit=MAX_TOPBOT_REPLAY_STREAM_BARS,
+                    not_before=session_start,
+                )
+                _require_complete_session_prefix(
+                    source_candles,
+                    expected_start=session_start,
+                    strategy_type="topbot:orb_fibonacci_pullback",
+                    enforce=True,
+                    expected_interval_seconds=_timeframe_seconds(
+                        str(self.config.timeframe_unit),
+                        int(self.config.timeframe_unit_number),
+                    ),
+                )
+                _require_complete_orb_opening_range(
+                    source_candles,
+                    config=source_config,
+                    session_start=session_start,
+                    latest_timestamp=_as_utc(source_candles[-1].candle_timestamp),
+                )
+                signal = bot_service_module.dispatch_strategy_evaluator(
+                    source_strategy,
+                    source_candles,
+                    timeframe_unit=str(self.config.timeframe_unit),
+                    timeframe_unit_number=int(self.config.timeframe_unit_number),
+                    strategy_params=source_params,
+                    session_start_time=str(self.config.trading_start_time),
+                    session_end_time=str(self.config.trading_end_time),
+                )
         elif source_strategy == "opening_rvol_breakout":
             lookback_days = int(source_params["relative_volume_lookback_days"])
             calendar_lookback_days = max(lookback_days + 14, 21)
@@ -1293,11 +1387,30 @@ class BacktestEngine:
             str(self.config.timeframe_unit), int(self.config.timeframe_unit_number)
         )
         if expected_seconds is not None:
-            gaps = 0
-            for previous, current in zip(self.execution_candles, self.execution_candles[1:]):
-                delta = (_as_utc(current.candle_timestamp) - _as_utc(previous.candle_timestamp)).total_seconds()
-                if delta > expected_seconds * 1.5:
-                    gaps += 1
+            actual_start = _as_utc(self.execution_candles[0].candle_timestamp)
+            actual_end = _candle_close_time(self.execution_candles[-1])
+            if _has_open_futures_interval(
+                self.settings.start,
+                actual_start,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles began after the requested start; replay coverage begins at "
+                    f"{actual_start.isoformat()}."
+                )
+            if _has_open_futures_interval(
+                actual_end,
+                self.settings.end,
+                interval_seconds=expected_seconds,
+            ):
+                self.warnings.append(
+                    "Stored candles ended before the requested end; replay coverage ends at "
+                    f"{actual_end.isoformat()}. The configured futures delivery may have expired or rolled."
+                )
+            gaps = _count_futures_session_gaps(
+                self.execution_candles,
+                interval_seconds=expected_seconds,
+            )
             if gaps:
                 self.warnings.append(
                     f"Detected {gaps} candle gap(s); the engine used the next available bar without interpolation."
@@ -1334,14 +1447,9 @@ class BacktestEngine:
                     if _as_utc(row.candle_timestamp) >= self.settings.start
                     and _candle_close_time(row) <= self.settings.end
                 ]
-                gaps = sum(
-                    1
-                    for previous, current in zip(execution_rows, execution_rows[1:])
-                    if (
-                        _as_utc(current.candle_timestamp)
-                        - _as_utc(previous.candle_timestamp)
-                    ).total_seconds()
-                    > expected * 1.5
+                gaps = _count_futures_session_gaps(
+                    execution_rows,
+                    interval_seconds=expected,
                 )
                 if gaps:
                     self.warnings.append(
@@ -1436,6 +1544,23 @@ def _relative_strength_spy_history_limit(
             50,
         ),
     )
+
+
+def _matching_benchmark_contract(
+    config: BotConfig,
+    source_params: Mapping[str, Any],
+) -> tuple[str | None, str]:
+    explicit_contract = source_params.get("benchmark_contract_id")
+    benchmark_symbol = str(source_params.get("benchmark_symbol") or "MES").strip().upper()
+    benchmark_root = benchmark_symbol.rsplit(".", 1)[-1]
+    canonical_symbol = f"F.US.{benchmark_root}"
+    if explicit_contract:
+        return str(explicit_contract), canonical_symbol
+
+    parts = str(config.contract_id).strip().split(".")
+    if len(parts) == 5 and parts[:3] == ["CON", "F", "US"]:
+        return ".".join([*parts[:3], benchmark_root, parts[4]]), canonical_symbol
+    return None, canonical_symbol
 
 
 def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec]:
@@ -1539,30 +1664,34 @@ def _topbot_stream_specs(config: BotConfig) -> dict[str, _TopBotReplayStreamSpec
                 min(5000, max(fvg_limit * ratio, fvg_limit + 25)),
             )
         elif source_strategy == "atr_adjusted_relative_strength":
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit=primary_unit,
                 unit_number=primary_unit_number,
                 warmup_bars=max(25, int(config.lookback_bars)),
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
         elif source_strategy == "relative_strength_spy":
             limit = _relative_strength_spy_history_limit(config, source_params)
             add_asset("minute", 5, limit)
-            benchmark_contract_id = source_params.get("benchmark_contract_id")
-            benchmark_symbol = str(source_params.get("benchmark_symbol") or "SPY")
+            benchmark_contract_id, benchmark_symbol = _matching_benchmark_contract(
+                config,
+                source_params,
+            )
             key = _topbot_benchmark_stream_key(source_strategy)
             specs[key] = _TopBotReplayStreamSpec(
                 key=key,
                 unit="minute",
                 unit_number=5,
                 warmup_bars=limit,
-                contract_id=str(benchmark_contract_id) if benchmark_contract_id else None,
+                contract_id=benchmark_contract_id,
                 symbol=benchmark_symbol,
                 source_strategy=source_strategy,
             )
@@ -1617,7 +1746,7 @@ def _prepare_topbot_replay_streams(
     *,
     primary_candles: list[ProjectXMarketCandle],
     replay_streams: Mapping[str, list[ProjectXMarketCandle]] | None,
-) -> tuple[dict[str, _PreparedReplayStream], int, list[str]]:
+) -> tuple[dict[str, _PreparedReplayStream], int]:
     provided = dict(replay_streams or {})
     primary_key = _topbot_asset_stream_key(
         str(config.timeframe_unit),
@@ -1626,7 +1755,6 @@ def _prepare_topbot_replay_streams(
     provided[primary_key] = primary_candles
     prepared: dict[str, _PreparedReplayStream] = {}
     excluded_partial = 0
-    missing: list[str] = []
 
     for key, spec in _topbot_stream_specs(config).items():
         rows, excluded = _validate_topbot_replay_stream(
@@ -1635,14 +1763,12 @@ def _prepare_topbot_replay_streams(
             config=config,
         )
         excluded_partial += excluded
-        if not rows:
-            missing.append(key)
         prepared[key] = _PreparedReplayStream(
             candles=rows,
             start_times=[_as_utc(row.candle_timestamp) for row in rows],
             close_times=[_candle_close_time(row) for row in rows],
         )
-    return prepared, excluded_partial, missing
+    return prepared, excluded_partial
 
 
 def _validate_topbot_replay_stream(
@@ -1651,7 +1777,7 @@ def _validate_topbot_replay_stream(
     spec: _TopBotReplayStreamSpec,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -1723,6 +1849,71 @@ def _validate_topbot_replay_stream(
             f"ambiguous_benchmark_replay_stream:{spec.key}: configure benchmark_contract_id"
         )
     return closed, excluded_partial
+
+
+def _topbot_unavailable_sources(
+    config: BotConfig,
+    *,
+    streams: Mapping[str, _PreparedReplayStream],
+    first_event: datetime,
+    last_event: datetime,
+) -> dict[str, tuple[str, ...]]:
+    params = bot_service_module._normalize_strategy_params(
+        _TOPBOT_STRATEGY,
+        config.strategy_params,
+    )
+    overrides = params.get("source_strategy_params") or {}
+    specs = _topbot_stream_specs(config)
+    unavailable: dict[str, tuple[str, ...]] = {}
+    for source_strategy in params["source_strategies"]:
+        source_params = bot_service_module._normalize_strategy_params(
+            source_strategy,
+            overrides.get(source_strategy, {}),
+        )
+        missing = tuple(
+            key
+            for key in _topbot_source_stream_keys(
+                config,
+                source_strategy,
+                source_params=source_params,
+            )
+            if not _prepared_stream_covers_replay_window(
+                streams.get(key),
+                spec=specs.get(key),
+                first_event=first_event,
+                last_event=last_event,
+            )
+        )
+        if missing:
+            unavailable[source_strategy] = missing
+    return unavailable
+
+
+def _prepared_stream_covers_replay_window(
+    stream: _PreparedReplayStream | None,
+    *,
+    spec: _TopBotReplayStreamSpec | None,
+    first_event: datetime,
+    last_event: datetime,
+) -> bool:
+    if stream is None or not stream.candles or spec is None:
+        return False
+    interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+    if interval_seconds is None or interval_seconds <= 0:
+        return False
+    for event_time in (first_event, last_event):
+        event_utc = _as_utc(event_time)
+        closed_count = bisect_right(stream.close_times, event_utc)
+        if closed_count <= 0:
+            return False
+        latest_close = stream.close_times[closed_count - 1]
+        if _has_open_futures_interval(
+            latest_close,
+            event_utc,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def _estimate_topbot_evaluator_operations(config: BotConfig, *, execution_bars: int) -> int:
@@ -1848,7 +2039,10 @@ def _load_topbot_replay_streams(
         warmup_rows = (
             query.filter(ProjectXMarketCandle.candle_timestamp < start)
             .order_by(ProjectXMarketCandle.candle_timestamp.desc())
-            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars)))
+            # One candle can start before the requested range while closing
+            # after the first replay event. Overfetch it so the requested
+            # number of genuinely closed warmup bars remains available.
+            .limit(min(MAX_TOPBOT_REPLAY_STREAM_BARS, max(1, spec.warmup_bars + 1)))
             .all()
         )
         warmup_rows.reverse()
@@ -1862,6 +2056,225 @@ def _load_topbot_replay_streams(
             )
 
     return streams
+
+
+def prepare_bot_backtest_data(
+    db: Session,
+    *,
+    user_id: str,
+    bot_config_id: int,
+    payload: Any,
+    client: ProjectXClient,
+) -> int:
+    """Populate TopBot's deterministic replay cache without running a replay."""
+
+    config = (
+        db.query(BotConfig)
+        .filter(BotConfig.user_id == user_id)
+        .filter(BotConfig.id == bot_config_id)
+        .one_or_none()
+    )
+    if config is None:
+        raise LookupError("bot_config_not_found")
+    if str(config.strategy_type) != _TOPBOT_STRATEGY:
+        return 0
+    _validate_replay_configuration(config)
+
+    start = _as_utc(payload.start)
+    end = _as_utc(payload.end)
+    if end <= start:
+        raise BacktestConfigurationError("backtest end must be after start")
+    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
+        raise BacktestConfigurationError(
+            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
+        )
+
+    fetch_end = min(end, datetime.now(timezone.utc))
+    requests: dict[tuple[str, str, int], tuple[str | None, datetime, int]] = {}
+    for spec in _topbot_stream_specs(config).values():
+        interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
+        if interval_seconds is None or interval_seconds <= 0:
+            raise BacktestConfigurationError(
+                f"unsupported_topbot_replay_timeframe:{spec.unit}:{spec.unit_number}"
+            )
+        contract_id = spec.contract_id or spec.symbol
+        if not contract_id:
+            raise BacktestConfigurationError(f"topbot_replay_contract_missing:{spec.key}")
+        fetch_start = start - timedelta(
+            seconds=interval_seconds * max(25, int(spec.warmup_bars)) * 3
+        )
+        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
+        existing = requests.get(identity)
+        if existing is None or fetch_start < existing[1]:
+            requests[identity] = (spec.symbol, fetch_start, int(spec.warmup_bars))
+        elif int(spec.warmup_bars) > existing[2]:
+            requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
+
+    primary_identity = (
+        str(config.contract_id),
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
+    primary_execution_rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    primary_execution_rows = [
+        row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+    ]
+    first_event = (
+        _candle_close_time(primary_execution_rows[0])
+        if primary_execution_rows
+        else start
+    )
+    last_event = (
+        _candle_close_time(primary_execution_rows[-1])
+        if primary_execution_rows
+        else fetch_end
+    )
+
+    prepared_count = 0
+    for (contract_id, unit, unit_number), (symbol, fetch_start, warmup_bars) in requests.items():
+        interval_seconds = _timeframe_seconds(unit, unit_number)
+        assert interval_seconds is not None
+        identity = (contract_id, unit, unit_number)
+        primary_cache_is_clean = not any(
+            _cached_candle_was_fetched_before_nominal_close(row)
+            for row in primary_execution_rows
+        ) and not _candle_stream_has_overlaps(primary_execution_rows)
+        if (
+            identity == primary_identity
+            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
+            and primary_cache_is_clean
+        ):
+            continue
+        if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
+            db,
+            user_id=user_id,
+            contract_id=contract_id,
+            unit=unit,
+            unit_number=unit_number,
+            fetch_start=fetch_start,
+            requested_start=start,
+            first_event=first_event,
+            last_event=last_event,
+            warmup_bars=warmup_bars,
+        ):
+            continue
+        cursor = fetch_start
+        chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
+        while cursor < fetch_end:
+            chunk_end = min(fetch_end, cursor + chunk_span)
+            bot_service_module.fetch_and_store_market_candles(
+                db,
+                user_id=user_id,
+                client=client,
+                contract_id=contract_id,
+                symbol=symbol,
+                live=False,
+                start=cursor,
+                end=chunk_end,
+                unit=unit,
+                unit_number=unit_number,
+                limit=MAX_PROVIDER_FETCH_BARS,
+                include_partial_bar=False,
+                prefer_current_contract=False,
+                preserve_cached_history=True,
+                authoritative_refresh=True,
+            )
+            if chunk_end >= fetch_end:
+                break
+            cursor = chunk_end
+        prepared_count += 1
+
+        if identity == primary_identity:
+            primary_execution_rows = (
+                db.query(ProjectXMarketCandle)
+                .filter(ProjectXMarketCandle.user_id == user_id)
+                .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+                .filter(ProjectXMarketCandle.live.is_(False))
+                .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+                .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+                .filter(ProjectXMarketCandle.is_partial.is_(False))
+                .filter(ProjectXMarketCandle.candle_timestamp >= start)
+                .filter(ProjectXMarketCandle.candle_timestamp <= fetch_end)
+                .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+                .all()
+            )
+            primary_execution_rows = [
+                row for row in primary_execution_rows if _candle_close_time(row) <= fetch_end
+            ]
+            if primary_execution_rows:
+                first_event = _candle_close_time(primary_execution_rows[0])
+                last_event = _candle_close_time(primary_execution_rows[-1])
+
+    return prepared_count
+
+
+def _cached_replay_stream_covers(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    unit: str,
+    unit_number: int,
+    fetch_start: datetime,
+    requested_start: datetime,
+    first_event: datetime,
+    last_event: datetime,
+    warmup_bars: int,
+) -> bool:
+    interval_seconds = _timeframe_seconds(unit, unit_number)
+    if interval_seconds is None:
+        return False
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == contract_id)
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp >= fetch_start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= last_event)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    if any(_cached_candle_was_fetched_before_nominal_close(row) for row in rows):
+        return False
+    if _candle_stream_has_overlaps(rows):
+        return False
+    closed_by_first = [row for row in rows if _candle_close_time(row) <= first_event]
+    warmup_count = sum(
+        _as_utc(row.candle_timestamp) < requested_start
+        for row in closed_by_first
+    )
+    if warmup_count < max(1, int(warmup_bars)):
+        return False
+
+    for event, candidates in (
+        (first_event, closed_by_first),
+        (last_event, [row for row in rows if _candle_close_time(row) <= last_event]),
+    ):
+        if not candidates:
+            return False
+        latest_close = _candle_close_time(candidates[-1])
+        if _has_open_futures_interval(
+            latest_close,
+            event,
+            interval_seconds=interval_seconds,
+        ):
+            return False
+    return True
 
 
 def run_backtest(
@@ -2032,8 +2445,8 @@ def create_bot_backtest(
         timeframe_unit_number=int(config.timeframe_unit_number),
         requested_start=start,
         requested_end=end,
-        actual_start=_as_utc(execution_rows[0].candle_timestamp) if execution_rows else start,
-        actual_end=_candle_close_time(execution_rows[-1]) if execution_rows else end,
+        actual_start=_as_utc(datetime.fromisoformat(str(result["range"]["start"]))),
+        actual_end=_as_utc(datetime.fromisoformat(str(result["range"]["end"]))),
         starting_balance=float(payload.starting_balance),
         commission_per_contract=float(payload.commission_per_contract),
         slippage_ticks=float(payload.slippage_ticks),
@@ -2197,7 +2610,7 @@ def _validate_and_sort_candles(
     *,
     config: BotConfig,
 ) -> tuple[list[ProjectXMarketCandle], int]:
-    closed = [row for row in candles if not bool(row.is_partial)]
+    closed = [row for row in candles if not _cached_candle_is_effectively_partial(row)]
     excluded_partial = len(candles) - len(closed)
     closed.sort(key=lambda row: _as_utc(row.candle_timestamp))
     seen: set[datetime] = set()
@@ -2254,6 +2667,36 @@ def _validate_and_sort_candles(
         if values["volume"] < 0:
             raise MalformedBacktestDataError(f"negative_candle_volume:{timestamp.isoformat()}")
     return closed, excluded_partial
+
+
+def _cached_candle_is_effectively_partial(candle: ProjectXMarketCandle) -> bool:
+    return bool(candle.is_partial) or _cached_candle_was_fetched_before_nominal_close(candle)
+
+
+def _cached_candle_was_fetched_before_nominal_close(
+    candle: ProjectXMarketCandle,
+) -> bool:
+    if str(candle.unit) not in {"second", "minute", "hour"}:
+        return False
+    fetched_at = candle.fetched_at
+    if fetched_at is None:
+        return False
+    raw_payload = candle.raw_payload
+    if isinstance(raw_payload, dict) and any(
+        key in raw_payload for key in ("isPartial", "is_partial", "partial")
+    ):
+        return False
+    return _as_utc(fetched_at) < _candle_close_time(candle)
+
+
+def _candle_stream_has_overlaps(candles: list[ProjectXMarketCandle]) -> bool:
+    previous_close_time: datetime | None = None
+    for row in sorted(candles, key=lambda candle: _as_utc(candle.candle_timestamp)):
+        timestamp = _as_utc(row.candle_timestamp)
+        if previous_close_time is not None and timestamp < previous_close_time:
+            return True
+        previous_close_time = _candle_close_time(row)
+    return False
 
 
 def _candle_close_time(candle: ProjectXMarketCandle) -> datetime:
@@ -2625,7 +3068,9 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
             "oversized_entries_are_blocked_not_capped"
         ),
         "session_rule": (
-            "entries_obey_bot_session_after-loss_cooldown_daily-trade_and_daily-loss_limits; "
+            "TopBot signals are evaluated only during the configured session while resting "
+            "brackets are processed on every execution candle; entries obey bot session "
+            "after-loss cooldown, daily-trade, and daily-loss limits; "
             "counters_reset_at_requested_start_and_loss_uses_isolated_simulated_realized_net_pnl"
         ),
         "commission_rule": "commission_per_contract_is_charged_per_side",
@@ -2647,6 +3092,61 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
 def _timeframe_seconds(unit: str, unit_number: int) -> int | None:
     seconds = _UNIT_SECONDS.get(unit)
     return seconds * unit_number if seconds is not None else None
+
+
+def _count_futures_session_gaps(
+    candles: list[ProjectXMarketCandle],
+    *,
+    interval_seconds: int,
+) -> int:
+    gaps = 0
+    for previous, current in zip(candles, candles[1:]):
+        previous_timestamp = _as_utc(previous.candle_timestamp)
+        current_timestamp = _as_utc(current.candle_timestamp)
+        elapsed = int((current_timestamp - previous_timestamp).total_seconds())
+        missing_slots = max(0, int(round(elapsed / interval_seconds)) - 1)
+        if missing_slots and _contains_open_futures_timestamp(
+            previous_timestamp + timedelta(seconds=interval_seconds),
+            current_timestamp,
+            step_seconds=interval_seconds,
+        ):
+            gaps += 1
+    return gaps
+
+
+def _has_open_futures_interval(
+    start: datetime,
+    end: datetime,
+    *,
+    interval_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc - cursor <= timedelta(seconds=interval_seconds * 1.5):
+        return False
+    return _contains_open_futures_timestamp(
+        cursor + timedelta(seconds=interval_seconds),
+        end_utc,
+        step_seconds=interval_seconds,
+    )
+
+
+def _contains_open_futures_timestamp(
+    start: datetime,
+    end: datetime,
+    *,
+    step_seconds: int,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    # Session boundaries are minute-aligned, so sub-minute streams need not
+    # scan every second across a weekend closure.
+    step = timedelta(seconds=max(60, int(step_seconds)))
+    while cursor < end_utc:
+        if futures_session_is_open(cursor):
+            return True
+        cursor += step
+    return False
 
 
 def _max_evaluator_input_bars(config: BotConfig, *, rolling_limit: int) -> int:
@@ -2687,6 +3187,57 @@ def _first_index_at_or_after(
         else:
             high = middle
     return low
+
+
+def _topbot_outside_session_signal(
+    strategy_type: str,
+    *,
+    event_timestamp: datetime,
+) -> SignalResult:
+    return SignalResult(
+        action="HOLD",
+        reason="Outside the configured trading session.",
+        candle_timestamp=_as_utc(event_timestamp),
+        price=None,
+        raw_payload={
+            "strategy_type": strategy_type,
+            "outside_configured_session": True,
+        },
+    )
+
+
+def _event_timestamp_is_in_configured_session(
+    config: BotConfig,
+    event_timestamp: datetime,
+) -> bool:
+    timestamp = _as_utc(event_timestamp)
+    if not futures_session_is_open(timestamp):
+        return False
+    session_start, session_end = _session_window_utc_for_reference(
+        timestamp,
+        start_text=str(config.trading_start_time),
+        end_text=str(config.trading_end_time),
+    )
+    return session_start <= timestamp <= session_end
+
+
+def _require_stream_current_through_event(
+    candles: list[ProjectXMarketCandle],
+    *,
+    event_time: datetime,
+    interval_seconds: int,
+    strategy_type: str,
+) -> None:
+    if not candles:
+        return
+    expected_latest_start = _as_utc(event_time) - timedelta(seconds=interval_seconds)
+    actual_latest_start = _as_utc(candles[-1].candle_timestamp)
+    if actual_latest_start != expected_latest_start:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: incomplete_session_history: "
+            f"{strategy_type} is missing the closed candle at "
+            f"{expected_latest_start.isoformat()}"
+        )
 
 
 def _require_complete_session_prefix(

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -51,6 +51,7 @@ BACKTEST_ENGINE_VERSION = "1.3.0"
 # limit. It is deliberately not used to truncate or reject replay history.
 MAX_BACKTEST_BARS = 20_000
 MAX_PROVIDER_FETCH_BARS = 20_000
+MAX_BACKTEST_PROVIDER_REQUESTS = 40
 CANDLE_QUERY_CHUNK_SIZE = 8_192
 _DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES = 1_536 * 1024 * 1024
 try:
@@ -166,6 +167,20 @@ class _ResolvedBacktestWindow:
     start: datetime
     end: datetime
     full_history: bool
+
+
+@dataclass
+class _ProviderRequestBudget:
+    limit: int
+    used: int = 0
+
+    def claim(self) -> None:
+        if self.used >= max(1, int(self.limit)):
+            raise BacktestConfigurationError(
+                "backtest_market_data_request_limit_exceeded: complete history could not be "
+                f"prepared within {self.limit} provider requests; no partial backtest was saved"
+            )
+        self.used += 1
 
 
 @dataclass(frozen=True)
@@ -2304,6 +2319,7 @@ def prepare_bot_backtest_data(
     client: ProjectXClient,
     now: datetime | None = None,
     include_primary: bool = True,
+    request_budget: _ProviderRequestBudget | None = None,
 ) -> int:
     """Populate TopBot's deterministic replay cache without running a replay."""
 
@@ -2325,6 +2341,7 @@ def prepare_bot_backtest_data(
         raise BacktestConfigurationError("backtest end must be after start")
 
     captured_now = _as_utc(now or datetime.now(timezone.utc))
+    budget = request_budget or _ProviderRequestBudget(MAX_BACKTEST_PROVIDER_REQUESTS)
     fetch_end = min(end, captured_now)
     primary_identity = (
         str(config.contract_id),
@@ -2418,6 +2435,7 @@ def prepare_bot_backtest_data(
         chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
         while cursor < fetch_end:
             chunk_end = min(fetch_end, cursor + chunk_span)
+            budget.claim()
             bot_service_module.fetch_and_store_market_candles(
                 db,
                 user_id=user_id,
@@ -2758,6 +2776,7 @@ def _fetch_exact_primary_chunk(
     user_id: str,
     config: BotConfig,
     client: ProjectXClient,
+    request_budget: _ProviderRequestBudget,
     start: datetime,
     end: datetime,
 ) -> list[ProjectXMarketCandle]:
@@ -2769,6 +2788,7 @@ def _fetch_exact_primary_chunk(
     provider_unit = bot_service_module._PROJECTX_UNIT_BY_NAME.get(unit)
     if provider_unit is None:
         raise BacktestConfigurationError(f"unsupported_candle_unit:{unit}")
+    request_budget.claim()
     bars = client.retrieve_bars(
         contract_id=str(config.contract_id),
         live=False,
@@ -2797,6 +2817,7 @@ def _prepare_topbot_primary_full_history(
     user_id: str,
     config: BotConfig,
     client: ProjectXClient,
+    request_budget: _ProviderRequestBudget,
     now: datetime,
 ) -> None:
     """Discover and persist the provider's complete configured-delivery history."""
@@ -2818,6 +2839,7 @@ def _prepare_topbot_primary_full_history(
         user_id=user_id,
         config=config,
         client=client,
+        request_budget=request_budget,
         start=_FULL_HISTORY_DISCOVERY_START,
         end=captured_now,
     )
@@ -2849,6 +2871,7 @@ def _prepare_topbot_primary_full_history(
             user_id=user_id,
             config=config,
             client=client,
+            request_budget=request_budget,
             start=chunk_start,
             end=backward_cursor,
         )
@@ -2881,6 +2904,7 @@ def _prepare_topbot_primary_full_history(
             user_id=user_id,
             config=config,
             client=client,
+            request_budget=request_budget,
             start=forward_cursor,
             end=chunk_end,
         )
@@ -2930,6 +2954,7 @@ def create_bot_backtest(
     captured_now = _as_utc(now or datetime.now(timezone.utc))
     requested_bounds = _requested_backtest_bounds(payload)
     is_topbot = str(config.strategy_type) == _TOPBOT_STRATEGY
+    request_budget = _ProviderRequestBudget(MAX_BACKTEST_PROVIDER_REQUESTS) if is_topbot else None
     if is_topbot:
         if client is None:
             raise BacktestConfigurationError("topbot_backtest_market_data_client_required")
@@ -2939,6 +2964,7 @@ def create_bot_backtest(
                 user_id=user_id,
                 config=config,
                 client=client,
+                request_budget=request_budget,
                 now=captured_now,
             )
         else:
@@ -2949,6 +2975,7 @@ def create_bot_backtest(
                 payload=payload,
                 client=client,
                 now=captured_now,
+                request_budget=request_budget,
             )
 
     primary_rows = _load_primary_closed_candles(
@@ -2968,6 +2995,7 @@ def create_bot_backtest(
             client=client,
             now=captured_now,
             include_primary=False,
+            request_budget=request_budget,
         )
         primary_rows = _load_primary_closed_candles(
             db,
@@ -3039,6 +3067,13 @@ def create_bot_backtest(
         force_close_at_end=bool(payload.force_close_at_end),
         replay_streams=replay_streams,
     )
+    if is_topbot and requested_bounds is None:
+        result["warnings"].append(
+            "Full-history preparation scanned the exact configured delivery backward and forward; "
+            "because ProjectX supplies no end-of-history marker, the older boundary is inferred only "
+            f"after at least {int(_MAX_PROVIDER_EMPTY_SPAN.total_seconds() // 86_400)} consecutive "
+            "empty calendar days. Provider limits fail explicitly instead of saving a partial replay."
+        )
     input_fingerprint = (
         candle_stream_input_fingerprint(replay_streams)
         if replay_streams is not None
@@ -3778,6 +3813,15 @@ def _count_futures_session_gaps(
     interval_seconds: int,
 ) -> int:
     gaps = 0
+    symbol = next(
+        (
+            str(value)
+            for row in candles
+            for value in (getattr(row, "symbol", None), getattr(row, "contract_id", None))
+            if value is not None and str(value).strip()
+        ),
+        None,
+    )
     for previous, current in zip(candles, candles[1:]):
         previous_timestamp = _as_utc(previous.candle_timestamp)
         current_timestamp = _as_utc(current.candle_timestamp)
@@ -3787,6 +3831,7 @@ def _count_futures_session_gaps(
             previous_timestamp + timedelta(seconds=interval_seconds),
             current_timestamp,
             step_seconds=interval_seconds,
+            symbol=symbol,
         ):
             gaps += 1
     return gaps
@@ -3831,6 +3876,7 @@ def _contains_open_futures_timestamp(
     end: datetime,
     *,
     step_seconds: int,
+    symbol: str | None = None,
 ) -> bool:
     cursor = _as_utc(start)
     end_utc = _as_utc(end)
@@ -3838,7 +3884,7 @@ def _contains_open_futures_timestamp(
     # scan every second across a weekend closure.
     step = timedelta(seconds=max(60, int(step_seconds)))
     while cursor < end_utc:
-        if futures_session_is_open(cursor):
+        if futures_session_is_open(cursor, symbol=symbol):
             return True
         cursor += step
     return False

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-import os
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
-from itertools import islice
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any, Callable, Mapping
 
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -48,27 +46,12 @@ from .trading_day import (
 
 
 BACKTEST_ENGINE_VERSION = "1.3.0"
-# Retained as a compatibility constant for callers/tests that display the old
-# limit. It is deliberately not used to truncate or reject replay history.
 MAX_BACKTEST_BARS = 20_000
+MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
+MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
+MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
+MAX_TOPBOT_REPLAY_TOTAL_BARS = 250_000
 MAX_PROVIDER_FETCH_BARS = 20_000
-CANDLE_QUERY_CHUNK_SIZE = 8_192
-_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES = 1_536 * 1024 * 1024
-try:
-    BACKTEST_MEMORY_BUDGET_BYTES = int(
-        os.getenv(
-            "TOPSIGNAL_BACKTEST_MEMORY_BUDGET_BYTES",
-            str(_DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES),
-        )
-    )
-except ValueError:
-    BACKTEST_MEMORY_BUDGET_BYTES = _DEFAULT_BACKTEST_MEMORY_BUDGET_BYTES
-
-# Calibrated with tracemalloc and the projected-row benchmark. These estimates
-# intentionally include Python container overhead and the two per-bar result
-# series, not only raw OHLCV payload bytes.
-ESTIMATED_REPLAY_CANDLE_BYTES = 640
-ESTIMATED_EXECUTION_RESULT_BYTES = 704
 MIN_EXECUTION_BARS = 2
 
 # These strategies have exact replay adapters for their required stored streams
@@ -187,33 +170,6 @@ class _PreparedReplayStream:
     close_times: list[datetime]
 
 
-class _ClosedCandleList(list[ProjectXMarketCandle]):
-    """Internal proof that a replay window is already closed and ordered."""
-
-    _topsignal_sorted_closed = True
-
-
-@dataclass(slots=True)
-class _ProjectedCandle:
-    """Lightweight query result with the candle attribute contract evaluators use."""
-
-    user_id: Any
-    contract_id: str
-    symbol: str | None
-    live: bool
-    unit: str
-    unit_number: int
-    candle_timestamp: datetime
-    open_price: Any
-    high_price: Any
-    low_price: Any
-    close_price: Any
-    volume: Any
-    is_partial: bool
-    raw_payload: Any
-    fetched_at: datetime | None
-
-
 @dataclass(frozen=True)
 class _PendingSignal:
     action: str
@@ -259,38 +215,11 @@ class BacktestEngine:
         _require_supported_strategy(self.strategy_type)
         _validate_replay_configuration(config)
         uses_real_evaluator = signal_evaluator is None
-        self._uses_real_evaluator = uses_real_evaluator
         self.signal_evaluator = signal_evaluator or self._evaluate_real_strategy
 
         self.all_candles, excluded_partial = _validate_and_sort_candles(candles, config=config)
-        self.all_start_times = [
-            _as_utc(candle.candle_timestamp) for candle in self.all_candles
-        ]
-        self.all_close_times = [
-            _candle_close_time(candle) for candle in self.all_candles
-        ]
-        self._sma_close_values = (
-            [float(candle.close_price) for candle in self.all_candles]
-            if uses_real_evaluator
-            and self.strategy_type == "sma_cross"
-            and evaluate_sma_cross is bot_service_module.evaluate_sma_cross
-            else None
-        )
         self.topbot_streams: dict[str, _PreparedReplayStream] = {}
         self.topbot_unavailable_sources: dict[str, tuple[str, ...]] = {}
-        self._topbot_params: dict[str, Any] = {}
-        self._topbot_source_params: dict[str, dict[str, Any]] = {}
-        self._topbot_source_keys: dict[str, tuple[str, ...]] = {}
-        self._topbot_source_configs: dict[str, _SourceConfigView] = {}
-        self._topbot_cursor_state: dict[str, tuple[datetime, int]] = {}
-        self._topbot_history_event: datetime | None = None
-        self._topbot_history_cache: dict[
-            tuple[str, int, datetime | None], list[ProjectXMarketCandle]
-        ] = {}
-        self._current_event_timestamp: datetime | None = None
-        self._current_event_in_session = False
-        self._configured_session_start = _parse_time(str(config.trading_start_time))
-        self._configured_session_end = _parse_time(str(config.trading_end_time))
         auxiliary_excluded_partial = 0
         deferred_execution_bars = 0
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
@@ -302,13 +231,12 @@ class BacktestEngine:
                 primary_candles=self.all_candles,
                 replay_streams=replay_streams,
             )
-            self._prepare_topbot_runtime()
-
-        execution_start = bisect_left(self.all_start_times, self.settings.start)
-        execution_end = bisect_right(self.all_close_times, self.settings.end)
-        self.execution_candles = self.all_candles[execution_start:execution_end]
-        self.execution_start_times = self.all_start_times[execution_start:execution_end]
-        self.execution_close_times = self.all_close_times[execution_start:execution_end]
+        self.execution_candles = [
+            candle
+            for candle in self.all_candles
+            if _as_utc(candle.candle_timestamp) >= self.settings.start
+            and _candle_close_time(candle) <= self.settings.end
+        ]
         if len(self.execution_candles) < MIN_EXECUTION_BARS:
             raise InsufficientBacktestDataError(
                 "insufficient_backtest_data: at least 2 closed execution bars are required "
@@ -316,72 +244,76 @@ class BacktestEngine:
             )
         if uses_real_evaluator and self.strategy_type != "orb_fibonacci_pullback":
             hard_minimum = _strategy_history_bars(config, hard_minimum=True)
-            first_event = self.execution_close_times[0]
-            closed_by_first_event = bisect_right(self.all_close_times, first_event)
+            first_event = _candle_close_time(self.execution_candles[0])
+            closed_by_first_event = sum(
+                1 for candle in self.all_candles if _candle_close_time(candle) <= first_event
+            )
             if closed_by_first_event < hard_minimum:
                 deferred_execution_bars = hard_minimum - closed_by_first_event
                 self.execution_candles = self.execution_candles[deferred_execution_bars:]
-                self.execution_start_times = self.execution_start_times[
-                    deferred_execution_bars:
-                ]
-                self.execution_close_times = self.execution_close_times[
-                    deferred_execution_bars:
-                ]
                 if len(self.execution_candles) < MIN_EXECUTION_BARS:
-                    available_closed_bars = bisect_right(
-                        self.all_close_times,
-                        self.settings.end,
+                    available_closed_bars = sum(
+                        1
+                        for candle in self.all_candles
+                        if _candle_close_time(candle) <= self.settings.end
                     )
                     raise InsufficientBacktestDataError(
                         "insufficient_backtest_data: insufficient_strategy_warmup: "
                         f"{self.strategy_type} requires at least {hard_minimum} closed bars; "
                         f"only {available_closed_bars} were available"
                     )
-        self.execution_in_session = (
-            [
-                self._event_in_configured_session(timestamp)
-                for timestamp in self.execution_start_times
-            ]
-            if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY
-            else [True] * len(self.execution_candles)
-        )
         if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
-            in_session_indexes = [
-                index
-                for index, inside in enumerate(self.execution_in_session)
-                if inside
+            session_execution_candles = [
+                candle
+                for candle in self.execution_candles
+                if _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
+                )
             ]
-            first_coverage_index = in_session_indexes[0] if in_session_indexes else 0
-            last_coverage_index = (
-                in_session_indexes[-1]
-                if in_session_indexes
-                else len(self.execution_candles) - 1
-            )
+            coverage_candles = session_execution_candles or self.execution_candles
             self.topbot_unavailable_sources = _topbot_unavailable_sources(
                 config,
                 streams=self.topbot_streams,
-                first_event=self.execution_close_times[first_coverage_index],
-                last_event=self.execution_close_times[last_coverage_index],
+                first_event=_candle_close_time(coverage_candles[0]),
+                last_event=_candle_close_time(coverage_candles[-1]),
             )
-        self.evaluator_history_limit = max(
-            int(config.lookback_bars),
-            _strategy_history_bars(config, hard_minimum=False),
+        self.evaluator_history_limit = min(
+            MAX_BACKTEST_BARS,
+            max(
+                int(config.lookback_bars),
+                _strategy_history_bars(config, hard_minimum=False),
+            ),
         )
         self.max_evaluator_input_bars = _max_evaluator_input_bars(
             config,
             rolling_limit=self.evaluator_history_limit,
         )
-        replay_row_count = len(self.all_candles)
-        if self.topbot_streams:
-            replay_row_count += sum(
-                len(stream.candles)
-                for stream in self.topbot_streams.values()
-                if stream.candles is not self.all_candles
+        if uses_real_evaluator and self.strategy_type == _TOPBOT_STRATEGY:
+            signal_evaluation_bars = sum(
+                _event_timestamp_is_in_configured_session(
+                    config,
+                    _as_utc(candle.candle_timestamp),
+                )
+                for candle in self.execution_candles
             )
-        _enforce_backtest_resource_budget(
-            replay_rows=replay_row_count,
-            execution_rows=len(self.execution_candles),
-        )
+            estimated_operations = _estimate_topbot_evaluator_operations(
+                config,
+                execution_bars=signal_evaluation_bars,
+            )
+            operation_limit = MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS
+        else:
+            estimated_operations = len(self.execution_candles) * min(
+                len(self.all_candles), self.max_evaluator_input_bars
+            )
+            operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
+        if estimated_operations > operation_limit:
+            raise BacktestConfigurationError(
+                "backtest_computation_limit_exceeded: the complete resolved history and bot "
+                "lookback exceed the current replay resource budget; no partial result was saved; "
+                f"estimated evaluator bar-visits {estimated_operations:,} exceed "
+                f"{operation_limit:,}"
+            )
 
         self.warnings: list[str] = []
         if excluded_partial:
@@ -419,8 +351,7 @@ class BacktestEngine:
                 "unrealized_pnl": 0.0,
             }
         ]
-        self.exposed_bar_count = 0
-        self._current_bar_exposed = False
+        self.exposed_bar_indexes: set[int] = set()
         self.daily_entry_counts: dict[Any, int] = defaultdict(int)
         self.daily_net_activity: dict[Any, float] = defaultdict(float)
         self.last_loss_at: datetime | None = None
@@ -431,24 +362,15 @@ class BacktestEngine:
         self.topbot_source_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 
     def run(self) -> dict[str, Any]:
-        closed_history: list[ProjectXMarketCandle] = _ClosedCandleList()
+        closed_history: list[ProjectXMarketCandle] = []
         history_cursor = 0
-        timeline = zip(
-            self.execution_candles,
-            self.execution_start_times,
-            self.execution_close_times,
-            self.execution_in_session,
-        )
-        for index, (candle, candle_start, event_time, inside_session) in enumerate(
-            timeline
-        ):
-            self._current_bar_exposed = False
-            self._current_event_timestamp = candle_start
-            self._current_event_in_session = inside_session
+        for index, candle in enumerate(self.execution_candles):
+            candle_start = _as_utc(candle.candle_timestamp)
+            event_time = _candle_close_time(candle)
 
             counted_position = self.position
             if counted_position is not None:
-                self._current_bar_exposed = True
+                self.exposed_bar_indexes.add(index)
                 counted_position.bars_held += 1
                 self._process_open_gap(candle)
 
@@ -458,24 +380,27 @@ class BacktestEngine:
                 self._fill_pending_signal(pending, candle=candle, bar_index=index)
 
             if self.position is not None:
-                self._current_bar_exposed = True
+                self.exposed_bar_indexes.add(index)
                 if self.position is not counted_position:
                     self.position.bars_held += 1
                 self._process_intrabar_bracket(candle)
 
             while (
                 history_cursor < len(self.all_candles)
-                and self.all_close_times[history_cursor] <= event_time
+                and _candle_close_time(self.all_candles[history_cursor]) <= event_time
             ):
                 closed_history.append(self.all_candles[history_cursor])
                 history_cursor += 1
-            if self.strategy_type == _TOPBOT_STRATEGY and not inside_session:
+            if (
+                self.strategy_type == _TOPBOT_STRATEGY
+                and not _event_timestamp_is_in_configured_session(
+                    self.config,
+                    candle_start,
+                )
+            ):
                 self._record_equity(event_time=event_time, mark_price=float(candle.close_price))
                 continue
-            if self._sma_close_values is not None:
-                signal = self._evaluate_prepared_sma(history_cursor)
-            else:
-                signal = self.signal_evaluator(self._evaluator_input(closed_history))
+            signal = self.signal_evaluator(self._evaluator_input(closed_history))
             if self.strategy_type == _TOPBOT_STRATEGY:
                 self._record_topbot_source_failures(signal)
             if signal.action in {"BUY", "SELL"}:
@@ -506,7 +431,7 @@ class BacktestEngine:
 
         if self.position is not None and self.settings.force_close_at_end:
             final_candle = self.execution_candles[-1]
-            final_time = self.execution_close_times[-1]
+            final_time = _candle_close_time(final_candle)
             self._update_excursion(float(final_candle.close_price), float(final_candle.close_price))
             self._close_position(
                 raw_exit_price=float(final_candle.close_price),
@@ -525,14 +450,12 @@ class BacktestEngine:
             self.trades,
             equity_curve=self.equity_curve,
             drawdown_series=drawdown_series,
-            exposure_percent=(
-                self.exposed_bar_count / len(self.execution_candles) * 100.0
-            ),
+            exposure_percent=(len(self.exposed_bar_indexes) / len(self.execution_candles) * 100.0),
         )
         return {
             "range": {
-                "start": self.execution_start_times[0].isoformat(),
-                "end": self.execution_close_times[-1].isoformat(),
+                "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
+                "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
                 "contract_id": str(self.execution_candles[0].contract_id),
                 "symbol": self.execution_candles[0].symbol or self.config.symbol,
@@ -550,142 +473,6 @@ class BacktestEngine:
             "warnings": self.warnings,
         }
 
-    def _prepare_topbot_runtime(self) -> None:
-        self._topbot_params = bot_service_module._normalize_strategy_params(
-            _TOPBOT_STRATEGY,
-            self.config.strategy_params,
-        )
-        source_overrides = self._topbot_params.get("source_strategy_params") or {}
-        self._topbot_source_static_errors: dict[str, str] = {}
-        self._topbot_generic_args: dict[str, dict[str, Any]] = {}
-        self._topbot_primary_limits: dict[str, int] = {}
-        for source_strategy in self._topbot_params["source_strategies"]:
-            source_params = bot_service_module._normalize_strategy_params(
-                source_strategy,
-                source_overrides.get(source_strategy, {}),
-            )
-            self._topbot_source_params[source_strategy] = source_params
-            self._topbot_source_keys[source_strategy] = tuple(
-                _topbot_source_stream_keys(
-                    self.config,
-                    source_strategy,
-                    source_params=source_params,
-                )
-            )
-            fast_period, slow_period = (
-                bot_service_module._normalized_strategy_period_values(
-                    source_strategy,
-                    fast_period=int(self.config.fast_period),
-                    slow_period=int(self.config.slow_period),
-                )
-            )
-            source_config = _SourceConfigView(
-                self.config,
-                strategy_type=source_strategy,
-                strategy_params=source_params,
-                fast_period=fast_period,
-                slow_period=slow_period,
-            )
-            self._topbot_source_configs[source_strategy] = source_config
-            self._topbot_primary_limits[source_strategy] = (
-                _topbot_primary_source_history_limit(
-                    self.config,
-                    source_strategy,
-                )
-            )
-            if source_strategy in _TOPBOT_SHARED_CONFIGURED_STRATEGIES:
-                self._topbot_generic_args[source_strategy] = (
-                    _generic_evaluator_arguments(
-                        source_strategy,
-                        config=source_config,
-                        strategy_params=source_params,
-                    )
-                )
-            try:
-                bot_service_module._validate_strategy_configuration(
-                    strategy_type=source_strategy,
-                    timeframe_unit=str(source_config.timeframe_unit),
-                    timeframe_unit_number=int(source_config.timeframe_unit_number),
-                    fast_period=fast_period,
-                    slow_period=slow_period,
-                )
-            except Exception as exc:
-                self._topbot_source_static_errors[source_strategy] = str(exc)
-
-    def _event_in_configured_session(self, event_timestamp: datetime) -> bool:
-        timestamp = _as_utc(event_timestamp)
-        if self._current_event_timestamp == timestamp:
-            return self._current_event_in_session
-        if not futures_session_is_open(timestamp):
-            return False
-        local_time = timestamp.astimezone(TRADING_TZ).time().replace(tzinfo=None)
-        start = self._configured_session_start
-        end = self._configured_session_end
-        if start <= end:
-            return start <= local_time <= end
-        return local_time >= start or local_time <= end
-
-    def _evaluate_prepared_sma(self, closed_count: int) -> SignalResult:
-        closes = self._sma_close_values
-        assert closes is not None
-        fast_period = int(self.config.fast_period)
-        slow_period = int(self.config.slow_period)
-        visible_count = min(closed_count, self.evaluator_history_limit)
-        latest_index = closed_count - 1
-        latest = self.all_candles[latest_index]
-        if visible_count < slow_period + 1:
-            return SignalResult(
-                action="HOLD",
-                reason=(
-                    f"Need at least {slow_period + 1} closed candles; "
-                    f"found {visible_count}."
-                ),
-                candle_timestamp=self.all_start_times[latest_index],
-                price=float(latest.close_price),
-                raw_payload={
-                    "fast_period": fast_period,
-                    "slow_period": slow_period,
-                    "closed_count": visible_count,
-                },
-            )
-
-        previous_fast = bot_service_module._average(
-            closes[closed_count - fast_period - 1 : closed_count - 1]
-        )
-        previous_slow = bot_service_module._average(
-            closes[closed_count - slow_period - 1 : closed_count - 1]
-        )
-        current_fast = bot_service_module._average(
-            closes[closed_count - fast_period : closed_count]
-        )
-        current_slow = bot_service_module._average(
-            closes[closed_count - slow_period : closed_count]
-        )
-        action = "HOLD"
-        if previous_fast <= previous_slow and current_fast > current_slow:
-            action = "BUY"
-        elif previous_fast >= previous_slow and current_fast < current_slow:
-            action = "SELL"
-        reason = (
-            "No SMA crossover on the latest closed candle."
-            if action == "HOLD"
-            else f"{fast_period}/{slow_period} SMA crossover generated {action}."
-        )
-        return SignalResult(
-            action=action,
-            reason=reason,
-            candle_timestamp=self.all_start_times[latest_index],
-            price=float(latest.close_price),
-            raw_payload={
-                "fast_period": fast_period,
-                "slow_period": slow_period,
-                "previous_fast": previous_fast,
-                "previous_slow": previous_slow,
-                "current_fast": current_fast,
-                "current_slow": current_slow,
-            },
-        )
-
     def _record_topbot_source_failures(self, signal: SignalResult) -> None:
         payload = signal.raw_payload if isinstance(signal.raw_payload, dict) else {}
         ensemble = payload.get("ensemble") if isinstance(payload.get("ensemble"), dict) else {}
@@ -702,7 +489,7 @@ class BacktestEngine:
         closed_history: list[ProjectXMarketCandle],
     ) -> list[ProjectXMarketCandle]:
         if not closed_history:
-            return _ClosedCandleList()
+            return []
         latest_timestamp = _as_utc(closed_history[-1].candle_timestamp)
         rolling_start = max(0, len(closed_history) - self.evaluator_history_limit)
 
@@ -713,11 +500,11 @@ class BacktestEngine:
                 end_text=str(self.config.trading_end_time),
             )
             if latest_timestamp < session_start:
-                return _ClosedCandleList()
+                return []
             if latest_timestamp > session_end:
-                return _ClosedCandleList()
+                return []
             session_start_index = _first_index_at_or_after(closed_history, session_start)
-            session_rows = _closed_candle_slice(closed_history, session_start_index)
+            session_rows = closed_history[session_start_index:]
             _require_complete_session_prefix(
                 session_rows,
                 expected_start=session_start,
@@ -738,9 +525,8 @@ class BacktestEngine:
                 trading_day_date(latest_timestamp)
             )
             session_start_index = _first_index_at_or_after(closed_history, session_start)
-            session_rows = _closed_candle_slice(closed_history, session_start_index)
             _require_complete_session_prefix(
-                session_rows,
+                closed_history[session_start_index:],
                 expected_start=session_start,
                 strategy_type=self.strategy_type,
                 enforce=_is_intraday_timeframe(self.config),
@@ -749,12 +535,9 @@ class BacktestEngine:
                     int(self.config.timeframe_unit_number),
                 ),
             )
-            return _closed_candle_slice(
-                closed_history,
-                min(rolling_start, session_start_index),
-            )
+            return closed_history[min(rolling_start, session_start_index) :]
 
-        return _closed_candle_slice(closed_history, rolling_start)
+        return closed_history[rolling_start:]
 
     def _evaluate_real_strategy(self, candles: list[ProjectXMarketCandle]) -> SignalResult:
         params = self.config.strategy_params

--- a/backend/app/services/bot_backtesting.py
+++ b/backend/app/services/bot_backtesting.py
@@ -45,9 +45,8 @@ from .trading_day import (
 )
 
 
-BACKTEST_ENGINE_VERSION = "1.2.0"
+BACKTEST_ENGINE_VERSION = "1.3.0"
 MAX_BACKTEST_BARS = 20_000
-MAX_BACKTEST_RANGE_DAYS = 366
 MAX_EVALUATOR_BAR_OPERATIONS = 10_000_000
 MAX_TOPBOT_EVALUATOR_BAR_OPERATIONS = 200_000_000
 MAX_TOPBOT_REPLAY_STREAM_BARS = 100_000
@@ -140,6 +139,17 @@ class BacktestSettings:
     tick_size: float
     tick_value: float
     force_close_at_end: bool = True
+
+
+@dataclass(frozen=True)
+class _ResolvedBacktestWindow:
+    """One captured request window used by preparation, replay, and persistence."""
+
+    requested_start: datetime
+    requested_end: datetime
+    start: datetime
+    end: datetime
+    full_history: bool
 
 
 @dataclass(frozen=True)
@@ -268,11 +278,6 @@ class BacktestEngine:
                 first_event=_candle_close_time(coverage_candles[0]),
                 last_event=_candle_close_time(coverage_candles[-1]),
             )
-        if len(self.execution_candles) > MAX_BACKTEST_BARS:
-            raise BacktestConfigurationError(
-                f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}; "
-                f"found {len(self.execution_candles)}"
-            )
         self.evaluator_history_limit = min(
             MAX_BACKTEST_BARS,
             max(
@@ -304,7 +309,8 @@ class BacktestEngine:
             operation_limit = MAX_EVALUATOR_BAR_OPERATIONS
         if estimated_operations > operation_limit:
             raise BacktestConfigurationError(
-                "backtest_computation_limit_exceeded: reduce the date range or bot lookback; "
+                "backtest_computation_limit_exceeded: the complete resolved history and bot "
+                "lookback exceed the current replay resource budget; no partial result was saved; "
                 f"estimated evaluator bar-visits {estimated_operations:,} exceed "
                 f"{operation_limit:,}"
             )
@@ -451,6 +457,10 @@ class BacktestEngine:
                 "start": _as_utc(self.execution_candles[0].candle_timestamp).isoformat(),
                 "end": _candle_close_time(self.execution_candles[-1]).isoformat(),
                 "bar_count": len(self.execution_candles),
+                "contract_id": str(self.execution_candles[0].contract_id),
+                "symbol": self.execution_candles[0].symbol or self.config.symbol,
+                "timeframe_unit": str(self.execution_candles[0].unit),
+                "timeframe_unit_number": int(self.execution_candles[0].unit_number),
             },
             "config_snapshot": _config_snapshot(self.config),
             "assumptions": _assumptions_snapshot(self.config, self.settings),
@@ -2065,6 +2075,8 @@ def prepare_bot_backtest_data(
     bot_config_id: int,
     payload: Any,
     client: ProjectXClient,
+    now: datetime | None = None,
+    include_primary: bool = True,
 ) -> int:
     """Populate TopBot's deterministic replay cache without running a replay."""
 
@@ -2084,12 +2096,14 @@ def prepare_bot_backtest_data(
     end = _as_utc(payload.end)
     if end <= start:
         raise BacktestConfigurationError("backtest end must be after start")
-    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
 
-    fetch_end = min(end, datetime.now(timezone.utc))
+    captured_now = _as_utc(now or datetime.now(timezone.utc))
+    fetch_end = min(end, captured_now)
+    primary_identity = (
+        str(config.contract_id),
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
     requests: dict[tuple[str, str, int], tuple[str | None, datetime, int]] = {}
     for spec in _topbot_stream_specs(config).values():
         interval_seconds = _timeframe_seconds(spec.unit, spec.unit_number)
@@ -2100,21 +2114,18 @@ def prepare_bot_backtest_data(
         contract_id = spec.contract_id or spec.symbol
         if not contract_id:
             raise BacktestConfigurationError(f"topbot_replay_contract_missing:{spec.key}")
+        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
+        if identity == primary_identity and not include_primary:
+            continue
         fetch_start = start - timedelta(
             seconds=interval_seconds * max(25, int(spec.warmup_bars)) * 3
         )
-        identity = (str(contract_id), str(spec.unit), int(spec.unit_number))
         existing = requests.get(identity)
         if existing is None or fetch_start < existing[1]:
             requests[identity] = (spec.symbol, fetch_start, int(spec.warmup_bars))
         elif int(spec.warmup_bars) > existing[2]:
             requests[identity] = (existing[0], existing[1], int(spec.warmup_bars))
 
-    primary_identity = (
-        str(config.contract_id),
-        str(config.timeframe_unit),
-        int(config.timeframe_unit_number),
-    )
     primary_execution_rows = (
         db.query(ProjectXMarketCandle)
         .filter(ProjectXMarketCandle.user_id == user_id)
@@ -2151,10 +2162,23 @@ def prepare_bot_backtest_data(
             _cached_candle_was_fetched_before_nominal_close(row)
             for row in primary_execution_rows
         ) and not _candle_stream_has_overlaps(primary_execution_rows)
+        primary_cache_covers_window = (
+            len(primary_execution_rows) >= MIN_EXECUTION_BARS
+            and primary_cache_is_clean
+            and not _has_open_futures_interval(
+                start,
+                _as_utc(primary_execution_rows[0].candle_timestamp),
+                interval_seconds=interval_seconds,
+            )
+            and not _has_open_futures_interval(
+                _candle_close_time(primary_execution_rows[-1]),
+                fetch_end,
+                interval_seconds=interval_seconds,
+            )
+        )
         if (
             identity == primary_identity
-            and len(primary_execution_rows) >= MIN_EXECUTION_BARS
-            and primary_cache_is_clean
+            and primary_cache_covers_window
         ):
             continue
         if identity != primary_identity and primary_execution_rows and _cached_replay_stream_covers(
@@ -2312,12 +2336,261 @@ def run_backtest(
     ).run()
 
 
+def _load_primary_closed_candles(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    closed_by: datetime,
+) -> list[ProjectXMarketCandle]:
+    """Load every eligible primary bar without rolling across futures deliveries."""
+
+    cutoff = _as_utc(closed_by)
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
+        .filter(ProjectXMarketCandle.live.is_(False))
+        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
+        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
+        .filter(ProjectXMarketCandle.is_partial.is_(False))
+        .filter(ProjectXMarketCandle.candle_timestamp <= cutoff)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    return [
+        row
+        for row in rows
+        if not _cached_candle_is_effectively_partial(row)
+        and _candle_close_time(row) <= cutoff
+    ]
+
+
+def _requested_backtest_bounds(payload: Any) -> tuple[datetime, datetime] | None:
+    raw_start = getattr(payload, "start", None)
+    raw_end = getattr(payload, "end", None)
+    if (raw_start is None) != (raw_end is None):
+        raise BacktestConfigurationError(
+            "backtest start and end must be provided together"
+        )
+    if raw_start is None:
+        return None
+    start = _as_utc(raw_start)
+    end = _as_utc(raw_end)
+    if end <= start:
+        raise BacktestConfigurationError("backtest end must be after start")
+    return start, end
+
+
+def _resolve_backtest_window(
+    rows: list[ProjectXMarketCandle],
+    *,
+    payload: Any,
+    now: datetime,
+) -> _ResolvedBacktestWindow:
+    """Resolve absent dates to complete exact-contract coverage at one instant."""
+
+    captured_now = _as_utc(now)
+    requested = _requested_backtest_bounds(payload)
+    if requested is None:
+        eligible = rows
+        full_history = True
+    else:
+        requested_start, requested_end = requested
+        effective_end = min(requested_end, captured_now)
+        eligible = [
+            row
+            for row in rows
+            if _as_utc(row.candle_timestamp) >= requested_start
+            and _candle_close_time(row) <= effective_end
+        ]
+        full_history = False
+
+    if len(eligible) < MIN_EXECUTION_BARS:
+        mode = "full configured-contract history" if requested is None else "requested range"
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: at least 2 fully closed execution bars are required "
+            f"for the {mode}; found {len(eligible)}"
+        )
+
+    if requested is None:
+        start = _as_utc(eligible[0].candle_timestamp)
+        end = _candle_close_time(eligible[-1])
+        requested_start = start
+        requested_end = end
+    else:
+        requested_start, requested_end = requested
+        start = requested_start
+        end = min(requested_end, captured_now)
+
+    return _ResolvedBacktestWindow(
+        requested_start=requested_start,
+        requested_end=requested_end,
+        start=start,
+        end=end,
+        full_history=full_history,
+    )
+
+
+_FULL_HISTORY_DISCOVERY_START = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_MAX_PROVIDER_EMPTY_SPAN = timedelta(days=14)
+
+
+def _fetch_exact_primary_chunk(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: ProjectXClient,
+    start: datetime,
+    end: datetime,
+) -> list[ProjectXMarketCandle]:
+    """Fetch one exact-delivery chunk and propagate provider failures."""
+
+    if end <= start:
+        return []
+    unit = str(config.timeframe_unit)
+    provider_unit = bot_service_module._PROJECTX_UNIT_BY_NAME.get(unit)
+    if provider_unit is None:
+        raise BacktestConfigurationError(f"unsupported_candle_unit:{unit}")
+    bars = client.retrieve_bars(
+        contract_id=str(config.contract_id),
+        live=False,
+        start=_as_utc(start),
+        end=_as_utc(end),
+        unit=provider_unit,
+        unit_number=int(config.timeframe_unit_number),
+        limit=MAX_PROVIDER_FETCH_BARS,
+        include_partial_bar=False,
+    )
+    return bot_service_module.store_market_candles(
+        db,
+        user_id=user_id,
+        contract_id=str(config.contract_id),
+        symbol=config.symbol,
+        live=False,
+        unit=unit,
+        unit_number=int(config.timeframe_unit_number),
+        bars=bars,
+    )
+
+
+def _prepare_topbot_primary_full_history(
+    db: Session,
+    *,
+    user_id: str,
+    config: BotConfig,
+    client: ProjectXClient,
+    now: datetime,
+) -> None:
+    """Discover and persist the provider's complete configured-delivery history."""
+
+    captured_now = _as_utc(now)
+    interval_seconds = _timeframe_seconds(
+        str(config.timeframe_unit),
+        int(config.timeframe_unit_number),
+    )
+    if interval_seconds is None or interval_seconds <= 0:
+        raise BacktestConfigurationError(
+            "unsupported_topbot_replay_timeframe:"
+            f"{config.timeframe_unit}:{config.timeframe_unit_number}"
+        )
+    chunk_span = timedelta(seconds=interval_seconds * (MAX_PROVIDER_FETCH_BARS - 1))
+
+    seed = _fetch_exact_primary_chunk(
+        db,
+        user_id=user_id,
+        config=config,
+        client=client,
+        start=_FULL_HISTORY_DISCOVERY_START,
+        end=captured_now,
+    )
+    if not seed:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: provider returned no closed history for configured "
+            f"contract {config.contract_id}"
+        )
+
+    rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
+    )
+    if not rows:
+        raise InsufficientBacktestDataError(
+            "insufficient_backtest_data: provider returned no valid closed history for "
+            f"configured contract {config.contract_id}"
+        )
+
+    earliest = _as_utc(rows[0].candle_timestamp)
+    backward_cursor = earliest
+    empty_span = timedelta(0)
+    while backward_cursor > _FULL_HISTORY_DISCOVERY_START:
+        chunk_start = max(_FULL_HISTORY_DISCOVERY_START, backward_cursor - chunk_span)
+        fetched = _fetch_exact_primary_chunk(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=chunk_start,
+            end=backward_cursor,
+        )
+        older = [
+            row for row in fetched if _as_utc(row.candle_timestamp) < earliest
+        ]
+        if older:
+            earliest = min(_as_utc(row.candle_timestamp) for row in older)
+            backward_cursor = earliest
+            empty_span = timedelta(0)
+            continue
+        empty_span += backward_cursor - chunk_start
+        backward_cursor = chunk_start
+        if empty_span >= _MAX_PROVIDER_EMPTY_SPAN:
+            break
+
+    rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
+    )
+    latest_timestamp = _as_utc(rows[-1].candle_timestamp)
+    forward_cursor = _candle_close_time(rows[-1])
+    empty_span = timedelta(0)
+    while forward_cursor < captured_now:
+        chunk_end = min(captured_now, forward_cursor + chunk_span)
+        fetched = _fetch_exact_primary_chunk(
+            db,
+            user_id=user_id,
+            config=config,
+            client=client,
+            start=forward_cursor,
+            end=chunk_end,
+        )
+        newer = [
+            row for row in fetched if _as_utc(row.candle_timestamp) > latest_timestamp
+        ]
+        if newer:
+            latest_row = max(newer, key=lambda row: _as_utc(row.candle_timestamp))
+            latest_timestamp = _as_utc(latest_row.candle_timestamp)
+            forward_cursor = _candle_close_time(latest_row)
+            empty_span = timedelta(0)
+            continue
+        empty_span += chunk_end - forward_cursor
+        forward_cursor = chunk_end
+        if empty_span >= _MAX_PROVIDER_EMPTY_SPAN:
+            break
+
+
 def create_bot_backtest(
     db: Session,
     *,
     user_id: str,
     bot_config_id: int,
     payload: Any,
+    client: ProjectXClient | None = None,
+    now: datetime | None = None,
 ) -> BotBacktest:
     config = (
         db.query(BotConfig)
@@ -2328,15 +2601,7 @@ def create_bot_backtest(
     if config is None:
         raise LookupError("bot_config_not_found")
     _require_supported_strategy(str(config.strategy_type))
-
-    start = _as_utc(payload.start)
-    end = _as_utc(payload.end)
-    if end <= start:
-        raise BacktestConfigurationError("backtest end must be after start")
-    if end - start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
+    _validate_replay_configuration(config)
 
     specs = load_instrument_specs(db)
     symbol_key = normalize_symbol_key(config.symbol) or normalize_symbol_key(config.contract_id)
@@ -2346,25 +2611,62 @@ def create_bot_backtest(
             f"instrument_metadata_missing:{symbol_key or config.contract_id}"
         )
 
-    execution_query = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp >= start)
-        .filter(ProjectXMarketCandle.candle_timestamp <= end)
-        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
-        .limit(MAX_BACKTEST_BARS + 1)
+    captured_now = _as_utc(now or datetime.now(timezone.utc))
+    requested_bounds = _requested_backtest_bounds(payload)
+    is_topbot = str(config.strategy_type) == _TOPBOT_STRATEGY
+    if is_topbot:
+        if client is None:
+            raise BacktestConfigurationError("topbot_backtest_market_data_client_required")
+        if requested_bounds is None:
+            _prepare_topbot_primary_full_history(
+                db,
+                user_id=user_id,
+                config=config,
+                client=client,
+                now=captured_now,
+            )
+        else:
+            prepare_bot_backtest_data(
+                db,
+                user_id=user_id,
+                bot_config_id=bot_config_id,
+                payload=payload,
+                client=client,
+                now=captured_now,
+            )
+
+    primary_rows = _load_primary_closed_candles(
+        db,
+        user_id=user_id,
+        config=config,
+        closed_by=captured_now,
     )
-    execution_rows = execution_query.all()
-    execution_rows = [row for row in execution_rows if _candle_close_time(row) <= end]
-    if len(execution_rows) > MAX_BACKTEST_BARS:
-        raise BacktestConfigurationError(
-            f"backtest_bar_limit_exceeded: maximum is {MAX_BACKTEST_BARS}"
+    window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
+
+    if is_topbot and requested_bounds is None:
+        prepare_bot_backtest_data(
+            db,
+            user_id=user_id,
+            bot_config_id=bot_config_id,
+            payload=window,
+            client=client,
+            now=captured_now,
+            include_primary=False,
         )
+        primary_rows = _load_primary_closed_candles(
+            db,
+            user_id=user_id,
+            config=config,
+            closed_by=captured_now,
+        )
+        window = _resolve_backtest_window(primary_rows, payload=payload, now=captured_now)
+
+    execution_rows = [
+        row
+        for row in primary_rows
+        if _as_utc(row.candle_timestamp) >= window.start
+        and _candle_close_time(row) <= window.end
+    ]
 
     rolling_warmup_limit = min(
         MAX_BACKTEST_BARS,
@@ -2373,7 +2675,7 @@ def create_bot_backtest(
             _strategy_history_bars(config, hard_minimum=False),
         ),
     )
-    if str(config.strategy_type) == _TOPBOT_STRATEGY:
+    if is_topbot:
         primary_key = _topbot_asset_stream_key(
             str(config.timeframe_unit),
             int(config.timeframe_unit_number),
@@ -2387,37 +2689,29 @@ def create_bot_backtest(
         config,
         rolling_limit=rolling_warmup_limit,
     )
-    warmup_rows = (
-        db.query(ProjectXMarketCandle)
-        .filter(ProjectXMarketCandle.user_id == user_id)
-        .filter(ProjectXMarketCandle.contract_id == str(config.contract_id))
-        .filter(ProjectXMarketCandle.live.is_(False))
-        .filter(ProjectXMarketCandle.unit == str(config.timeframe_unit))
-        .filter(ProjectXMarketCandle.unit_number == int(config.timeframe_unit_number))
-        .filter(ProjectXMarketCandle.is_partial.is_(False))
-        .filter(ProjectXMarketCandle.candle_timestamp < start)
-        .order_by(ProjectXMarketCandle.candle_timestamp.desc())
-        .limit(warmup_limit)
-        .all()
-    )
-    warmup_rows.reverse()
+    warmup_candidates = [
+        row
+        for row in primary_rows
+        if _as_utc(row.candle_timestamp) < window.start
+    ]
+    warmup_rows = warmup_candidates[-warmup_limit:]
     replay_rows = [*warmup_rows, *execution_rows]
     replay_streams: dict[str, list[ProjectXMarketCandle]] | None = None
-    if str(config.strategy_type) == _TOPBOT_STRATEGY:
+    if is_topbot:
         replay_streams = _load_topbot_replay_streams(
             db,
             user_id=user_id,
             config=config,
-            start=start,
-            end=end,
+            start=window.start,
+            end=window.end,
             primary_rows=replay_rows,
         )
 
     result = run_backtest(
         config=config,
         candles=replay_rows,
-        start=start,
-        end=end,
+        start=window.start,
+        end=window.end,
         starting_balance=float(payload.starting_balance),
         commission_per_contract=float(payload.commission_per_contract),
         slippage_ticks=float(payload.slippage_ticks),
@@ -2443,8 +2737,8 @@ def create_bot_backtest(
         symbol=config.symbol,
         timeframe_unit=str(config.timeframe_unit),
         timeframe_unit_number=int(config.timeframe_unit_number),
-        requested_start=start,
-        requested_end=end,
+        requested_start=window.requested_start,
+        requested_end=window.requested_end,
         actual_start=_as_utc(datetime.fromisoformat(str(result["range"]["start"]))),
         actual_end=_as_utc(datetime.fromisoformat(str(result["range"]["end"]))),
         starting_balance=float(payload.starting_balance),
@@ -2590,10 +2884,6 @@ def _validate_settings(settings: BacktestSettings) -> BacktestSettings:
     )
     if normalized.end <= normalized.start:
         raise BacktestConfigurationError("backtest end must be after start")
-    if normalized.end - normalized.start > timedelta(days=MAX_BACKTEST_RANGE_DAYS):
-        raise BacktestConfigurationError(
-            f"backtest range cannot exceed {MAX_BACKTEST_RANGE_DAYS} days"
-        )
     for name in ["starting_balance", "tick_size", "tick_value"]:
         value = getattr(normalized, name)
         if not math.isfinite(value) or value <= 0:
@@ -3077,7 +3367,10 @@ def _assumptions_snapshot(config: BotConfig, settings: BacktestSettings) -> dict
         "slippage_rule": "configured_ticks_are_applied_adversely_to_every_entry_and_exit_fill",
         "pnl_rule": "price_delta_divided_by_tick_size_times_tick_value_times_quantity",
         "metric_basis": "profit_factor_expectancy_average_win_and_average_loss_use_net_trade_pnl",
-        "market_data": "stored_user_scoped_non_live_closed_candles_only; no_provider_fetch",
+        "market_data": (
+            "preparation_may_fetch_exact_configured_contract; replay_uses_persisted_"
+            "user_scoped_non_live_closed_candles_only"
+        ),
         "live_order_routing": "disabled_by_architecture",
         "timezone": str(getattr(TRADING_TZ, "key", "America/New_York")),
         "commission_per_contract": _clean(settings.commission_per_contract),

--- a/backend/app/services/bot_candle_acquisition.py
+++ b/backend/app/services/bot_candle_acquisition.py
@@ -46,6 +46,44 @@ def _service() -> Any:
     return import_module(".bot_service", package=__package__)
 
 
+def _canonical_candles(service: Any, candles: list[Any]) -> list[Any]:
+    """Defense-in-depth before any strategy consumes an acquired stream."""
+
+    # Registry adapter tests intentionally use opaque sentinels to assert
+    # argument identity. Real acquisition rows are always candle models.
+    if candles and all(not hasattr(row, "candle_timestamp") for row in candles):
+        return candles
+    closed = [row for row in candles if not bool(getattr(row, "is_partial", False))]
+    closed.sort(key=lambda row: service._as_utc(row.candle_timestamp))
+    seen: set[Any] = set()
+    previous_close = None
+    for row in closed:
+        timestamp = service._as_utc(row.candle_timestamp)
+        if timestamp in seen:
+            raise service.CandleIntegrityError(
+                f"duplicate_candle_timestamp:{timestamp.isoformat()}"
+            )
+        seen.add(timestamp)
+        if service.validate_candle_ohlcv(row) is not None:
+            raise service.CandleIntegrityError(
+                f"invalid_candle_ohlc:{timestamp.isoformat()}"
+            )
+        if previous_close is not None and timestamp < previous_close:
+            raise service.CandleIntegrityError(
+                f"overlapping_candles:{timestamp.isoformat()}"
+            )
+        previous_close = service.integrity_candle_close_time(
+            timestamp,
+            unit=str(row.unit),
+            unit_number=int(row.unit_number),
+        )
+    return closed
+
+
+def _canonical_candle_sets(service: Any, candle_sets: dict[str, list[Any]]) -> dict[str, list[Any]]:
+    return {key: _canonical_candles(service, rows) for key, rows in candle_sets.items()}
+
+
 def acquire_and_evaluate_strategy(
     db: Any,
     *,
@@ -74,6 +112,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         candles = candle_sets.get("1m", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -91,6 +130,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -110,6 +150,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -126,6 +167,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candles = _canonical_candles(service, candles)
         return candles, service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -141,6 +183,7 @@ def acquire_and_evaluate_strategy(
             strategy_type=strategy_type,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         signal_candles = candle_sets.get("1H", [])
         evaluator_args: dict[str, Any] = {
             "higher_timeframe_candles": candle_sets.get("4H", []),
@@ -163,6 +206,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         signal_candles = candle_sets.get("signal", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -180,6 +224,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         structure_candles = candle_sets.get("structure", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -190,7 +235,10 @@ def acquire_and_evaluate_strategy(
         return structure_candles, signal
 
     if strategy_type == "atr_adjusted_relative_strength":
-        candles = service.fetch_and_store_candles(db, user_id=user_id, config=config, client=client)
+        candles = _canonical_candles(
+            service,
+            service.fetch_and_store_candles(db, user_id=user_id, config=config, client=client),
+        )
         benchmark_candles = service.fetch_and_store_relative_strength_benchmark_candles(
             db,
             user_id=user_id,
@@ -198,6 +246,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        benchmark_candles = _canonical_candles(service, benchmark_candles)
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             candles,
@@ -215,6 +264,7 @@ def acquire_and_evaluate_strategy(
             client=client,
             strategy_params=strategy_params,
         )
+        candle_sets = _canonical_candle_sets(service, candle_sets)
         asset_candles = candle_sets.get("5m", [])
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
@@ -238,6 +288,7 @@ def acquire_and_evaluate_strategy(
         client=client,
         minimum_lookback_bars=minimum_lookback_bars,
     )
+    candles = _canonical_candles(service, candles)
 
     if strategy_type == "donchian_breakout":
         latest_candle = candles[-1] if candles else None
@@ -289,6 +340,7 @@ def _acquire_and_evaluate_topbot(
         client=client,
         minimum_lookback_bars=300,
     )
+    main_candles = _canonical_candles(service, main_candles)
     source_overrides = strategy_params.get("source_strategy_params") or {}
     source_results: list[dict[str, Any]] = []
 

--- a/backend/app/services/bot_candle_acquisition.py
+++ b/backend/app/services/bot_candle_acquisition.py
@@ -219,7 +219,7 @@ def acquire_and_evaluate_strategy(
         signal = service.dispatch_strategy_evaluator(
             strategy_type,
             asset_candles=asset_candles,
-            benchmark_candles=candle_sets.get("SPY", []),
+            benchmark_candles=candle_sets.get("benchmark", []),
             strategy_params=strategy_params,
         )
         return asset_candles, signal

--- a/backend/app/services/bot_market_analysis.py
+++ b/backend/app/services/bot_market_analysis.py
@@ -5,6 +5,8 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Iterable, Sequence
 from zoneinfo import ZoneInfo
 
+from .trading_day import futures_session_is_open
+
 
 ANALYSIS_VERSION = "market_analysis_v2"
 PROBABILITY_METHOD = "heuristic_scenario_weight"
@@ -523,7 +525,7 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
         missing = sum(
             1
             for index in range(1, raw_missing + 1)
-            if _is_futures_session_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
+            if futures_session_is_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
         )
         if missing <= 0:
             continue
@@ -535,21 +537,6 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
             }
         )
     return gaps[:20]
-
-
-def _is_futures_session_open(timestamp: datetime) -> bool:
-    local = timestamp.astimezone(_NEW_YORK)
-    weekday = local.weekday()
-    local_time = local.time()
-    if weekday == 5:
-        return False
-    if weekday == 6 and local_time < time(18, 0):
-        return False
-    if weekday == 4 and local_time >= time(17, 0):
-        return False
-    if time(17, 0) <= local_time < time(18, 0):
-        return False
-    return True
 
 
 def _true_ranges(rows: list[dict[str, Any]]) -> list[float]:

--- a/backend/app/services/bot_market_analysis.py
+++ b/backend/app/services/bot_market_analysis.py
@@ -5,6 +5,8 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, Iterable, Sequence
 from zoneinfo import ZoneInfo
 
+from .trading_day import is_expected_futures_candle
+
 
 ANALYSIS_VERSION = "market_analysis_v2"
 PROBABILITY_METHOD = "heuristic_scenario_weight"
@@ -523,7 +525,10 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
         missing = sum(
             1
             for index in range(1, raw_missing + 1)
-            if _is_futures_session_open(previous["timestamp"] + timedelta(seconds=interval_seconds * index))
+            if is_expected_futures_candle(
+                previous["timestamp"] + timedelta(seconds=interval_seconds * index),
+                previous["timestamp"] + timedelta(seconds=interval_seconds * (index + 1)),
+            )
         )
         if missing <= 0:
             continue
@@ -535,22 +540,6 @@ def _detect_gaps(rows: list[dict[str, Any]], interval_seconds: int) -> list[dict
             }
         )
     return gaps[:20]
-
-
-def _is_futures_session_open(timestamp: datetime) -> bool:
-    local = timestamp.astimezone(_NEW_YORK)
-    weekday = local.weekday()
-    local_time = local.time()
-    if weekday == 5:
-        return False
-    if weekday == 6 and local_time < time(18, 0):
-        return False
-    if weekday == 4 and local_time >= time(17, 0):
-        return False
-    if time(17, 0) <= local_time < time(18, 0):
-        return False
-    return True
-
 
 def _true_ranges(rows: list[dict[str, Any]]) -> list[float]:
     output: list[float] = []

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable
 
 from sqlalchemy import func, or_
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -49,7 +50,12 @@ from .bot_strategy_registry import (
 from .bot_risk import RiskBlock, RiskEvaluationContext, evaluate_risk
 from . import bot_serialization as _bot_serialization
 from .trade_plan_evaluator import TradePlan, TradePlanEvaluator, build_market_context_from_ohlcv
-from .trading_day import TRADING_TZ, trading_day_bounds_utc, trading_day_date
+from .trading_day import (
+    TRADING_TZ,
+    futures_session_is_open,
+    trading_day_bounds_utc,
+    trading_day_date,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -1938,7 +1944,13 @@ def market_candle_cache_needs_refresh(
     interval = _market_candle_interval(unit=unit, unit_number=unit_number)
     latest_timestamp = max(_as_utc(row.candle_timestamp) for row in cached_candles)
     end_utc = _as_utc(end)
-    if latest_timestamp + interval <= end_utc:
+    if latest_timestamp + interval <= end_utc and _market_candle_range_contains_open_slot(
+        latest_timestamp + interval,
+        end_utc,
+        interval=interval,
+        include_end=True,
+        closure_aware=_market_candle_unit_is_closure_aware(unit),
+    ):
         return _market_candle_tail_revalidation_due(cached_candles)
     return False
 
@@ -1957,9 +1969,14 @@ def market_candle_rows_are_stale(
     interval = _market_candle_interval(unit=unit, unit_number=unit_number)
     latest_timestamp = max(_as_utc(row.candle_timestamp) for row in candles)
     end_utc = _as_utc(end)
-    if include_partial_bar:
-        return latest_timestamp + interval <= end_utc
-    return latest_timestamp + interval + interval <= end_utc
+    latest_expected_start = end_utc if include_partial_bar else end_utc - interval
+    return _market_candle_range_contains_open_slot(
+        latest_timestamp + interval,
+        latest_expected_start,
+        interval=interval,
+        include_end=True,
+        closure_aware=_market_candle_unit_is_closure_aware(unit),
+    )
 
 
 def market_candle_cache_covers_request(
@@ -1973,13 +1990,81 @@ def market_candle_cache_covers_request(
     if not cached_candles:
         return False
 
+    interval = _market_candle_interval(unit=unit, unit_number=unit_number)
+    if _market_candle_rows_have_open_session_gap(
+        cached_candles,
+        interval=interval,
+        closure_aware=_market_candle_unit_is_closure_aware(unit),
+    ):
+        return False
+
     normalized_limit = max(1, int(limit))
     if len(cached_candles) >= normalized_limit:
         return True
 
-    interval = _market_candle_interval(unit=unit, unit_number=unit_number)
     earliest_timestamp = min(_as_utc(row.candle_timestamp) for row in cached_candles)
-    return earliest_timestamp <= _as_utc(start) + interval
+    first_expected_timestamp = _as_utc(start) + interval
+    if earliest_timestamp <= first_expected_timestamp:
+        return True
+    return not _market_candle_range_contains_open_slot(
+        first_expected_timestamp,
+        earliest_timestamp,
+        interval=interval,
+        include_end=False,
+        closure_aware=_market_candle_unit_is_closure_aware(unit),
+    )
+
+
+def _market_candle_rows_have_open_session_gap(
+    cached_candles: list[ProjectXMarketCandle],
+    *,
+    interval: timedelta,
+    closure_aware: bool,
+) -> bool:
+    timestamps = sorted({_as_utc(row.candle_timestamp) for row in cached_candles})
+    for previous, current in zip(timestamps, timestamps[1:]):
+        if _market_candle_range_contains_open_slot(
+            previous + interval,
+            current,
+            interval=interval,
+            include_end=False,
+            closure_aware=closure_aware,
+        ):
+            return True
+    return False
+
+
+def _market_candle_range_contains_open_slot(
+    start: datetime,
+    end: datetime,
+    *,
+    interval: timedelta,
+    include_end: bool,
+    closure_aware: bool,
+) -> bool:
+    cursor = _as_utc(start)
+    end_utc = _as_utc(end)
+    if cursor > end_utc or (cursor == end_utc and not include_end):
+        return False
+    if not closure_aware:
+        return True
+
+    # Futures closures are minute-aligned. Scanning at minute granularity keeps
+    # second-bar cache checks bounded across a weekend while preserving whether
+    # any tradable slot exists inside the missing range.
+    step = max(interval, timedelta(minutes=1))
+    while cursor < end_utc or (include_end and cursor == end_utc):
+        if futures_session_is_open(cursor):
+            return True
+        cursor += step
+    return False
+
+
+def _market_candle_unit_is_closure_aware(unit: str) -> bool:
+    # Daily bars are UTC-date stamped, but their missing weekend buckets still
+    # land inside the regular Globex close. Weekly/monthly buckets are calendar
+    # aggregates and are not meaningful inputs to the slot-by-slot session scan.
+    return str(unit).strip().lower() in {"second", "minute", "hour", "day"}
 
 
 def next_market_candle_fetch_start(
@@ -2115,23 +2200,25 @@ def store_market_candles(
     timestamps = [bar["timestamp"] for bar in normalized]
     fetched_at = datetime.now(timezone.utc)
 
-    if _session_dialect_name(db) == "postgresql":
-        _upsert_market_candle_rows(
-            db,
-            values=[
-                _market_candle_insert_values(
-                    user_id=user_id,
-                    contract_id=contract_id,
-                    symbol=symbol,
-                    live=live,
-                    unit=unit,
-                    unit_number=unit_number,
-                    bar=bar,
-                    fetched_at=fetched_at,
-                )
-                for bar in normalized
-            ],
-        )
+    dialect_name = _session_dialect_name(db)
+    if dialect_name in {"postgresql", "sqlite"}:
+        values = [
+            _market_candle_insert_values(
+                user_id=user_id,
+                contract_id=contract_id,
+                symbol=symbol,
+                live=live,
+                unit=unit,
+                unit_number=unit_number,
+                bar=bar,
+                fetched_at=fetched_at,
+            )
+            for bar in normalized
+        ]
+        if dialect_name == "postgresql":
+            _upsert_market_candle_rows(db, values=values)
+        else:
+            _upsert_sqlite_market_candle_rows(db, values=values)
         return _query_market_candles_by_timestamps(
             db,
             user_id=user_id,
@@ -2158,6 +2245,10 @@ def store_market_candles(
     for bar in normalized:
         timestamp = bar["timestamp"]
         row = existing_by_timestamp.get(timestamp)
+        incoming_is_partial = bool(bar.get("is_partial") or False)
+        if row is not None and not bool(row.is_partial) and incoming_is_partial:
+            output.append(row)
+            continue
         if row is None:
             row = ProjectXMarketCandle(
                 user_id=user_id,
@@ -2174,7 +2265,7 @@ def store_market_candles(
         row.low_price = float(bar.get("low") or 0.0)
         row.close_price = float(bar.get("close") or 0.0)
         row.volume = float(bar.get("volume") or 0.0)
-        row.is_partial = bool(bar.get("is_partial") or False)
+        row.is_partial = incoming_is_partial
         row.raw_payload = bar.get("raw_payload")
         row.fetched_at = fetched_at
         output.append(row)
@@ -2193,7 +2284,15 @@ def _dedupe_market_candle_bars(bars: Iterable[dict[str, Any]]) -> list[dict[str,
         if not isinstance(timestamp, datetime):
             continue
         timestamp_utc = _as_utc(timestamp)
-        by_timestamp[timestamp_utc] = {**bar, "timestamp": timestamp_utc}
+        candidate = {**bar, "timestamp": timestamp_utc}
+        existing = by_timestamp.get(timestamp_utc)
+        if (
+            existing is not None
+            and not bool(existing.get("is_partial") or False)
+            and bool(candidate.get("is_partial") or False)
+        ):
+            continue
+        by_timestamp[timestamp_utc] = candidate
     return [by_timestamp[timestamp] for timestamp in sorted(by_timestamp)]
 
 
@@ -2262,6 +2361,42 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
                     "raw_payload": excluded.raw_payload,
                     "fetched_at": excluded.fetched_at,
                 },
+                where=table.c.is_partial.is_(True) | excluded.is_partial.is_(False),
+            )
+        )
+
+
+def _upsert_sqlite_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> None:
+    if not values:
+        return
+
+    table = ProjectXMarketCandle.__table__
+    for offset in range(0, len(values), _MARKET_CANDLE_UPSERT_BATCH_SIZE):
+        batch = values[offset : offset + _MARKET_CANDLE_UPSERT_BATCH_SIZE]
+        insert_stmt = sqlite_insert(table).values(batch)
+        excluded = insert_stmt.excluded
+        db.execute(
+            insert_stmt.on_conflict_do_update(
+                index_elements=[
+                    table.c.user_id,
+                    table.c.contract_id,
+                    table.c.live,
+                    table.c.unit,
+                    table.c.unit_number,
+                    table.c.candle_timestamp,
+                ],
+                set_={
+                    "symbol": excluded.symbol,
+                    "open_price": excluded.open_price,
+                    "high_price": excluded.high_price,
+                    "low_price": excluded.low_price,
+                    "close_price": excluded.close_price,
+                    "volume": excluded.volume,
+                    "is_partial": excluded.is_partial,
+                    "raw_payload": excluded.raw_payload,
+                    "fetched_at": excluded.fetched_at,
+                },
+                where=table.c.is_partial.is_(True) | excluded.is_partial.is_(False),
             )
         )
 

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -72,6 +72,7 @@ _UNIT_SECONDS_BY_NAME = {
 }
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
+_MARKET_CANDLE_UPSERT_BATCH_SIZE = 1_000
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -301,7 +302,7 @@ _FVG_SWEEP_MSS_DEFAULTS = {
     "target_mode": _FVG_TARGET_MODE_NEXT_LIQUIDITY,
 }
 _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "move_lookback_bars": 3,
     "atr_period": 14,
     "relative_volume_period": 20,
@@ -314,7 +315,7 @@ _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
     "take_profit_r_multiple": 2.0,
 }
 _RELATIVE_STRENGTH_SPY_DEFAULTS = {
-    "benchmark_symbol": "SPY",
+    "benchmark_symbol": "MES",
     "comparison_bars": 12,
     "pullback_lookback_bars": 3,
     "relative_volume_period": 20,
@@ -1476,7 +1477,7 @@ def fetch_and_store_relative_strength_spy_candles(
             prefer_current_contract=True,
             preserve_cached_history=True,
         ),
-        "SPY": fetch_and_store_market_candles(
+        "benchmark": fetch_and_store_market_candles(
             db,
             user_id=user_id,
             client=client,
@@ -1731,6 +1732,7 @@ def fetch_and_store_market_candles(
     include_partial_bar: bool = False,
     prefer_current_contract: bool = False,
     preserve_cached_history: bool = False,
+    authoritative_refresh: bool = False,
 ) -> list[ProjectXMarketCandle]:
     normalized_unit = str(unit).strip().lower()
     if normalized_unit not in _PROJECTX_UNIT_BY_NAME:
@@ -1785,6 +1787,31 @@ def fetch_and_store_market_candles(
         unit_number=unit_number,
         bars=bars,
     )
+    if authoritative_refresh and stored:
+        provider_timestamps = [_as_utc(row.candle_timestamp) for row in stored]
+        provider_timestamp_set = set(provider_timestamps)
+        provider_start = min(provider_timestamps)
+        provider_end = max(provider_timestamps)
+        prune_market_candle_cache_range(
+            db,
+            user_id=user_id,
+            contract_id=resolved_contract_id,
+            live=live,
+            start=provider_start,
+            end=provider_end,
+            unit=normalized_unit,
+            unit_number=unit_number,
+            keep_timestamps=provider_timestamps,
+        )
+        cached = [
+            row
+            for row in cached
+            if (
+                _as_utc(row.candle_timestamp) < provider_start
+                or _as_utc(row.candle_timestamp) > provider_end
+                or _as_utc(row.candle_timestamp) in provider_timestamp_set
+            )
+        ]
     if not preserve_cached_history:
         return stored
 
@@ -2210,31 +2237,33 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
         return
 
     table = ProjectXMarketCandle.__table__
-    insert_stmt = postgresql_insert(table).values(values)
-    excluded = insert_stmt.excluded
-    db.execute(
-        insert_stmt.on_conflict_do_update(
-            index_elements=[
-                table.c.user_id,
-                table.c.contract_id,
-                table.c.live,
-                table.c.unit,
-                table.c.unit_number,
-                table.c.candle_timestamp,
-            ],
-            set_={
-                "symbol": excluded.symbol,
-                "open_price": excluded.open_price,
-                "high_price": excluded.high_price,
-                "low_price": excluded.low_price,
-                "close_price": excluded.close_price,
-                "volume": excluded.volume,
-                "is_partial": excluded.is_partial,
-                "raw_payload": excluded.raw_payload,
-                "fetched_at": excluded.fetched_at,
-            },
+    for offset in range(0, len(values), _MARKET_CANDLE_UPSERT_BATCH_SIZE):
+        batch = values[offset : offset + _MARKET_CANDLE_UPSERT_BATCH_SIZE]
+        insert_stmt = postgresql_insert(table).values(batch)
+        excluded = insert_stmt.excluded
+        db.execute(
+            insert_stmt.on_conflict_do_update(
+                index_elements=[
+                    table.c.user_id,
+                    table.c.contract_id,
+                    table.c.live,
+                    table.c.unit,
+                    table.c.unit_number,
+                    table.c.candle_timestamp,
+                ],
+                set_={
+                    "symbol": excluded.symbol,
+                    "open_price": excluded.open_price,
+                    "high_price": excluded.high_price,
+                    "low_price": excluded.low_price,
+                    "close_price": excluded.close_price,
+                    "volume": excluded.volume,
+                    "is_partial": excluded.is_partial,
+                    "raw_payload": excluded.raw_payload,
+                    "fetched_at": excluded.fetched_at,
+                },
+            )
         )
-    )
 
 
 def _query_market_candles_by_timestamps(
@@ -2628,6 +2657,7 @@ def evaluate_relative_strength_vs_spy(
     strategy_params: dict[str, Any] | None = None,
 ) -> SignalResult:
     params = _normalize_strategy_params(_STRATEGY_RELATIVE_STRENGTH_SPY, strategy_params)
+    benchmark_name = str(params["benchmark_symbol"])
     comparison_bars = int(params["comparison_bars"])
     pullback_lookback_bars = int(params["pullback_lookback_bars"])
     relative_volume_period = int(params["relative_volume_period"])
@@ -2661,7 +2691,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="HOLD",
             reason=(
-                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and SPY; "
+                f"Need at least {minimum_required} aligned closed 5-minute candles for the symbol and {benchmark_name}; "
                 f"found {len(aligned_asset)}."
             ),
             candle_timestamp=latest_timestamp,
@@ -2750,7 +2780,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol outperformed SPY over {comparison_bars} candles, but SPY is not in a meaningful pullback "
+                    f"Symbol outperformed {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful pullback "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2760,7 +2791,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent <= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol outperformed SPY overall, but it did not hold up better during the latest SPY pullback.",
+                reason=(
+                    f"Symbol outperformed {benchmark_name} overall, but it did not hold up better "
+                    f"during the latest {benchmark_name} pullback."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2807,7 +2841,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="BUY",
             reason=(
-                f"BUY on relative strength vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"BUY on relative strength vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {long_entry[0]} "
                 f"{_format_strategy_price(long_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -2823,7 +2857,8 @@ def evaluate_relative_strength_vs_spy(
             return SignalResult(
                 action="HOLD",
                 reason=(
-                    f"Symbol lagged SPY over {comparison_bars} candles, but SPY is not in a meaningful bounce "
+                    f"Symbol lagged {benchmark_name} over {comparison_bars} candles, but "
+                    f"{benchmark_name} is not in a meaningful bounce "
                     f"({_format_percent(benchmark_recent_move_percent)}% over the last {pullback_lookback_bars} candles)."
                 ),
                 candle_timestamp=latest_timestamp,
@@ -2833,7 +2868,10 @@ def evaluate_relative_strength_vs_spy(
         if asset_recent_move_percent >= benchmark_recent_move_percent:
             return SignalResult(
                 action="HOLD",
-                reason="Symbol lagged SPY overall, but it bounced too much during the latest SPY rebound.",
+                reason=(
+                    f"Symbol lagged {benchmark_name} overall, but it bounced too much during the "
+                    f"latest {benchmark_name} rebound."
+                ),
                 candle_timestamp=latest_timestamp,
                 price=price,
                 raw_payload=raw_payload,
@@ -2880,7 +2918,7 @@ def evaluate_relative_strength_vs_spy(
         return SignalResult(
             action="SELL",
             reason=(
-                f"SELL on relative weakness vs SPY: {_format_percent(asset_move_percent)}% vs "
+                f"SELL on relative weakness vs {benchmark_name}: {_format_percent(asset_move_percent)}% vs "
                 f"{_format_percent(benchmark_move_percent)}% over {comparison_bars} candles, "
                 f"RVOL {_format_percent(relative_volume)}x, entry at {short_entry[0]} "
                 f"{_format_strategy_price(short_entry[1])}. SL {_format_strategy_price(stop_loss)}, "
@@ -9633,6 +9671,8 @@ def _validate_strategy_configuration(
     slow_period: int,
 ) -> None:
     _validate_strategy_periods(fast_period, slow_period)
+    if strategy_type == _STRATEGY_TOPBOT_ADAPTIVE and str(timeframe_unit) == "month":
+        raise ValueError("TopBot Adaptive does not support month candles.")
     if strategy_type != _STRATEGY_EMA_SCALPING:
         return
     if str(timeframe_unit) != "minute" or int(timeframe_unit_number) not in _EMA_SCALPING_ALLOWED_MINUTE_BUCKETS:
@@ -9852,8 +9892,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_ATR_ADJUSTED_RELATIVE_STRENGTH:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         return {
@@ -9932,8 +9973,9 @@ def _normalize_strategy_params(strategy_type: Any, params: Any) -> dict[str, Any
         }
 
     if normalized_strategy_type == _STRATEGY_RELATIVE_STRENGTH_SPY:
-        benchmark_symbol = _normalized_optional_text(raw_params.get("benchmark_symbol")) or str(
-            _RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]
+        benchmark_symbol = _normalize_projectx_benchmark_symbol(
+            raw_params.get("benchmark_symbol"),
+            default=str(_RELATIVE_STRENGTH_SPY_DEFAULTS["benchmark_symbol"]),
         )
         benchmark_contract_id = _normalized_optional_text(raw_params.get("benchmark_contract_id"))
         swing_window = _bounded_int_param(
@@ -10902,6 +10944,15 @@ def _validate_unique_bot_name(
 
 def _looks_like_projectx_contract_id(value: str) -> bool:
     return value.upper().startswith("CON.")
+
+
+def _normalize_projectx_benchmark_symbol(value: Any, *, default: str) -> str:
+    """Map the legacy SPY benchmark to the MES futures feed ProjectX supports."""
+
+    normalized = _normalized_optional_text(value) or str(default)
+    if normalized.strip().upper() in {"SPY", "F.US.SPY"}:
+        return "MES"
+    return normalized.strip().upper()
 
 
 def _pick_market_contract(rows: Iterable[dict[str, Any]]) -> dict[str, Any] | None:

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, time, timedelta, timezone
 from numbers import Number
 from typing import Any, Iterable
 
-from sqlalchemy import func, or_
+from sqlalchemy import case, func, or_
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -41,6 +41,19 @@ from .bot_execution_safety import (
 )
 from .projectx_accounts import get_projectx_account_row
 from .projectx_client import ProjectXClient, ProjectXClientError
+from .candle_integrity import (
+    CandleIntegrityReport,
+    CandleRepairRange,
+    audit_candle_rows,
+    candle_close_time as integrity_candle_close_time,
+    candle_interval,
+    clear_failed_repair,
+    normalize_provider_bars,
+    note_failed_repair,
+    repair_request_in_cooldown,
+    retrieve_bars_singleflight,
+    validate_candle_ohlcv,
+)
 from .bot_strategy_registry import (
     SUPPORTED_STRATEGY_IDENTIFIERS,
     dispatch_strategy_evaluator,
@@ -72,6 +85,8 @@ _UNIT_SECONDS_BY_NAME = {
 }
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
+_MARKET_CANDLE_PROVIDER_LIMIT = 20_000
+_MARKET_CANDLE_INTEGRITY_QUERY_PADDING = 64
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -505,6 +520,10 @@ class BotRunEvaluationError(RuntimeError):
         self.cause = cause
         self.run = run
         self.correlation_id = correlation_id
+
+
+class CandleIntegrityError(RuntimeError):
+    """A strict consumer could not obtain a complete authoritative candle stream."""
 
 
 def list_bot_configs(
@@ -1326,25 +1345,20 @@ def fetch_and_store_fvg_sweep_mss_candles(
         unit_seconds = _UNIT_SECONDS_BY_NAME[unit]
         lookback_seconds = unit_seconds * unit_number * limit * 3
         start = now - timedelta(seconds=max(lookback_seconds, unit_seconds * unit_number * 25))
-        bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME[unit],
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=False,
-        )
-        candle_sets[key] = store_market_candles(
+        candle_sets[key] = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=start,
+            end=now,
             unit=unit,
             unit_number=unit_number,
-            bars=bars,
+            limit=limit,
+            include_partial_bar=False,
+            preserve_cached_history=True,
         )
 
     return candle_sets
@@ -1519,25 +1533,20 @@ def fetch_and_store_support_resistance_candles(
         unit_seconds = _UNIT_SECONDS_BY_NAME[unit]
         lookback_seconds = unit_seconds * unit_number * bars_per_timeframe * 3
         start = now - timedelta(seconds=lookback_seconds)
-        bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME[unit],
-            unit_number=unit_number,
-            limit=bars_per_timeframe,
-            include_partial_bar=False,
-        )
-        candle_sets[label] = store_market_candles(
+        candle_sets[label] = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=start,
+            end=now,
             unit=unit,
             unit_number=unit_number,
-            bars=bars,
+            limit=bars_per_timeframe,
+            include_partial_bar=False,
+            preserve_cached_history=True,
         )
 
     return candle_sets
@@ -1567,51 +1576,43 @@ def fetch_and_store_supertrend_pivot_candles(
     signal_unit_seconds = _UNIT_SECONDS_BY_NAME[signal_unit]
     signal_lookback_seconds = signal_unit_seconds * signal_unit_number * lookback_bars * 3
     signal_start = now - timedelta(seconds=signal_lookback_seconds)
-    signal_bars = client.retrieve_bars(
+    signal_candles = fetch_and_store_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
         contract_id=contract_id,
+        symbol=symbol,
         live=False,
         start=signal_start,
         end=now,
-        unit=_PROJECTX_UNIT_BY_NAME[signal_unit],
+        unit=signal_unit,
         unit_number=signal_unit_number,
         limit=lookback_bars,
         include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
     daily_lookback_seconds = _UNIT_SECONDS_BY_NAME["day"] * daily_bars * 3
     daily_start = now - timedelta(seconds=daily_lookback_seconds)
-    daily_bars_payload = client.retrieve_bars(
+    daily_candles = fetch_and_store_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
         contract_id=contract_id,
+        symbol=symbol,
         live=False,
         start=daily_start,
         end=now,
-        unit=_PROJECTX_UNIT_BY_NAME["day"],
+        unit="day",
         unit_number=1,
         limit=daily_bars,
         include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
     return {
-        "signal": store_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=contract_id,
-            symbol=symbol,
-            live=False,
-            unit=signal_unit,
-            unit_number=signal_unit_number,
-            bars=signal_bars,
-        ),
-        "1D": store_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=contract_id,
-            symbol=symbol,
-            live=False,
-            unit="day",
-            unit_number=1,
-            bars=daily_bars_payload,
-        ),
+        "signal": signal_candles,
+        "1D": daily_candles,
     }
 
 
@@ -1634,32 +1635,28 @@ def fetch_and_store_delayed_orb_candles(
         symbol=config.symbol,
         live=False,
     )
-    intraday_bars: list[dict[str, Any]] = []
+    intraday_candles: list[ProjectXMarketCandle] = []
     if session_start <= now:
         minimum_required_bars = opening_range_minutes + confirmation_minutes + 5
         minutes_since_session_start = max(0, int((now - session_start).total_seconds() // 60) + 1)
         limit = max(minimum_required_bars, minutes_since_session_start + 5)
-        intraday_bars = client.retrieve_bars(
-            contract_id=contract_id,
-            live=False,
-            start=session_start,
-            end=now,
-            unit=_PROJECTX_UNIT_BY_NAME["minute"],
-            unit_number=1,
-            limit=limit,
-            include_partial_bar=False,
-        )
-    return {
-        "1m": store_market_candles(
+        intraday_candles = fetch_and_store_market_candles(
             db,
             user_id=user_id,
+            client=client,
             contract_id=contract_id,
             symbol=symbol,
             live=False,
+            start=session_start,
+            end=now,
             unit="minute",
             unit_number=1,
-            bars=intraday_bars,
-        ),
+            limit=limit,
+            include_partial_bar=False,
+            preserve_cached_history=True,
+        )
+    return {
+        "1m": intraday_candles,
         "1D": [],
     }
 
@@ -1693,25 +1690,20 @@ def fetch_and_store_orb_fibonacci_candles(
         symbol=config.symbol,
         live=False,
     )
-    bars = client.retrieve_bars(
-        contract_id=contract_id,
-        live=False,
-        start=session_start,
-        end=now,
-        unit=_PROJECTX_UNIT_BY_NAME["minute"],
-        unit_number=unit_number,
-        limit=limit,
-        include_partial_bar=False,
-    )
-    return store_market_candles(
+    return fetch_and_store_market_candles(
         db,
         user_id=user_id,
+        client=client,
         contract_id=contract_id,
         symbol=symbol,
         live=False,
+        start=session_start,
+        end=now,
         unit="minute",
         unit_number=unit_number,
-        bars=bars,
+        limit=limit,
+        include_partial_bar=False,
+        preserve_cached_history=True,
     )
 
 
@@ -1731,12 +1723,65 @@ def fetch_and_store_market_candles(
     include_partial_bar: bool = False,
     prefer_current_contract: bool = False,
     preserve_cached_history: bool = False,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
+    strict_integrity: bool = False,
 ) -> list[ProjectXMarketCandle]:
+    return ensure_market_candles(
+        db,
+        user_id=user_id,
+        client=client,
+        contract_id=contract_id,
+        symbol=symbol,
+        live=live,
+        start=start,
+        end=end,
+        unit=unit,
+        unit_number=unit_number,
+        limit=limit,
+        include_partial_bar=include_partial_bar,
+        prefer_current_contract=prefer_current_contract,
+        force_refresh=force_refresh,
+        force_full_repair=force_full_repair,
+        strict_integrity=strict_integrity,
+    )
+
+
+def ensure_market_candles(
+    db: Session,
+    *,
+    user_id: str,
+    client: ProjectXClient,
+    contract_id: str,
+    symbol: str | None,
+    live: bool,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool = False,
+    prefer_current_contract: bool = False,
+    force_refresh: bool = False,
+    force_full_repair: bool = False,
+    strict_integrity: bool = False,
+) -> list[ProjectXMarketCandle]:
+    """Return canonical cached candles after one bounded authoritative repair pass.
+
+    Provider bars are the only source of replacements. Missing slots are never
+    synthesized, and a usable vetted cache remains available when ProjectX is
+    temporarily unavailable.
+    """
+
     normalized_unit = str(unit).strip().lower()
     if normalized_unit not in _PROJECTX_UNIT_BY_NAME:
         raise ValueError("unsupported candle unit")
-    if start > end:
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if start_utc > end_utc:
         raise ValueError("start must be before end")
+    normalized_unit_number = max(1, int(unit_number))
+    normalized_limit = max(1, min(int(limit), _MARKET_CANDLE_PROVIDER_LIMIT))
     resolver = resolve_current_market_contract if prefer_current_contract else resolve_market_contract
     resolved_contract_id, resolved_symbol = resolver(
         client,
@@ -1744,69 +1789,385 @@ def fetch_and_store_market_candles(
         symbol=symbol,
         live=live,
     )
-    cached = (
-        list_market_candles(
-            db,
-            user_id=user_id,
-            contract_id=resolved_contract_id,
-            live=live,
-            start=start,
-            end=end,
-            unit=normalized_unit,
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=include_partial_bar,
-        )
-        if preserve_cached_history
-        else []
-    )
-    try:
-        bars = client.retrieve_bars(
-            contract_id=resolved_contract_id,
-            live=live,
-            start=start,
-            end=end,
-            unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=include_partial_bar,
-        )
-    except ProjectXClientError:
-        if cached:
-            return cached
-        raise
-    stored = store_market_candles(
-        db,
-        user_id=user_id,
-        contract_id=resolved_contract_id,
-        symbol=resolved_symbol,
-        live=live,
-        unit=normalized_unit,
-        unit_number=unit_number,
-        bars=bars,
-    )
-    if not preserve_cached_history:
-        return stored
 
-    combined = list_market_candles(
+    cached = _list_market_candles_for_integrity(
         db,
         user_id=user_id,
         contract_id=resolved_contract_id,
         live=live,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+    )
+    report = audit_candle_rows(
+        cached,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+        include_partial_bar=include_partial_bar,
+        symbol=resolved_symbol or symbol,
+    )
+
+    if force_refresh or force_full_repair or not cached:
+        repair_ranges = [
+            CandleRepairRange(
+                start=start_utc,
+                end=end_utc,
+                reasons=("refresh" if force_refresh else "full_repair",),
+            )
+        ]
+    else:
+        repair_ranges = list(report.repair_ranges)
+        interval = candle_interval(unit=normalized_unit, unit_number=normalized_unit_number)
+        near_live_tail = interval is not None and end_utc >= datetime.now(timezone.utc) - interval * 2
+        if (
+            not repair_ranges
+            and near_live_tail
+            and report.valid_rows
+            and _market_candle_tail_revalidation_due(list(report.valid_rows))
+        ):
+            fetch_start = next_market_candle_fetch_start(
+                list(report.valid_rows),
+                start=start_utc,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+            )
+            repair_ranges = [
+                CandleRepairRange(
+                    start=fetch_start,
+                    end=end_utc,
+                    reasons=("tail_revalidation",),
+                )
+            ]
+
+    repair_ranges = _pad_and_coalesce_market_repair_ranges(
+        repair_ranges,
+        start=start_utc,
+        end=end_utc,
+        interval=candle_interval(unit=normalized_unit, unit_number=normalized_unit_number),
+    )
+
+    last_provider_error: ProjectXClientError | None = None
+    for repair_range in repair_ranges:
+        request_limit = _market_candle_repair_limit(
+            repair_range,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            requested_limit=normalized_limit,
+            full_window=repair_range.start == start_utc and repair_range.end == end_utc,
+        )
+        request_key = _market_candle_request_key(
+            user_id=user_id,
+            client=client,
+            contract_id=resolved_contract_id,
+            live=live,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            start=repair_range.start,
+            end=repair_range.end,
+            limit=request_limit,
+            include_partial_bar=include_partial_bar,
+        )
+        if repair_request_in_cooldown(request_key):
+            continue
+
+        try:
+            raw_bars = retrieve_bars_singleflight(
+                key=request_key,
+                retrieve=lambda repair_range=repair_range, request_limit=request_limit: client.retrieve_bars(
+                    contract_id=resolved_contract_id,
+                    live=live,
+                    start=repair_range.start,
+                    end=repair_range.end,
+                    unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
+                    unit_number=normalized_unit_number,
+                    limit=request_limit,
+                    include_partial_bar=include_partial_bar,
+                ),
+            )
+        except ProjectXClientError as exc:
+            last_provider_error = exc
+            note_failed_repair(request_key)
+            continue
+
+        normalized_bars = normalize_provider_bars(
+            raw_bars,
+            unit=normalized_unit,
+            unit_number=normalized_unit_number,
+            request_start=repair_range.start,
+            request_end=repair_range.end,
+            include_partial_bar=include_partial_bar,
+        )
+        if raw_bars and not normalized_bars:
+            note_failed_repair(request_key)
+            continue
+
+        authoritative_timestamps = {
+            _as_utc(bar["timestamp"])
+            for bar in normalized_bars
+        }
+        _delete_repaired_duplicate_candle_rows(
+            db,
+            report=report,
+            repair_range=repair_range,
+        )
+        db.flush()
+        if normalized_bars:
+            store_market_candles(
+                db,
+                user_id=user_id,
+                contract_id=resolved_contract_id,
+                symbol=resolved_symbol,
+                live=live,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+                bars=normalized_bars,
+            )
+            clear_failed_repair(request_key)
+        else:
+            note_failed_repair(request_key)
+
+        _delete_repaired_bad_candle_rows(
+            db,
+            report=report,
+            repair_range=repair_range,
+            authoritative_timestamps=authoritative_timestamps,
+        )
+        if force_refresh and normalized_bars:
+            prune_market_candle_cache_range(
+                db,
+                user_id=user_id,
+                contract_id=resolved_contract_id,
+                live=live,
+                start=repair_range.start,
+                end=repair_range.end,
+                unit=normalized_unit,
+                unit_number=normalized_unit_number,
+                keep_timestamps=authoritative_timestamps,
+            )
+
+    db.flush()
+    final_rows = _list_market_candles_for_integrity(
+        db,
+        user_id=user_id,
+        contract_id=resolved_contract_id,
+        live=live,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+    )
+    final_report = audit_candle_rows(
+        final_rows,
+        start=start_utc,
+        end=end_utc,
+        unit=normalized_unit,
+        unit_number=normalized_unit_number,
+        limit=normalized_limit,
+        include_partial_bar=include_partial_bar,
+        symbol=resolved_symbol or symbol,
+    )
+    vetted_rows = list(final_report.valid_rows)
+    if strict_integrity and not final_report.is_complete:
+        raise CandleIntegrityError(
+            "candle_integrity_unresolved:" + ",".join(final_report.issue_codes)
+        )
+    if not vetted_rows and last_provider_error is not None:
+        raise last_provider_error
+    return vetted_rows
+
+
+def market_candle_cache_integrity_report(
+    cached_candles: list[ProjectXMarketCandle],
+    *,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool = False,
+    symbol: str | None = None,
+) -> CandleIntegrityReport:
+    return audit_candle_rows(
+        cached_candles,
         start=start,
         end=end,
-        unit=normalized_unit,
+        unit=unit,
         unit_number=unit_number,
         limit=limit,
         include_partial_bar=include_partial_bar,
+        symbol=symbol,
     )
-    by_timestamp = {
-        _as_utc(row.candle_timestamp): row
-        for row in [*cached, *combined, *stored]
-        if include_partial_bar or not bool(row.is_partial)
+
+
+def _list_market_candles_for_integrity(
+    db: Session,
+    *,
+    user_id: str,
+    contract_id: str,
+    live: bool,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+) -> list[ProjectXMarketCandle]:
+    audit_limit = min(
+        _MARKET_CANDLE_PROVIDER_LIMIT,
+        max(limit + _MARKET_CANDLE_INTEGRITY_QUERY_PADDING, limit * 2),
+    )
+    rows = (
+        db.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == user_id)
+        .filter(ProjectXMarketCandle.contract_id == contract_id)
+        .filter(ProjectXMarketCandle.live == bool(live))
+        .filter(ProjectXMarketCandle.unit == unit)
+        .filter(ProjectXMarketCandle.unit_number == unit_number)
+        .filter(ProjectXMarketCandle.candle_timestamp >= start)
+        .filter(ProjectXMarketCandle.candle_timestamp <= end)
+        .order_by(ProjectXMarketCandle.candle_timestamp.desc())
+        .limit(audit_limit)
+        .all()
+    )
+    rows.sort(key=lambda row: _as_utc(row.candle_timestamp))
+    return rows
+
+
+def _market_candle_repair_limit(
+    repair_range: CandleRepairRange,
+    *,
+    unit: str,
+    unit_number: int,
+    requested_limit: int,
+    full_window: bool,
+) -> int:
+    if full_window:
+        return max(1, min(requested_limit, _MARKET_CANDLE_PROVIDER_LIMIT))
+    interval = candle_interval(unit=unit, unit_number=unit_number)
+    if interval is None:
+        return max(1, min(requested_limit, _MARKET_CANDLE_PROVIDER_LIMIT))
+    slots = max(1, math.ceil((repair_range.end - repair_range.start) / interval))
+    return min(_MARKET_CANDLE_PROVIDER_LIMIT, max(5, slots + 2))
+
+
+def _market_candle_request_key(
+    *,
+    user_id: str,
+    client: ProjectXClient,
+    contract_id: str,
+    live: bool,
+    unit: str,
+    unit_number: int,
+    start: datetime,
+    end: datetime,
+    limit: int,
+    include_partial_bar: bool,
+) -> tuple[Any, ...]:
+    return (
+        "projectx_market_candles",
+        str(user_id),
+        _market_candle_client_identity(client),
+        str(contract_id),
+        bool(live),
+        str(unit),
+        int(unit_number),
+        _as_utc(start).isoformat(),
+        _as_utc(end).isoformat(),
+        int(limit),
+        bool(include_partial_bar),
+    )
+
+
+def _market_candle_client_identity(client: ProjectXClient) -> tuple[str, str]:
+    base_url = str(getattr(client, "base_url", "") or "")
+    username = str(getattr(client, "username", "") or "")
+    if base_url or username:
+        return base_url, username
+    client_type = type(client)
+    return client_type.__module__, client_type.__qualname__
+
+
+def _pad_and_coalesce_market_repair_ranges(
+    ranges: list[CandleRepairRange],
+    *,
+    start: datetime,
+    end: datetime,
+    interval: timedelta | None,
+) -> list[CandleRepairRange]:
+    if not ranges:
+        return []
+    padding = (interval * _MARKET_CANDLE_TAIL_REVALIDATION_BARS) if interval else timedelta(0)
+    padded = [
+        CandleRepairRange(
+            start=max(start, item.start - padding),
+            end=min(end, item.end + padding),
+            reasons=item.reasons,
+        )
+        for item in ranges
+    ]
+    merged: list[CandleRepairRange] = []
+    for item in sorted(padded, key=lambda value: (value.start, value.end)):
+        if not merged or item.start > merged[-1].end:
+            merged.append(item)
+            continue
+        previous = merged[-1]
+        merged[-1] = CandleRepairRange(
+            start=previous.start,
+            end=max(previous.end, item.end),
+            reasons=tuple(sorted(set((*previous.reasons, *item.reasons)))),
+        )
+    return merged
+
+
+def _delete_repaired_bad_candle_rows(
+    db: Session,
+    *,
+    report: CandleIntegrityReport,
+    repair_range: CandleRepairRange,
+    authoritative_timestamps: set[datetime],
+) -> None:
+    deleted_ids: set[int] = set()
+    duplicate_ids = {
+        int(row.id)
+        for row in report.duplicate_rows
+        if getattr(row, "id", None) is not None
     }
-    ordered = [by_timestamp[timestamp] for timestamp in sorted(by_timestamp)]
-    return ordered[-max(1, int(limit)):]
+    for row in report.bad_rows:
+        row_id = getattr(row, "id", None)
+        timestamp = getattr(row, "candle_timestamp", None)
+        if row_id is None or not isinstance(timestamp, datetime):
+            continue
+        if int(row_id) in duplicate_ids:
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if not (repair_range.start <= timestamp_utc <= repair_range.end):
+            continue
+        if int(row_id) in deleted_ids:
+            continue
+        if timestamp_utc in authoritative_timestamps:
+            continue
+        deleted_ids.add(int(row_id))
+        db.delete(row)
+
+
+def _delete_repaired_duplicate_candle_rows(
+    db: Session,
+    *,
+    report: CandleIntegrityReport,
+    repair_range: CandleRepairRange,
+) -> None:
+    for row in report.duplicate_rows:
+        timestamp = getattr(row, "candle_timestamp", None)
+        if getattr(row, "id", None) is None or not isinstance(timestamp, datetime):
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if repair_range.start <= timestamp_utc <= repair_range.end:
+            db.delete(row)
 
 
 def list_market_candles(
@@ -2141,12 +2502,17 @@ def store_market_candles(
                 candle_timestamp=timestamp,
             )
             db.add(row)
+        elif not bool(row.is_partial) and bool(bar.get("is_partial")):
+            # A late or racing partial response can never regress a bar that
+            # has already been observed as authoritatively closed.
+            output.append(row)
+            continue
         row.symbol = symbol
-        row.open_price = float(bar.get("open") or 0.0)
-        row.high_price = float(bar.get("high") or 0.0)
-        row.low_price = float(bar.get("low") or 0.0)
-        row.close_price = float(bar.get("close") or 0.0)
-        row.volume = float(bar.get("volume") or 0.0)
+        row.open_price = float(bar["open"])
+        row.high_price = float(bar["high"])
+        row.low_price = float(bar["low"])
+        row.close_price = float(bar["close"])
+        row.volume = float(bar["volume"])
         row.is_partial = bool(bar.get("is_partial") or False)
         row.raw_payload = bar.get("raw_payload")
         row.fetched_at = fetched_at
@@ -2166,8 +2532,29 @@ def _dedupe_market_candle_bars(bars: Iterable[dict[str, Any]]) -> list[dict[str,
         if not isinstance(timestamp, datetime):
             continue
         timestamp_utc = _as_utc(timestamp)
-        by_timestamp[timestamp_utc] = {**bar, "timestamp": timestamp_utc}
+        candidate = {
+            **bar,
+            "timestamp": timestamp_utc,
+            "volume": bar.get("volume", 0.0),
+            "is_partial": bool(bar.get("is_partial")),
+        }
+        if validate_candle_ohlcv(candidate) is not None:
+            continue
+        existing = by_timestamp.get(timestamp_utc)
+        if existing is None or _provider_candle_rank(candidate) >= _provider_candle_rank(existing):
+            by_timestamp[timestamp_utc] = candidate
     return [by_timestamp[timestamp] for timestamp in sorted(by_timestamp)]
+
+
+def _provider_candle_rank(bar: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        int(not bool(bar.get("is_partial"))),
+        float(bar["open"]),
+        float(bar["high"]),
+        float(bar["low"]),
+        float(bar["close"]),
+        float(bar["volume"]),
+    )
 
 
 def _session_dialect_name(db: Session) -> str:
@@ -2194,11 +2581,11 @@ def _market_candle_insert_values(
         "unit": unit,
         "unit_number": unit_number,
         "candle_timestamp": bar["timestamp"],
-        "open_price": float(bar.get("open") or 0.0),
-        "high_price": float(bar.get("high") or 0.0),
-        "low_price": float(bar.get("low") or 0.0),
-        "close_price": float(bar.get("close") or 0.0),
-        "volume": float(bar.get("volume") or 0.0),
+        "open_price": float(bar["open"]),
+        "high_price": float(bar["high"]),
+        "low_price": float(bar["low"]),
+        "close_price": float(bar["close"]),
+        "volume": float(bar["volume"]),
         "is_partial": bool(bar.get("is_partial") or False),
         "raw_payload": bar.get("raw_payload"),
         "fetched_at": fetched_at,
@@ -2212,6 +2599,7 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
     table = ProjectXMarketCandle.__table__
     insert_stmt = postgresql_insert(table).values(values)
     excluded = insert_stmt.excluded
+    preserve_closed = table.c.is_partial.is_(False) & excluded.is_partial.is_(True)
     db.execute(
         insert_stmt.on_conflict_do_update(
             index_elements=[
@@ -2223,15 +2611,15 @@ def _upsert_market_candle_rows(db: Session, *, values: list[dict[str, Any]]) -> 
                 table.c.candle_timestamp,
             ],
             set_={
-                "symbol": excluded.symbol,
-                "open_price": excluded.open_price,
-                "high_price": excluded.high_price,
-                "low_price": excluded.low_price,
-                "close_price": excluded.close_price,
-                "volume": excluded.volume,
-                "is_partial": excluded.is_partial,
-                "raw_payload": excluded.raw_payload,
-                "fetched_at": excluded.fetched_at,
+                "symbol": case((preserve_closed, table.c.symbol), else_=excluded.symbol),
+                "open_price": case((preserve_closed, table.c.open_price), else_=excluded.open_price),
+                "high_price": case((preserve_closed, table.c.high_price), else_=excluded.high_price),
+                "low_price": case((preserve_closed, table.c.low_price), else_=excluded.low_price),
+                "close_price": case((preserve_closed, table.c.close_price), else_=excluded.close_price),
+                "volume": case((preserve_closed, table.c.volume), else_=excluded.volume),
+                "is_partial": case((preserve_closed, table.c.is_partial), else_=excluded.is_partial),
+                "raw_payload": case((preserve_closed, table.c.raw_payload), else_=excluded.raw_payload),
+                "fetched_at": case((preserve_closed, table.c.fetched_at), else_=excluded.fetched_at),
             },
         )
     )

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -6,7 +6,8 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from numbers import Number
-from typing import Any, Iterable
+from threading import Event, Lock
+from typing import Any, Callable, Iterable
 
 from sqlalchemy import func, or_
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
@@ -79,6 +80,7 @@ _UNIT_SECONDS_BY_NAME = {
 _MARKET_CANDLE_TAIL_REVALIDATION_BARS = 3
 _MARKET_CANDLE_TAIL_REVALIDATION_TTL = timedelta(seconds=15)
 _MARKET_CANDLE_UPSERT_BATCH_SIZE = 1_000
+_MARKET_CANDLE_SINGLEFLIGHT_WAIT_SECONDS = 75
 _EVALUATION_INTRADAY_LOOKBACK_FLOOR = timedelta(days=7)
 _ORDER_TYPE_MARKET = 2
 _SIDE_BY_ACTION = {"BUY": 0, "SELL": 1}
@@ -385,6 +387,17 @@ _TOPBOT_ADAPTIVE_DEFAULTS = {
     "move_to_breakeven_at_r": 1.0,
     "block_expired_contracts": False,
 }
+
+
+@dataclass
+class _CandleProviderFlight:
+    event: Event
+    result: list[dict[str, Any]] | None = None
+    error: Exception | None = None
+
+
+_CANDLE_PROVIDER_FLIGHT_LOCK = Lock()
+_CANDLE_PROVIDER_FLIGHTS: dict[tuple[Any, ...], _CandleProviderFlight] = {}
 
 
 @dataclass(frozen=True)
@@ -1722,6 +1735,42 @@ def fetch_and_store_orb_fibonacci_candles(
     )
 
 
+def _retrieve_market_bars_singleflight(
+    key: tuple[Any, ...],
+    retrieve: Callable[[], list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    owner = False
+    with _CANDLE_PROVIDER_FLIGHT_LOCK:
+        flight = _CANDLE_PROVIDER_FLIGHTS.get(key)
+        if flight is None:
+            flight = _CandleProviderFlight(event=Event())
+            _CANDLE_PROVIDER_FLIGHTS[key] = flight
+            owner = True
+
+    if not owner:
+        if not flight.event.wait(timeout=_MARKET_CANDLE_SINGLEFLIGHT_WAIT_SECONDS):
+            raise ProjectXClientError(
+                "Timed out waiting for an identical candle request.",
+                status_code=504,
+            )
+        if flight.error is not None:
+            raise flight.error
+        return [dict(row) for row in (flight.result or [])]
+
+    try:
+        result = retrieve()
+        flight.result = [dict(row) for row in result]
+        return [dict(row) for row in result]
+    except Exception as exc:
+        flight.error = exc
+        raise
+    finally:
+        flight.event.set()
+        with _CANDLE_PROVIDER_FLIGHT_LOCK:
+            if _CANDLE_PROVIDER_FLIGHTS.get(key) is flight:
+                _CANDLE_PROVIDER_FLIGHTS.pop(key, None)
+
+
 def fetch_and_store_market_candles(
     db: Session,
     *,
@@ -1769,15 +1818,29 @@ def fetch_and_store_market_candles(
         else []
     )
     try:
-        bars = client.retrieve_bars(
-            contract_id=resolved_contract_id,
-            live=live,
-            start=start,
-            end=end,
-            unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
-            unit_number=unit_number,
-            limit=limit,
-            include_partial_bar=include_partial_bar,
+        request_key = (
+            str(user_id),
+            resolved_contract_id,
+            bool(live),
+            normalized_unit,
+            int(unit_number),
+            _as_utc(start).isoformat(),
+            _as_utc(end).isoformat(),
+            int(limit),
+            bool(include_partial_bar),
+        )
+        bars = _retrieve_market_bars_singleflight(
+            request_key,
+            lambda: client.retrieve_bars(
+                contract_id=resolved_contract_id,
+                live=live,
+                start=start,
+                end=end,
+                unit=_PROJECTX_UNIT_BY_NAME[normalized_unit],
+                unit_number=unit_number,
+                limit=limit,
+                include_partial_bar=include_partial_bar,
+            ),
         )
     except ProjectXClientError:
         if cached:
@@ -1928,6 +1991,7 @@ def market_candle_cache_needs_refresh(
     unit: str,
     unit_number: int,
     include_partial_bar: bool = False,
+    symbol: str | None = None,
 ) -> bool:
     if not cached_candles:
         return True
@@ -1938,6 +2002,7 @@ def market_candle_cache_needs_refresh(
         unit=unit,
         unit_number=unit_number,
         include_partial_bar=include_partial_bar,
+        symbol=symbol,
     ):
         return True
 
@@ -1950,6 +2015,7 @@ def market_candle_cache_needs_refresh(
         interval=interval,
         include_end=True,
         closure_aware=_market_candle_unit_is_closure_aware(unit),
+        symbol=symbol,
     ):
         return _market_candle_tail_revalidation_due(cached_candles)
     return False
@@ -1962,6 +2028,7 @@ def market_candle_rows_are_stale(
     unit: str,
     unit_number: int,
     include_partial_bar: bool = False,
+    symbol: str | None = None,
 ) -> bool:
     if not candles:
         return True
@@ -1976,6 +2043,7 @@ def market_candle_rows_are_stale(
         interval=interval,
         include_end=True,
         closure_aware=_market_candle_unit_is_closure_aware(unit),
+        symbol=symbol,
     )
 
 
@@ -1986,6 +2054,7 @@ def market_candle_cache_covers_request(
     unit: str,
     unit_number: int,
     limit: int,
+    symbol: str | None = None,
 ) -> bool:
     if not cached_candles:
         return False
@@ -1995,6 +2064,7 @@ def market_candle_cache_covers_request(
         cached_candles,
         interval=interval,
         closure_aware=_market_candle_unit_is_closure_aware(unit),
+        symbol=symbol,
     ):
         return False
 
@@ -2012,6 +2082,7 @@ def market_candle_cache_covers_request(
         interval=interval,
         include_end=False,
         closure_aware=_market_candle_unit_is_closure_aware(unit),
+        symbol=symbol,
     )
 
 
@@ -2020,6 +2091,7 @@ def _market_candle_rows_have_open_session_gap(
     *,
     interval: timedelta,
     closure_aware: bool,
+    symbol: str | None = None,
 ) -> bool:
     timestamps = sorted({_as_utc(row.candle_timestamp) for row in cached_candles})
     for previous, current in zip(timestamps, timestamps[1:]):
@@ -2029,6 +2101,7 @@ def _market_candle_rows_have_open_session_gap(
             interval=interval,
             include_end=False,
             closure_aware=closure_aware,
+            symbol=symbol,
         ):
             return True
     return False
@@ -2041,6 +2114,7 @@ def _market_candle_range_contains_open_slot(
     interval: timedelta,
     include_end: bool,
     closure_aware: bool,
+    symbol: str | None = None,
 ) -> bool:
     cursor = _as_utc(start)
     end_utc = _as_utc(end)
@@ -2054,7 +2128,7 @@ def _market_candle_range_contains_open_slot(
     # any tradable slot exists inside the missing range.
     step = max(interval, timedelta(minutes=1))
     while cursor < end_utc or (include_end and cursor == end_utc):
-        if futures_session_is_open(cursor):
+        if futures_session_is_open(cursor, symbol=symbol):
             return True
         cursor += step
     return False

--- a/backend/app/services/bot_service.py
+++ b/backend/app/services/bot_service.py
@@ -2298,8 +2298,11 @@ def evaluate_sma_cross(
     slow_period: int,
 ) -> SignalResult:
     _validate_strategy_periods(fast_period, slow_period)
-    closed = [candle for candle in candles if not bool(candle.is_partial)]
-    closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        closed = candles
+    else:
+        closed = [candle for candle in candles if not bool(candle.is_partial)]
+        closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
     if len(closed) < slow_period + 1:
         return SignalResult(
             action="HOLD",
@@ -8121,6 +8124,8 @@ def _serialize_pivot_level(level: PivotLevel) -> dict[str, Any]:
 
 
 def _closed_candles(candles: list[ProjectXMarketCandle]) -> list[ProjectXMarketCandle]:
+    if getattr(candles, "_topsignal_sorted_closed", False):
+        return candles
     closed = [candle for candle in candles if not bool(candle.is_partial)]
     closed.sort(key=lambda candle: _as_utc(candle.candle_timestamp))
     return closed

--- a/backend/app/services/candle_integrity.py
+++ b/backend/app/services/candle_integrity.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import Event, Lock
+from typing import Any, Callable
+
+from .projectx_client import ProjectXClientError
+from .trading_day import is_expected_futures_candle
+
+
+_CANDLE_CLOSE_GRACE = timedelta(seconds=2)
+_MAX_AUDIT_SLOTS = 25_000
+_MAX_REPAIR_WINDOWS = 8
+_PROVIDER_ATTEMPTS = 3
+_PROVIDER_RETRY_DELAYS = (0.0, 0.05, 0.15)
+_SINGLEFLIGHT_WAIT_SECONDS = 30.0
+_FAILED_REPAIR_COOLDOWN = timedelta(seconds=5)
+
+_UNIT_SECONDS = {
+    "second": 1,
+    "minute": 60,
+    "hour": 60 * 60,
+    "day": 24 * 60 * 60,
+    "week": 7 * 24 * 60 * 60,
+}
+
+
+@dataclass(frozen=True)
+class CandleRepairRange:
+    start: datetime
+    end: datetime
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CandleIntegrityReport:
+    valid_rows: tuple[Any, ...]
+    invalid_rows: tuple[Any, ...]
+    stale_partial_rows: tuple[Any, ...]
+    current_partial_rows: tuple[Any, ...]
+    duplicate_rows: tuple[Any, ...]
+    overlapping_rows: tuple[Any, ...]
+    missing_ranges: tuple[CandleRepairRange, ...]
+    repair_ranges: tuple[CandleRepairRange, ...]
+    issue_codes: tuple[str, ...]
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.issue_codes
+
+    @property
+    def bad_rows(self) -> tuple[Any, ...]:
+        rows: list[Any] = []
+        seen: set[int] = set()
+        for row in (
+            *self.invalid_rows,
+            *self.stale_partial_rows,
+            *self.duplicate_rows,
+            *self.overlapping_rows,
+        ):
+            marker = id(row)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            rows.append(row)
+        return tuple(rows)
+
+
+@dataclass
+class _ProviderFlight:
+    event: Event
+    result: list[dict[str, Any]] | None = None
+    error: Exception | None = None
+
+
+_FLIGHT_GUARD = Lock()
+_ACTIVE_FLIGHTS: dict[tuple[Any, ...], _ProviderFlight] = {}
+_FAILED_REPAIR_UNTIL: dict[tuple[Any, ...], datetime] = {}
+
+
+def candle_interval(*, unit: str, unit_number: int) -> timedelta | None:
+    seconds = _UNIT_SECONDS.get(str(unit).strip().lower())
+    if seconds is None:
+        return None
+    return timedelta(seconds=seconds * max(1, int(unit_number)))
+
+
+def candle_close_time(timestamp: datetime, *, unit: str, unit_number: int) -> datetime:
+    value = _as_utc(timestamp)
+    normalized_unit = str(unit).strip().lower()
+    if normalized_unit == "month":
+        return _add_months(value, max(1, int(unit_number)))
+    interval = candle_interval(unit=normalized_unit, unit_number=unit_number)
+    if interval is None:
+        raise ValueError(f"unsupported candle unit: {unit}")
+    return value + interval
+
+
+def validate_candle_ohlcv(row: Any) -> str | None:
+    values: dict[str, float] = {}
+    for field in ("open", "high", "low", "close", "volume"):
+        raw_value = _row_value(row, field)
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError, OverflowError):
+            return f"invalid_{field}"
+        if not math.isfinite(value):
+            return f"non_finite_{field}"
+        values[field] = value
+
+    if min(values["open"], values["high"], values["low"], values["close"]) <= 0:
+        return "non_positive_ohlc"
+    if values["high"] < max(values["open"], values["close"], values["low"]):
+        return "invalid_candle_high"
+    if values["low"] > min(values["open"], values["close"], values["high"]):
+        return "invalid_candle_low"
+    if values["volume"] < 0:
+        return "negative_candle_volume"
+    return None
+
+
+def audit_candle_rows(
+    rows: Iterable[Any],
+    *,
+    start: datetime,
+    end: datetime,
+    unit: str,
+    unit_number: int,
+    limit: int,
+    include_partial_bar: bool,
+    symbol: str | None = None,
+    as_of: datetime | None = None,
+) -> CandleIntegrityReport:
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc < start_utc:
+        raise ValueError("start must be before end")
+    now = _as_utc(as_of or datetime.now(timezone.utc))
+    interval = candle_interval(unit=unit, unit_number=unit_number)
+
+    timestamped: list[tuple[datetime, Any]] = []
+    invalid_rows: list[Any] = []
+    issue_codes: set[str] = set()
+    for row in rows:
+        timestamp = _row_timestamp(row)
+        if timestamp is None:
+            invalid_rows.append(row)
+            issue_codes.add("invalid_candle_timestamp")
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if timestamp_utc < start_utc or timestamp_utc > end_utc:
+            continue
+        timestamped.append((timestamp_utc, row))
+
+    grouped: dict[datetime, list[Any]] = {}
+    for timestamp, row in timestamped:
+        grouped.setdefault(timestamp, []).append(row)
+
+    canonical: list[tuple[datetime, Any]] = []
+    duplicate_rows: list[Any] = []
+    for timestamp in sorted(grouped):
+        candidates = grouped[timestamp]
+        winner = max(candidates, key=_canonical_row_rank)
+        canonical.append((timestamp, winner))
+        if len(candidates) > 1:
+            issue_codes.add("duplicate_candle_timestamp")
+            duplicate_rows.extend(row for row in candidates if row is not winner)
+
+    usable: list[tuple[datetime, Any, bool]] = []
+    stale_partial_rows: list[Any] = []
+    current_partial_rows: list[Any] = []
+    closed_through = min(end_utc, now - _CANDLE_CLOSE_GRACE)
+    for timestamp, row in canonical:
+        invalid_code = validate_candle_ohlcv(row)
+        if invalid_code is not None:
+            invalid_rows.append(row)
+            issue_codes.add(invalid_code)
+            continue
+        try:
+            close_time = candle_close_time(timestamp, unit=unit, unit_number=unit_number)
+        except ValueError:
+            invalid_rows.append(row)
+            issue_codes.add("unsupported_candle_unit")
+            continue
+
+        declared_partial = _row_is_partial(row)
+        effectively_partial = declared_partial and close_time > closed_through
+        if declared_partial and not effectively_partial:
+            stale_partial_rows.append(row)
+            issue_codes.add("stale_partial_candle")
+            continue
+        is_current_partial = declared_partial or effectively_partial
+        if is_current_partial:
+            current_partial_rows.append(row)
+            if not include_partial_bar:
+                continue
+        usable.append((timestamp, row, is_current_partial))
+
+    overlapping_rows: list[Any] = []
+    non_overlapping: list[tuple[datetime, Any, bool]] = []
+    for candidate in usable:
+        if not non_overlapping or interval is None:
+            non_overlapping.append(candidate)
+            continue
+        previous = non_overlapping[-1]
+        previous_close = candle_close_time(previous[0], unit=unit, unit_number=unit_number)
+        if candidate[0] >= previous_close:
+            non_overlapping.append(candidate)
+            continue
+
+        issue_codes.add("overlapping_candles")
+        preferred = max(
+            (previous, candidate),
+            key=lambda item: _overlap_rank(item[0], item[1], item[2], interval),
+        )
+        rejected = candidate if preferred is previous else previous
+        overlapping_rows.append(rejected[1])
+        if preferred is candidate:
+            non_overlapping[-1] = candidate
+
+    valid_rows = [item[1] for item in non_overlapping]
+    closed_rows = [item for item in non_overlapping if not item[2]]
+    missing_ranges: list[CandleRepairRange] = []
+    if interval is not None and str(unit).strip().lower() in {"second", "minute", "hour"}:
+        missing_ranges = _find_missing_ranges(
+            closed_rows,
+            start=start_utc,
+            end=end_utc,
+            closed_through=closed_through,
+            interval=interval,
+            limit=max(1, int(limit)),
+            symbol=symbol,
+        )
+        if missing_ranges:
+            issue_codes.add("missing_candle")
+
+    bad_ranges: list[CandleRepairRange] = []
+    for code, bad_rows in (
+        ("invalid_candle", invalid_rows),
+        ("stale_partial_candle", stale_partial_rows),
+        ("duplicate_candle_timestamp", duplicate_rows),
+        ("overlapping_candles", overlapping_rows),
+    ):
+        for row in bad_rows:
+            timestamp = _row_timestamp(row)
+            if timestamp is None:
+                continue
+            timestamp_utc = _as_utc(timestamp)
+            padding = interval or timedelta(days=1)
+            bad_ranges.append(
+                CandleRepairRange(
+                    start=max(start_utc, timestamp_utc - padding),
+                    end=min(end_utc, candle_close_time(timestamp_utc, unit=unit, unit_number=unit_number) + padding),
+                    reasons=(code,),
+                )
+            )
+
+    repair_ranges = _merge_repair_ranges([*missing_ranges, *bad_ranges], maximum=_MAX_REPAIR_WINDOWS)
+    valid_rows.sort(key=lambda row: _as_utc(_row_timestamp(row) or start_utc))
+    return CandleIntegrityReport(
+        valid_rows=tuple(valid_rows[-max(1, int(limit)) :]),
+        invalid_rows=tuple(invalid_rows),
+        stale_partial_rows=tuple(stale_partial_rows),
+        current_partial_rows=tuple(current_partial_rows),
+        duplicate_rows=tuple(duplicate_rows),
+        overlapping_rows=tuple(overlapping_rows),
+        missing_ranges=tuple(missing_ranges),
+        repair_ranges=tuple(repair_ranges),
+        issue_codes=tuple(sorted(issue_codes)),
+    )
+
+
+def normalize_provider_bars(
+    bars: Iterable[dict[str, Any]],
+    *,
+    unit: str,
+    unit_number: int,
+    request_start: datetime | None = None,
+    request_end: datetime,
+    include_partial_bar: bool,
+    as_of: datetime | None = None,
+) -> list[dict[str, Any]]:
+    now = _as_utc(as_of or datetime.now(timezone.utc))
+    request_start_utc = _as_utc(request_start) if request_start is not None else None
+    request_end_utc = _as_utc(request_end)
+    closed_through = min(request_end_utc, now - _CANDLE_CLOSE_GRACE)
+    candidates: list[dict[str, Any]] = []
+    for raw_bar in bars:
+        if not isinstance(raw_bar, dict):
+            continue
+        timestamp = raw_bar.get("timestamp")
+        if not isinstance(timestamp, datetime):
+            continue
+        timestamp_utc = _as_utc(timestamp)
+        if timestamp_utc > request_end_utc or (
+            request_start_utc is not None and timestamp_utc < request_start_utc
+        ):
+            continue
+        try:
+            close_time = candle_close_time(timestamp_utc, unit=unit, unit_number=unit_number)
+        except ValueError:
+            continue
+        normalized = {**raw_bar, "timestamp": timestamp_utc}
+        inferred_partial = (
+            bool(raw_bar.get("is_partial"))
+            or close_time > request_end_utc
+            or (include_partial_bar and close_time > closed_through)
+        )
+        normalized["is_partial"] = inferred_partial
+        if validate_candle_ohlcv(normalized) is not None:
+            continue
+        if inferred_partial and not include_partial_bar:
+            continue
+        candidates.append(normalized)
+
+    if not candidates:
+        return []
+    start = min(_as_utc(row["timestamp"]) for row in candidates)
+    end = max(candle_close_time(row["timestamp"], unit=unit, unit_number=unit_number) for row in candidates)
+    report = audit_candle_rows(
+        candidates,
+        start=start,
+        end=end,
+        unit=unit,
+        unit_number=unit_number,
+        limit=len(candidates),
+        include_partial_bar=include_partial_bar,
+        as_of=now,
+    )
+    return [dict(row) for row in report.valid_rows]
+
+
+def retrieve_bars_singleflight(
+    *,
+    key: tuple[Any, ...],
+    retrieve: Callable[[], list[dict[str, Any]]],
+    attempts: int = _PROVIDER_ATTEMPTS,
+) -> list[dict[str, Any]]:
+    owner = False
+    with _FLIGHT_GUARD:
+        flight = _ACTIVE_FLIGHTS.get(key)
+        if flight is None:
+            flight = _ProviderFlight(event=Event())
+            _ACTIVE_FLIGHTS[key] = flight
+            owner = True
+
+    if not owner:
+        if not flight.event.wait(timeout=_SINGLEFLIGHT_WAIT_SECONDS):
+            raise ProjectXClientError("Timed out waiting for an identical candle request.", status_code=504)
+        if flight.error is not None:
+            raise flight.error
+        return [dict(row) for row in (flight.result or [])]
+
+    try:
+        result = _retrieve_with_bounded_retries(retrieve, attempts=attempts)
+        flight.result = [dict(row) for row in result]
+        return [dict(row) for row in result]
+    except Exception as exc:
+        flight.error = exc
+        raise
+    finally:
+        flight.event.set()
+        with _FLIGHT_GUARD:
+            if _ACTIVE_FLIGHTS.get(key) is flight:
+                _ACTIVE_FLIGHTS.pop(key, None)
+
+
+def repair_request_in_cooldown(key: tuple[Any, ...], *, now: datetime | None = None) -> bool:
+    current = _as_utc(now or datetime.now(timezone.utc))
+    with _FLIGHT_GUARD:
+        expires_at = _FAILED_REPAIR_UNTIL.get(key)
+        if expires_at is None:
+            return False
+        if expires_at <= current:
+            _FAILED_REPAIR_UNTIL.pop(key, None)
+            return False
+        return True
+
+
+def note_failed_repair(key: tuple[Any, ...], *, now: datetime | None = None) -> None:
+    current = _as_utc(now or datetime.now(timezone.utc))
+    with _FLIGHT_GUARD:
+        _FAILED_REPAIR_UNTIL[key] = current + _FAILED_REPAIR_COOLDOWN
+
+
+def clear_failed_repair(key: tuple[Any, ...]) -> None:
+    with _FLIGHT_GUARD:
+        _FAILED_REPAIR_UNTIL.pop(key, None)
+
+
+def _reset_request_state_for_tests() -> None:
+    with _FLIGHT_GUARD:
+        _ACTIVE_FLIGHTS.clear()
+        _FAILED_REPAIR_UNTIL.clear()
+
+
+def _retrieve_with_bounded_retries(
+    retrieve: Callable[[], list[dict[str, Any]]],
+    *,
+    attempts: int,
+) -> list[dict[str, Any]]:
+    bounded_attempts = max(1, min(int(attempts), _PROVIDER_ATTEMPTS))
+    for attempt in range(bounded_attempts):
+        try:
+            return retrieve()
+        except ProjectXClientError as exc:
+            if attempt + 1 >= bounded_attempts or not _is_transient_provider_error(exc):
+                raise
+            delay = _PROVIDER_RETRY_DELAYS[min(attempt + 1, len(_PROVIDER_RETRY_DELAYS) - 1)]
+            if delay > 0:
+                time.sleep(delay)
+    return []
+
+
+def _is_transient_provider_error(exc: ProjectXClientError) -> bool:
+    status_code = exc.status_code
+    return status_code is None or status_code == 429 or status_code >= 500
+
+
+def _find_missing_ranges(
+    closed_rows: list[tuple[datetime, Any, bool]],
+    *,
+    start: datetime,
+    end: datetime,
+    closed_through: datetime,
+    interval: timedelta,
+    limit: int,
+    symbol: str | None,
+) -> list[CandleRepairRange]:
+    if closed_through < start:
+        return []
+    timestamps = [row[0] for row in closed_rows]
+    missing: list[datetime] = []
+    broad_ranges: list[CandleRepairRange] = []
+    scanned = 0
+
+    wall_slots = max(0, int((closed_through - start) // interval) + 1)
+    if wall_slots <= limit:
+        candidate = _ceil_timestamp(start, interval)
+        first = timestamps[0] if timestamps else None
+        while candidate < (first or closed_through + interval) and candidate + interval <= closed_through:
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if is_expected_futures_candle(candidate, candidate + interval, symbol=symbol):
+                missing.append(candidate)
+            candidate += interval
+
+    for left, right in zip(timestamps, timestamps[1:]):
+        candidate = left + interval
+        candidate_slots = max(0, math.ceil((right - candidate) / interval))
+        if scanned + candidate_slots > _MAX_AUDIT_SLOTS:
+            if candidate < right and is_expected_futures_candle(candidate, right, symbol=symbol):
+                broad_ranges.append(
+                    CandleRepairRange(
+                        start=candidate,
+                        end=right,
+                        reasons=("missing_candle",),
+                    )
+                )
+            scanned = _MAX_AUDIT_SLOTS + 1
+            break
+        while candidate < right:
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if candidate + interval <= closed_through and is_expected_futures_candle(
+                candidate,
+                candidate + interval,
+                symbol=symbol,
+            ):
+                missing.append(candidate)
+            candidate += interval
+        if scanned > _MAX_AUDIT_SLOTS:
+            break
+
+    if scanned <= _MAX_AUDIT_SLOTS:
+        candidate = (timestamps[-1] + interval) if timestamps else _ceil_timestamp(start, interval)
+        tail_slots = max(0, int((closed_through - candidate) // interval))
+        if scanned + tail_slots > _MAX_AUDIT_SLOTS:
+            if candidate < closed_through and is_expected_futures_candle(
+                candidate,
+                closed_through,
+                symbol=symbol,
+            ):
+                broad_ranges.append(
+                    CandleRepairRange(
+                        start=candidate,
+                        end=closed_through,
+                        reasons=("missing_candle",),
+                    )
+                )
+            scanned = _MAX_AUDIT_SLOTS + 1
+        while candidate + interval <= closed_through:
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            scanned += 1
+            if scanned > _MAX_AUDIT_SLOTS:
+                break
+            if is_expected_futures_candle(candidate, candidate + interval, symbol=symbol):
+                missing.append(candidate)
+            candidate += interval
+    elif timestamps:
+        candidate = timestamps[-1] + interval
+        if candidate + interval <= closed_through and is_expected_futures_candle(
+            candidate,
+            closed_through,
+            symbol=symbol,
+        ):
+            broad_ranges.append(
+                CandleRepairRange(
+                    start=candidate,
+                    end=closed_through,
+                    reasons=("missing_candle",),
+                )
+            )
+
+    if not missing:
+        return broad_ranges
+    unique = sorted(set(missing))
+    ranges: list[CandleRepairRange] = []
+    range_start = unique[0]
+    previous = unique[0]
+    for timestamp in unique[1:]:
+        if timestamp == previous + interval:
+            previous = timestamp
+            continue
+        ranges.append(
+            CandleRepairRange(start=range_start, end=previous + interval, reasons=("missing_candle",))
+        )
+        range_start = timestamp
+        previous = timestamp
+    ranges.append(CandleRepairRange(start=range_start, end=previous + interval, reasons=("missing_candle",)))
+    return _merge_repair_ranges([*ranges, *broad_ranges], maximum=_MAX_REPAIR_WINDOWS)
+
+
+def _merge_repair_ranges(
+    ranges: Iterable[CandleRepairRange],
+    *,
+    maximum: int,
+) -> list[CandleRepairRange]:
+    ordered = sorted(ranges, key=lambda item: (item.start, item.end))
+    merged: list[CandleRepairRange] = []
+    for item in ordered:
+        if item.end <= item.start:
+            continue
+        if not merged or item.start > merged[-1].end:
+            merged.append(item)
+            continue
+        previous = merged[-1]
+        merged[-1] = CandleRepairRange(
+            start=previous.start,
+            end=max(previous.end, item.end),
+            reasons=tuple(sorted(set((*previous.reasons, *item.reasons)))),
+        )
+
+    maximum = max(1, int(maximum))
+    while len(merged) > maximum:
+        pair_index = min(
+            range(len(merged) - 1),
+            key=lambda index: merged[index + 1].start - merged[index].end,
+        )
+        left = merged[pair_index]
+        right = merged[pair_index + 1]
+        merged[pair_index : pair_index + 2] = [
+            CandleRepairRange(
+                start=left.start,
+                end=right.end,
+                reasons=tuple(sorted(set((*left.reasons, *right.reasons)))),
+            )
+        ]
+    return merged
+
+
+def _canonical_row_rank(row: Any) -> tuple[Any, ...]:
+    valid = validate_candle_ohlcv(row) is None
+    partial = _row_is_partial(row)
+    fetched_at = _row_fetched_at(row)
+    fetched_epoch = fetched_at.timestamp() if fetched_at is not None else 0.0
+    numeric: list[float] = []
+    for field in ("open", "high", "low", "close", "volume"):
+        try:
+            numeric.append(float(_row_value(row, field)))
+        except (TypeError, ValueError, OverflowError):
+            numeric.append(float("-inf"))
+    return (int(valid), int(not partial), fetched_epoch, *numeric)
+
+
+def _overlap_rank(
+    timestamp: datetime,
+    row: Any,
+    is_partial: bool,
+    interval: timedelta,
+) -> tuple[Any, ...]:
+    aligned = _floor_timestamp(timestamp, interval) == timestamp
+    fetched_at = _row_fetched_at(row)
+    return (
+        int(not is_partial),
+        int(aligned),
+        fetched_at.timestamp() if fetched_at is not None else 0.0,
+        -timestamp.timestamp(),
+    )
+
+
+def _row_timestamp(row: Any) -> datetime | None:
+    value = row.get("timestamp") if isinstance(row, Mapping) else getattr(row, "candle_timestamp", None)
+    return value if isinstance(value, datetime) else None
+
+
+def _row_value(row: Any, field: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(field)
+    return getattr(row, f"{field}_price" if field != "volume" else "volume", None)
+
+
+def _row_is_partial(row: Any) -> bool:
+    if isinstance(row, Mapping):
+        return bool(row.get("is_partial"))
+    return bool(getattr(row, "is_partial", False))
+
+
+def _row_fetched_at(row: Any) -> datetime | None:
+    value = row.get("fetched_at") if isinstance(row, Mapping) else getattr(row, "fetched_at", None)
+    return _as_utc(value) if isinstance(value, datetime) else None
+
+
+def _floor_timestamp(value: datetime, interval: timedelta) -> datetime:
+    value_utc = _as_utc(value)
+    seconds = max(1, int(interval.total_seconds()))
+    epoch = int(value_utc.timestamp())
+    return datetime.fromtimestamp(epoch - epoch % seconds, tz=timezone.utc)
+
+
+def _ceil_timestamp(value: datetime, interval: timedelta) -> datetime:
+    floor = _floor_timestamp(value, interval)
+    return floor if floor >= _as_utc(value) else floor + interval
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _add_months(value: datetime, months: int) -> datetime:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    if month == 12:
+        next_month = datetime(year + 1, 1, 1, tzinfo=value.tzinfo)
+    else:
+        next_month = datetime(year, month + 1, 1, tzinfo=value.tzinfo)
+    month_start = datetime(year, month, 1, tzinfo=value.tzinfo)
+    last_day = (next_month - month_start).days
+    return value.replace(year=year, month=month, day=min(value.day, last_day))

--- a/backend/app/services/projectx_client.py
+++ b/backend/app/services/projectx_client.py
@@ -23,6 +23,8 @@ _TOKEN_CACHE_BY_KEY: dict[str, _TokenCache] = {}
 _TOKEN_SAFETY_WINDOW = timedelta(seconds=60)
 _PROJECTX_ORDER_TYPES = {1, 2, 4, 5, 6, 7}
 _PROJECTX_ORDER_SIDES = {0, 1}
+_PROJECTX_INTRADAY_UNIT_SECONDS = {1: 1, 2: 60, 3: 60 * 60}
+_PARTIAL_BAR_KEYS = ("isPartial", "is_partial", "partial")
 
 
 class ProjectXClientError(RuntimeError):
@@ -183,6 +185,15 @@ class ProjectXClient:
             timestamp = _parse_datetime(_first_value(row, ["t", "timestamp", "time"]))
             if timestamp is None:
                 continue
+            has_partial_marker = any(key in row for key in _PARTIAL_BAR_KEYS)
+            is_partial = _is_truthy(_first_value(row, list(_PARTIAL_BAR_KEYS)))
+            interval_seconds = _PROJECTX_INTRADAY_UNIT_SECONDS.get(int(unit))
+            if not has_partial_marker and interval_seconds is not None:
+                is_partial = timestamp + timedelta(
+                    seconds=interval_seconds * max(1, int(unit_number))
+                ) > _as_utc(end)
+            if is_partial and not include_partial_bar:
+                continue
 
             output.append(
                 {
@@ -192,7 +203,7 @@ class ProjectXClient:
                     "low": _safe_float(_first_value(row, ["l", "low"])),
                     "close": _safe_float(_first_value(row, ["c", "close"])),
                     "volume": _safe_float(_first_value(row, ["v", "volume"])),
-                    "is_partial": _is_truthy(_first_value(row, ["isPartial", "is_partial", "partial"])),
+                    "is_partial": is_partial,
                     "raw_payload": row,
                 }
             )

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -1,10 +1,82 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
+from functools import lru_cache
 from zoneinfo import ZoneInfo
 
 TRADING_TZ = ZoneInfo("America/New_York")
 TRADING_DAY_ROLLOVER_HOUR = 18
+
+_REGULAR_SESSION_OPEN = time(hour=18)
+_REGULAR_SESSION_CLOSE = time(hour=17)
+_EQUITY_HALT_START = time(hour=16, minute=15)
+_EQUITY_HALT_END = time(hour=16, minute=30)
+_EARLY_CLOSE = time(hour=13)
+_EARLY_CLOSE_OLD = time(hour=11, minute=30)
+_EARLY_CLOSE_1215_CT = time(hour=13, minute=15)
+_GOOD_FRIDAY_CLOSE = time(hour=9, minute=15)
+
+# ProjectX symbols can be short roots (``MNQ``), provider symbols
+# (``F.US.MNQ``), or full contract ids (``CON.F.US.MNQ.M26``).  Unknown
+# symbols use the equity schedule because that is TopSignal's primary market;
+# known non-equity roots retain the common Globex week and maintenance break
+# without incorrectly borrowing equity-specific holiday close times.
+_CME_EQUITY_ROOTS = frozenset(
+    {
+        "ES",
+        "MES",
+        "NQ",
+        "MNQ",
+        "YM",
+        "MYM",
+        "RTY",
+        "M2K",
+        "EMD",
+        "MME",
+        "NKD",
+        "NIY",
+    }
+)
+_KNOWN_NON_EQUITY_ROOTS = frozenset(
+    {
+        "CL",
+        "MCL",
+        "NG",
+        "QG",
+        "GC",
+        "MGC",
+        "SI",
+        "SIL",
+        "HG",
+        "MHG",
+        "ZB",
+        "ZN",
+        "ZF",
+        "ZT",
+        "6A",
+        "6B",
+        "6C",
+        "6E",
+        "6J",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FuturesHolidaySchedule:
+    """A deterministic CME equity holiday exception for one trading date.
+
+    ``full_close`` means the session that would normally start at 18:00 ET on
+    the prior calendar date never opens.  ``early_close`` is an ET wall-clock
+    close on ``trading_date``; the next trading date can still open at 18:00 ET.
+    """
+
+    name: str
+    trading_date: date
+    full_close: bool = False
+    early_close: time | None = None
 
 
 def as_utc(value: datetime) -> datetime:
@@ -34,3 +106,279 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     )
     end_local = start_local + timedelta(days=1) - timedelta(microseconds=1)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def futures_holiday_schedule(
+    value: date,
+    *,
+    symbol: str | None = None,
+) -> FuturesHolidaySchedule | None:
+    """Return the CME equity holiday exception for a trading date, if any.
+
+    Holiday hours are product-family specific.  The equity calendar is used for
+    CME equity roots and when no root is available.  Known non-equity roots use
+    only the common Globex weekly schedule until a dedicated product calendar is
+    added, avoiding false claims about their special close times.
+    """
+
+    if not _uses_cme_equity_schedule(symbol):
+        return None
+    return _cme_equity_holiday_schedule(value)
+
+
+def futures_session_intervals_utc(
+    value: date,
+    *,
+    symbol: str | None = None,
+) -> tuple[tuple[datetime, datetime], ...]:
+    """Return authoritative open intervals for one futures trading date.
+
+    Intervals are half-open UTC ranges.  A normal CME equity trading date has
+    two ranges because the 16:15-16:30 ET equity halt is excluded.  Weekends,
+    full holidays, the daily 17:00-18:00 maintenance period, and holiday hours
+    therefore never appear as expected candle time.
+    """
+
+    return _futures_session_intervals_utc_cached(value, _uses_cme_equity_schedule(symbol))
+
+
+def is_futures_market_open(at: datetime, *, symbol: str | None = None) -> bool:
+    """Return whether ``at`` is inside a scheduled CME futures session."""
+
+    instant = as_utc(at)
+    session_date = trading_day_date(instant)
+    return any(
+        session_open <= instant < session_close
+        for session_open, session_close in futures_session_intervals_utc(
+            session_date,
+            symbol=symbol,
+        )
+    )
+
+
+def is_expected_futures_candle(
+    timestamp: datetime,
+    close_time: datetime,
+    *,
+    symbol: str | None = None,
+) -> bool:
+    """Return whether a candle bucket overlaps scheduled trading time.
+
+    The bucket is treated as ``[timestamp, close_time)``.  This interval-based
+    test handles larger bars that straddle a scheduled halt without inventing a
+    candle for a bucket wholly contained in a weekend, holiday, or maintenance
+    period.  It only describes whether a bar may be expected; it never creates
+    or interpolates market data.
+    """
+
+    start_utc = as_utc(timestamp)
+    end_utc = as_utc(close_time)
+    if end_utc <= start_utc:
+        return False
+
+    start_local_date = start_utc.astimezone(TRADING_TZ).date()
+    end_local_date = end_utc.astimezone(TRADING_TZ).date()
+    # A session beginning after 18:00 belongs to the following trading date, so
+    # inspect one date beyond the local end.  API/backtest ranges are bounded;
+    # iterating dates avoids scanning every missing second across a weekend.
+    final_session_date = _add_date_safely(end_local_date, days=1)
+    session_date = start_local_date
+    while session_date <= final_session_date:
+        for session_open, session_close in futures_session_intervals_utc(
+            session_date,
+            symbol=symbol,
+        ):
+            if session_open < end_utc and session_close > start_utc:
+                return True
+        if session_date == date.max:
+            break
+        session_date += timedelta(days=1)
+    return False
+
+
+@lru_cache(maxsize=8_192)
+def _futures_session_intervals_utc_cached(
+    value: date,
+    equity_schedule: bool,
+) -> tuple[tuple[datetime, datetime], ...]:
+    if value.weekday() >= 5:
+        return ()
+
+    holiday = _cme_equity_holiday_schedule(value) if equity_schedule else None
+    if holiday is not None and holiday.full_close:
+        return ()
+
+    open_local = datetime.combine(
+        value - timedelta(days=1),
+        _REGULAR_SESSION_OPEN,
+        tzinfo=TRADING_TZ,
+    )
+    close_at = (
+        holiday.early_close
+        if holiday is not None and holiday.early_close is not None
+        else _REGULAR_SESSION_CLOSE
+    )
+    close_local = datetime.combine(value, close_at, tzinfo=TRADING_TZ)
+    if close_local <= open_local:
+        return ()
+
+    local_intervals: list[tuple[datetime, datetime]] = []
+    if equity_schedule:
+        halt_start = datetime.combine(value, _EQUITY_HALT_START, tzinfo=TRADING_TZ)
+        halt_end = datetime.combine(value, _EQUITY_HALT_END, tzinfo=TRADING_TZ)
+        first_close = min(close_local, halt_start)
+        if open_local < first_close:
+            local_intervals.append((open_local, first_close))
+        if halt_end < close_local:
+            local_intervals.append((halt_end, close_local))
+    else:
+        local_intervals.append((open_local, close_local))
+
+    return tuple(
+        (interval_open.astimezone(timezone.utc), interval_close.astimezone(timezone.utc))
+        for interval_open, interval_close in local_intervals
+    )
+
+
+@lru_cache(maxsize=1_024)
+def _cme_equity_holiday_schedule(value: date) -> FuturesHolidaySchedule | None:
+    """Contemporary CME Globex equity holiday rules in Eastern time.
+
+    CME publishes product-specific schedules annually.  These deterministic
+    rules encode the recurring equity-index schedule and its documented regime
+    changes; unusual exchange notices can be added as explicit date overrides
+    without changing gap-detection behavior elsewhere.
+    """
+
+    year = value.year
+
+    new_year = date(year, 1, 1)
+    observed_new_year = new_year + timedelta(days=1) if new_year.weekday() == 6 else new_year
+    if value == observed_new_year:
+        return FuturesHolidaySchedule("New Year's Day", value, full_close=True)
+
+    christmas = _nearest_weekday(date(year, 12, 25))
+    if value == christmas:
+        return FuturesHolidaySchedule("Christmas", value, full_close=True)
+
+    good_friday = _easter_sunday(year) - timedelta(days=2)
+    if value == good_friday:
+        if year == 2022 or (year < 2021 and year not in {2010, 2012, 2015}):
+            return FuturesHolidaySchedule("Good Friday", value, full_close=True)
+        return FuturesHolidaySchedule(
+            "Good Friday",
+            value,
+            early_close=_GOOD_FRIDAY_CLOSE,
+        )
+
+    early_close_name: str | None = None
+    early_close_at: time | None = None
+
+    if year >= 1998 and value == _nth_weekday(year, 1, weekday=0, occurrence=3):
+        early_close_name = "Martin Luther King Jr. Day"
+        early_close_at = _EARLY_CLOSE if year >= 2015 else _EARLY_CLOSE_OLD
+    elif value == _nth_weekday(year, 2, weekday=0, occurrence=3):
+        early_close_name = "Presidents Day"
+        early_close_at = _EARLY_CLOSE if year >= 2015 else _EARLY_CLOSE_OLD
+    elif value == _last_weekday(year, 5, weekday=0):
+        early_close_name = "Memorial Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    elif year >= 2022 and value == _nearest_weekday(date(year, 6, 19)):
+        early_close_name = "Juneteenth"
+        early_close_at = _EARLY_CLOSE
+    elif value == _nearest_weekday(date(year, 7, 4)):
+        early_close_name = "Independence Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    elif value == _pre_independence_early_close(year):
+        early_close_name = "Independence Day Eve"
+        early_close_at = _EARLY_CLOSE_1215_CT
+    elif value == _nth_weekday(year, 9, weekday=0, occurrence=1):
+        early_close_name = "Labor Day"
+        early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+    else:
+        thanksgiving = _nth_weekday(year, 11, weekday=3, occurrence=4)
+        if value == thanksgiving:
+            early_close_name = "Thanksgiving Day"
+            early_close_at = _EARLY_CLOSE if year >= 2014 else _EARLY_CLOSE_OLD
+        elif value == thanksgiving + timedelta(days=1):
+            early_close_name = "Day After Thanksgiving"
+            early_close_at = _EARLY_CLOSE_1215_CT
+        elif year >= 1993 and value == date(year, 12, 24) and value.weekday() < 5:
+            early_close_name = "Christmas Eve"
+            early_close_at = _EARLY_CLOSE_1215_CT
+
+    if early_close_name is None or early_close_at is None:
+        return None
+    return FuturesHolidaySchedule(
+        early_close_name,
+        value,
+        early_close=early_close_at,
+    )
+
+
+def _uses_cme_equity_schedule(symbol: str | None) -> bool:
+    if symbol is None or not str(symbol).strip():
+        return True
+    tokens = {token for token in re.split(r"[^A-Z0-9]+", str(symbol).upper()) if token}
+    if tokens & _CME_EQUITY_ROOTS:
+        return True
+    if tokens & _KNOWN_NON_EQUITY_ROOTS:
+        return False
+    return True
+
+
+def _nth_weekday(year: int, month: int, *, weekday: int, occurrence: int) -> date:
+    first = date(year, month, 1)
+    offset = (weekday - first.weekday()) % 7
+    return first + timedelta(days=offset + 7 * (occurrence - 1))
+
+
+def _last_weekday(year: int, month: int, *, weekday: int) -> date:
+    if month == 12:
+        next_month = date(year + 1, 1, 1)
+    else:
+        next_month = date(year, month + 1, 1)
+    last = next_month - timedelta(days=1)
+    return last - timedelta(days=(last.weekday() - weekday) % 7)
+
+
+def _nearest_weekday(value: date) -> date:
+    if value.weekday() == 5:
+        return value - timedelta(days=1)
+    if value.weekday() == 6:
+        return value + timedelta(days=1)
+    return value
+
+
+def _pre_independence_early_close(year: int) -> date | None:
+    independence_day = date(year, 7, 4)
+    if independence_day.weekday() not in {1, 2, 3, 4}:
+        return None
+    return independence_day - timedelta(days=1)
+
+
+def _easter_sunday(year: int) -> date:
+    """Gregorian Easter (Meeus/Jones/Butcher), used to derive Good Friday."""
+
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    ell = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * ell) // 451
+    month = (h + ell - 7 * m + 114) // 31
+    day = ((h + ell - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
+
+
+def _add_date_safely(value: date, *, days: int) -> date:
+    try:
+        return value + timedelta(days=days)
+    except OverflowError:
+        return date.max if days >= 0 else date.min

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -34,3 +34,20 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     )
     end_local = start_local + timedelta(days=1) - timedelta(microseconds=1)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def futures_session_is_open(value: datetime) -> bool:
+    """Return whether a timestamp falls inside the regular CME Globex week."""
+
+    local = as_utc(value).astimezone(TRADING_TZ)
+    weekday = local.weekday()
+    local_time = local.time()
+    if weekday == 5:
+        return False
+    if weekday == 6 and local_time < time(hour=18):
+        return False
+    if weekday == 4 and local_time >= time(hour=17):
+        return False
+    if time(hour=17) <= local_time < time(hour=18):
+        return False
+    return True

--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -1,10 +1,30 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
+from functools import lru_cache
 from zoneinfo import ZoneInfo
 
 TRADING_TZ = ZoneInfo("America/New_York")
 TRADING_DAY_ROLLOVER_HOUR = 18
+
+_EQUITY_HALT_START = time(hour=16, minute=15)
+_EQUITY_HALT_END = time(hour=16, minute=30)
+_EARLY_CLOSE = time(hour=13)
+_DAY_AFTER_THANKSGIVING_CLOSE = time(hour=13, minute=15)
+_GOOD_FRIDAY_CLOSE = time(hour=9, minute=15)
+_CME_EQUITY_ROOTS = frozenset(
+    {"ES", "MES", "NQ", "MNQ", "YM", "MYM", "RTY", "M2K", "EMD", "MME", "NKD", "NIY"}
+)
+
+
+@dataclass(frozen=True)
+class FuturesHolidaySchedule:
+    name: str
+    trading_date: date
+    full_close: bool = False
+    early_close: time | None = None
 
 
 def as_utc(value: datetime) -> datetime:
@@ -36,8 +56,13 @@ def trading_day_bounds_utc(value: date) -> tuple[datetime, datetime]:
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
 
 
-def futures_session_is_open(value: datetime) -> bool:
-    """Return whether a timestamp falls inside the regular CME Globex week."""
+def futures_session_is_open(value: datetime, *, symbol: str | None = None) -> bool:
+    """Return whether a timestamp falls inside the scheduled CME futures session.
+
+    The common Globex week is used for unknown products. Known equity-index
+    roots additionally honor the daily 16:15-16:30 ET halt and modern recurring
+    CME holiday closures, avoiding false candle-gap repairs during closures.
+    """
 
     local = as_utc(value).astimezone(TRADING_TZ)
     weekday = local.weekday()
@@ -50,4 +75,120 @@ def futures_session_is_open(value: datetime) -> bool:
         return False
     if time(hour=17) <= local_time < time(hour=18):
         return False
+    if not _uses_cme_equity_schedule(symbol):
+        return True
+
+    trading_date = trading_day_date(value)
+    holiday = _cme_equity_holiday_schedule(trading_date)
+    if holiday is not None and holiday.full_close:
+        return False
+    if local.date() == trading_date:
+        close_time = holiday.early_close if holiday and holiday.early_close else time(hour=17)
+        if local_time >= close_time:
+            return False
+        if _EQUITY_HALT_START <= local_time < _EQUITY_HALT_END:
+            return False
     return True
+
+
+def futures_holiday_schedule(value: date, *, symbol: str | None = None) -> FuturesHolidaySchedule | None:
+    if not _uses_cme_equity_schedule(symbol):
+        return None
+    return _cme_equity_holiday_schedule(value)
+
+
+def _uses_cme_equity_schedule(symbol: str | None) -> bool:
+    if symbol is None or not str(symbol).strip():
+        return False
+    tokens = {token for token in re.split(r"[^A-Z0-9]+", str(symbol).upper()) if token}
+    return bool(tokens & _CME_EQUITY_ROOTS)
+
+
+@lru_cache(maxsize=1_024)
+def _cme_equity_holiday_schedule(value: date) -> FuturesHolidaySchedule | None:
+    """Recurring CME equity-index exceptions for the modern schedule regime."""
+
+    year = value.year
+    new_year = date(year, 1, 1)
+    observed_new_year = new_year + timedelta(days=1) if new_year.weekday() == 6 else new_year
+    if value == observed_new_year:
+        return FuturesHolidaySchedule("New Year's Day", value, full_close=True)
+
+    if value == _nearest_weekday(date(year, 12, 25)):
+        return FuturesHolidaySchedule("Christmas", value, full_close=True)
+
+    if value == _easter_sunday(year) - timedelta(days=2):
+        return FuturesHolidaySchedule("Good Friday", value, early_close=_GOOD_FRIDAY_CLOSE)
+
+    early_close_name: str | None = None
+    if value == _nth_weekday(year, 1, weekday=0, occurrence=3):
+        early_close_name = "Martin Luther King Jr. Day"
+    elif value == _nth_weekday(year, 2, weekday=0, occurrence=3):
+        early_close_name = "Presidents Day"
+    elif value == _last_weekday(year, 5, weekday=0):
+        early_close_name = "Memorial Day"
+    elif year >= 2022 and value == _nearest_weekday(date(year, 6, 19)):
+        early_close_name = "Juneteenth"
+    elif value == _nearest_weekday(date(year, 7, 4)):
+        early_close_name = "Independence Day"
+    elif value == _nth_weekday(year, 9, weekday=0, occurrence=1):
+        early_close_name = "Labor Day"
+    else:
+        thanksgiving = _nth_weekday(year, 11, weekday=3, occurrence=4)
+        if value == thanksgiving:
+            early_close_name = "Thanksgiving Day"
+        elif value == thanksgiving + timedelta(days=1):
+            return FuturesHolidaySchedule(
+                "Day After Thanksgiving",
+                value,
+                early_close=_DAY_AFTER_THANKSGIVING_CLOSE,
+            )
+        elif value == date(year, 12, 24) and value.weekday() < 5:
+            return FuturesHolidaySchedule(
+                "Christmas Eve",
+                value,
+                early_close=_DAY_AFTER_THANKSGIVING_CLOSE,
+            )
+
+    if early_close_name is None:
+        return None
+    return FuturesHolidaySchedule(early_close_name, value, early_close=_EARLY_CLOSE)
+
+
+def _nth_weekday(year: int, month: int, *, weekday: int, occurrence: int) -> date:
+    first = date(year, month, 1)
+    offset = (weekday - first.weekday()) % 7
+    return first + timedelta(days=offset + 7 * (occurrence - 1))
+
+
+def _last_weekday(year: int, month: int, *, weekday: int) -> date:
+    next_month = date(year + (month == 12), 1 if month == 12 else month + 1, 1)
+    last = next_month - timedelta(days=1)
+    return last - timedelta(days=(last.weekday() - weekday) % 7)
+
+
+def _nearest_weekday(value: date) -> date:
+    if value.weekday() == 5:
+        return value - timedelta(days=1)
+    if value.weekday() == 6:
+        return value + timedelta(days=1)
+    return value
+
+
+def _easter_sunday(year: int) -> date:
+    # Anonymous Gregorian algorithm.
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    l = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * l) // 451
+    month = (h + l - 7 * m + 114) // 31
+    day = ((h + l - 7 * m + 114) % 31) + 1
+    return date(year, month, day)

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -772,6 +772,24 @@ def test_insufficient_closed_data_is_rejected_and_partial_bars_are_never_replaye
     assert any("Excluded 1 partial candle" in warning for warning in result["warnings"])
 
 
+def test_input_fingerprints_exclude_effectively_partial_cached_bars():
+    premature = _candle(BASE_TIME)
+    premature.fetched_at = BASE_TIME + timedelta(minutes=1)
+    premature.raw_payload = {"t": BASE_TIME.isoformat()}
+    closed = _candle(BASE_TIME + timedelta(minutes=5))
+    closed.fetched_at = BASE_TIME + timedelta(minutes=10)
+    closed.raw_payload = {"t": closed.candle_timestamp.isoformat()}
+
+    assert backtesting_module.candle_input_fingerprint(
+        [premature, closed]
+    ) == backtesting_module.candle_input_fingerprint([closed])
+    assert backtesting_module.candle_stream_input_fingerprint(
+        {"asset:minute:5": [premature, closed]}
+    ) == backtesting_module.candle_stream_input_fingerprint(
+        {"asset:minute:5": [closed]}
+    )
+
+
 @pytest.mark.parametrize(
     ("bars", "error_fragment"),
     [
@@ -1160,6 +1178,196 @@ def test_topbot_cache_preparation_skips_streams_that_already_cover_the_replay(
     assert prepared == 0
 
 
+def test_topbot_cache_preparation_refetches_a_truncated_primary_stream(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["sma_cross"]},
+        lookback_bars=25,
+    )
+    db_session.add_all(
+        [
+            _candle(BASE_TIME),
+            _candle(BASE_TIME + timedelta(minutes=5)),
+        ]
+    )
+    db_session.commit()
+    fetches: list[dict[str, Any]] = []
+
+    def record_fetch(*_args, **kwargs):
+        fetches.append(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "fetch_and_store_market_candles",
+        record_fetch,
+    )
+
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+        ),
+        client=object(),
+    )
+
+    assert prepared == 1
+    assert len(fetches) == 1
+    assert fetches[0]["contract_id"] == CONTRACT_ID
+
+
+@pytest.mark.parametrize(
+    "execution_offsets",
+    [
+        [5, 10, 15],
+        [0, 5, 10],
+    ],
+    ids=["leading-bar", "trailing-bar"],
+)
+def test_primary_cache_coverage_rejects_one_missing_boundary_bar(
+    db_session,
+    monkeypatch,
+    execution_offsets,
+):
+    monkeypatch.setattr(
+        backtesting_module,
+        "_cached_replay_stream_covers",
+        lambda *_args, **_kwargs: True,
+    )
+    execution_rows = [
+        _candle(BASE_TIME + timedelta(minutes=offset))
+        for offset in execution_offsets
+    ]
+
+    assert not backtesting_module._cached_primary_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="minute",
+        unit_number=5,
+        fetch_start=BASE_TIME - timedelta(days=1),
+        requested_start=BASE_TIME,
+        requested_end=BASE_TIME + timedelta(minutes=20),
+        warmup_bars=1,
+        execution_rows=execution_rows,
+    )
+
+
+def test_topbot_cache_preparation_pages_the_entire_provider_range(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["sma_cross"]},
+        lookback_bars=25,
+    )
+    primary_key = backtesting_module._topbot_asset_stream_key("minute", 5)
+    primary_spec = backtesting_module._TopBotReplayStreamSpec(
+        key=primary_key,
+        unit="minute",
+        unit_number=5,
+        warmup_bars=1,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+    )
+    fetches: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_topbot_stream_specs",
+        lambda _config: {primary_key: primary_spec},
+    )
+    monkeypatch.setattr(backtesting_module, "MAX_PROVIDER_FETCH_BARS", 20)
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "fetch_and_store_market_candles",
+        lambda *_args, **kwargs: fetches.append(kwargs) or [],
+    )
+
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=50),
+        ),
+        client=object(),
+    )
+
+    assert prepared == 1
+    assert len(fetches) == 5
+    assert fetches[0]["start"] == BASE_TIME - timedelta(minutes=375)
+    assert fetches[-1]["end"] == BASE_TIME + timedelta(minutes=50)
+    assert all(call["limit"] == 20 for call in fetches)
+    assert all(
+        current["start"] == previous["end"]
+        for previous, current in zip(fetches, fetches[1:])
+    )
+
+
+def test_topbot_replay_loader_queries_a_shared_benchmark_identity_once(db_session):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+    benchmark_rows = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id="CON.F.US.MES.M26",
+            symbol="F.US.MES",
+        )
+        for index in range(-3, 2)
+    ]
+    db_session.add_all(benchmark_rows)
+    db_session.commit()
+    select_count = 0
+
+    def count_candle_selects(_conn, _cursor, statement, _parameters, _context, _many):
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT") and "projectx_market_candles" in statement:
+            select_count += 1
+
+    from sqlalchemy import event
+
+    event.listen(db_session.bind, "before_cursor_execute", count_candle_selects)
+    try:
+        streams = backtesting_module._load_topbot_replay_streams(
+            db_session,
+            user_id=OWNER_ID,
+            config=config,
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=10),
+            primary_rows=[_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))],
+        )
+    finally:
+        event.remove(db_session.bind, "before_cursor_execute", count_candle_selects)
+
+    left = streams[
+        backtesting_module._topbot_benchmark_stream_key("atr_adjusted_relative_strength")
+    ]
+    right = streams[
+        backtesting_module._topbot_benchmark_stream_key("relative_strength_spy")
+    ]
+    assert left is right
+    assert select_count == 2
+
+
 def test_topbot_cache_coverage_rejects_overlapping_candles(db_session):
     canonical = [
         _candle(
@@ -1188,6 +1396,52 @@ def test_topbot_cache_coverage_rejects_overlapping_candles(db_session):
         first_event=BASE_TIME + timedelta(minutes=5),
         last_event=BASE_TIME + timedelta(minutes=10),
         warmup_bars=25,
+    )
+
+
+def test_topbot_cache_coverage_rejects_an_open_session_gap(db_session):
+    db_session.add_all(
+        [
+            _candle(BASE_TIME - timedelta(minutes=5)),
+            _candle(BASE_TIME),
+            _candle(BASE_TIME + timedelta(minutes=10)),
+        ]
+    )
+    db_session.commit()
+
+    assert not backtesting_module._cached_replay_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="minute",
+        unit_number=5,
+        fetch_start=BASE_TIME - timedelta(minutes=5),
+        requested_start=BASE_TIME,
+        first_event=BASE_TIME + timedelta(minutes=5),
+        last_event=BASE_TIME + timedelta(minutes=15),
+        warmup_bars=1,
+    )
+
+
+def test_topbot_cache_coverage_accepts_a_weekend_market_closure(db_session):
+    friday_tail = _candle(datetime(2026, 7, 10, 20, 55, tzinfo=timezone.utc))
+    sunday_open = _candle(datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc))
+    for row in (friday_tail, sunday_open):
+        row.raw_payload = {"isPartial": False}
+    db_session.add_all([friday_tail, sunday_open])
+    db_session.commit()
+
+    assert backtesting_module._cached_replay_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="minute",
+        unit_number=5,
+        fetch_start=friday_tail.candle_timestamp,
+        requested_start=sunday_open.candle_timestamp,
+        first_event=_utc(sunday_open.candle_timestamp) + timedelta(minutes=5),
+        last_event=_utc(sunday_open.candle_timestamp) + timedelta(minutes=5),
+        warmup_bars=1,
     )
 
 
@@ -1625,6 +1879,37 @@ def test_authenticated_route_reuses_real_strategy_and_never_routes_orders(
     assert response["assumptions"]["live_order_routing"] == "disabled_by_architecture"
     assert evaluator_calls
     assert db_session.query(BotBacktest).count() == 1
+
+
+def test_authenticated_backtest_rejects_the_bar_cap_instead_of_truncating(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100 + index)
+            for index in range(4)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(backtesting_module, "MAX_BACKTEST_BARS", 3)
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_bar_limit_exceeded: maximum is 3",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=20),
+            ),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
 
 
 def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -2009,4 +2011,308 @@ def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history
         .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
         .count()
         == 30
+    )
+
+
+def test_prepared_sma_replay_exactly_matches_legacy_evaluator_path():
+    prices = [
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+    ]
+    candles = backtesting_module._ClosedCandleList(
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            open_price=price - 0.25,
+            high_price=price + 0.75,
+            low_price=price - 0.75,
+            close_price=price,
+        )
+        for index, price in enumerate(prices)
+    )
+    config = _config(
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=8,
+        max_trades_per_day=2,
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(candles))
+    run_options = {
+        "config": config,
+        "start": start,
+        "end": end,
+        "starting_balance": 25_000,
+        "commission_per_contract": 1.25,
+        "slippage_ticks": 1.5,
+        "tick_size": 0.25,
+        "tick_value": 0.50,
+    }
+
+    optimized = _run(candles, **run_options)
+    legacy_calls = 0
+
+    def legacy_evaluator(rows: list[ProjectXMarketCandle]) -> SignalResult:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return bot_service_module.evaluate_sma_cross(
+            rows,
+            fast_period=int(config.fast_period),
+            slow_period=int(config.slow_period),
+        )
+
+    legacy = _run(candles, evaluator=legacy_evaluator, **run_options)
+
+    assert legacy_calls == optimized["range"]["bar_count"]
+    assert optimized["trades"]
+    assert any(float(trade["commission"]) > 0 for trade in optimized["trades"])
+    assert any("max trades per day" in warning for warning in optimized["warnings"])
+    for key in (
+        "range",
+        "metrics",
+        "equity_curve",
+        "drawdown_series",
+        "daily_results",
+        "monthly_results",
+        "trades",
+        "warnings",
+    ):
+        assert optimized[key] == legacy[key]
+    assert optimized == legacy
+
+
+def test_incremental_fingerprints_match_legacy_canonical_json_for_unsorted_streams():
+    primary = [
+        _candle(BASE_TIME + timedelta(minutes=10), close_price=103.25),
+        _candle(BASE_TIME, close_price=101.25),
+        _candle(
+            BASE_TIME + timedelta(minutes=5),
+            close_price=102.25,
+            is_partial=True,
+        ),
+    ]
+    hourly = [
+        _candle(
+            BASE_TIME - timedelta(hours=1),
+            unit="hour",
+            unit_number=1,
+            close_price=99.5,
+        ),
+        _candle(
+            BASE_TIME - timedelta(hours=2),
+            unit="hour",
+            unit_number=1,
+            close_price=98.5,
+        ),
+    ]
+    streams = {"z-primary": primary, "a-hourly": hourly}
+
+    def canonical_row(
+        row: ProjectXMarketCandle,
+        *,
+        stream: str | None = None,
+    ) -> dict[str, Any]:
+        canonical = {
+            "contract_id": str(row.contract_id),
+            "live": bool(row.live),
+            "unit": str(row.unit),
+            "unit_number": int(row.unit_number),
+            "timestamp": _utc(row.candle_timestamp).isoformat(),
+            "open": str(row.open_price),
+            "high": str(row.high_price),
+            "low": str(row.low_price),
+            "close": str(row.close_price),
+            "volume": str(row.volume),
+            "is_partial": bool(row.is_partial),
+        }
+        if stream is not None:
+            canonical = {"stream": stream, **canonical}
+        return canonical
+
+    def legacy_digest(rows: list[dict[str, Any]]) -> str:
+        encoded = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return hashlib.sha256(encoded).hexdigest()
+
+    expected_primary = legacy_digest(
+        [
+            canonical_row(row)
+            for row in sorted(primary, key=lambda value: _utc(value.candle_timestamp))
+            if not bool(row.is_partial)
+        ]
+    )
+    expected_streams = legacy_digest(
+        [
+            canonical_row(row, stream=key)
+            for key in sorted(streams)
+            for row in sorted(
+                streams[key],
+                key=lambda value: _utc(value.candle_timestamp),
+            )
+            if not bool(row.is_partial)
+        ]
+    )
+
+    assert backtesting_module.candle_input_fingerprint(primary) == expected_primary
+    assert (
+        backtesting_module.candle_stream_input_fingerprint(streams)
+        == expected_streams
+    )
+
+
+def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
+    bar_count = backtesting_module.MAX_BACKTEST_BARS + 1
+    oldest = BASE_TIME - timedelta(days=400)
+    candles = backtesting_module._ClosedCandleList(
+        [
+            _candle(oldest, close_price=100),
+            *[
+                _candle(
+                    BASE_TIME + timedelta(minutes=5 * index),
+                    close_price=100 + (index % 3),
+                )
+                for index in range(bar_count - 1)
+            ],
+        ]
+    )
+
+    result = _run(candles, evaluator=_hold)
+
+    assert candles[-1].candle_timestamp - candles[0].candle_timestamp > timedelta(
+        days=366
+    )
+    assert result["range"]["bar_count"] == bar_count
+    assert result["range"]["start"] == oldest.isoformat()
+    assert len(result["equity_curve"]) == bar_count + 1
+    assert len(result["drawdown_series"]) == bar_count + 1
+    assert result["metrics"]["trade_count"] == 0
+
+
+def test_resource_budget_failure_occurs_before_backtest_persistence(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+            for index in range(6)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(backtesting_module, "BACKTEST_MEMORY_BUDGET_BYTES", 1)
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_resource_budget_exceeded.*no partial result was saved",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=int(config.id),
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=30),
+            ),
+            now=BASE_TIME + timedelta(minutes=35),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_projected_loader_avoids_candle_identities_and_matches_orm_replay(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=25,
+    )
+    prices = [100, 99, 98, 97, 98, 99, 100, 99, 98, 97, 98, 99]
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                open_price=price - 0.25,
+                close_price=price,
+            )
+            for index, price in enumerate(prices)
+        ]
+    )
+    db_session.commit()
+    config_id = int(config.id)
+    db_session.expunge_all()
+    loaded_config = db_session.query(BotConfig).filter(BotConfig.id == config_id).one()
+
+    projected = backtesting_module._load_primary_closed_candles(
+        db_session,
+        user_id=OWNER_ID,
+        config=loaded_config,
+        closed_by=BASE_TIME + timedelta(minutes=5 * len(prices)),
+    )
+
+    assert projected
+    assert all(type(row) is backtesting_module._ProjectedCandle for row in projected)
+    assert not any(
+        isinstance(value, ProjectXMarketCandle)
+        for value in db_session.identity_map.values()
+    )
+
+    orm_rows = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == OWNER_ID)
+        .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(prices))
+
+    assert backtesting_module.candle_input_fingerprint(
+        projected
+    ) == backtesting_module.candle_input_fingerprint(orm_rows)
+    assert _run(
+        projected,
+        config=loaded_config,
+        start=start,
+        end=end,
+    ) == _run(
+        orm_rows,
+        config=loaded_config,
+        start=start,
+        end=end,
     )

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -767,6 +767,29 @@ def test_malformed_candle_streams_are_rejected(bars, error_fragment: str):
         _run(bars, evaluator=_hold)
 
 
+def test_backtest_gap_detection_ignores_futures_weekend_and_maintenance():
+    friday_close = datetime(2026, 4, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 4, 12, 22, 0, tzinfo=timezone.utc)
+    maintenance_close = datetime(2026, 4, 13, 20, 55, tzinfo=timezone.utc)
+    maintenance_reopen = datetime(2026, 4, 13, 22, 0, tzinfo=timezone.utc)
+
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(friday_close), _candle(sunday_open)],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(maintenance_close), _candle(maintenance_reopen)],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=10))],
+        expected_seconds=5 * 60,
+        symbol="MNQ",
+    ) == 1
+
+
 def test_unsupported_strategy_fails_explicitly_without_approximation():
     bars = [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))]
 
@@ -1036,6 +1059,151 @@ def test_orb_rejects_an_incompatible_non_minute_timeframe():
             evaluator=_hold,
             end=BASE_TIME + timedelta(hours=2),
         )
+
+
+def test_backtest_route_repairs_missing_execution_bar_before_replay(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    timestamps = [
+        BASE_TIME - timedelta(minutes=10),
+        BASE_TIME - timedelta(minutes=5),
+        BASE_TIME,
+        BASE_TIME + timedelta(minutes=10),
+        BASE_TIME + timedelta(minutes=15),
+    ]
+    db_session.add_all(
+        [_candle(timestamp, close_price=100 + index) for index, timestamp in enumerate(timestamps)]
+    )
+    db_session.commit()
+
+    authoritative_timestamps = [
+        BASE_TIME - timedelta(minutes=10),
+        BASE_TIME - timedelta(minutes=5),
+        BASE_TIME,
+        BASE_TIME + timedelta(minutes=5),
+        BASE_TIME + timedelta(minutes=10),
+        BASE_TIME + timedelta(minutes=15),
+    ]
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return [
+                {
+                    "timestamp": timestamp,
+                    "open": 100 + index,
+                    "high": 101 + index,
+                    "low": 99 + index,
+                    "close": 100 + index,
+                    "volume": 10,
+                }
+                for index, timestamp in enumerate(authoritative_timestamps)
+                if kwargs["start"] <= timestamp <= kwargs["end"]
+            ]
+
+    client = StubClient()
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
+
+    response = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        db=db_session,
+    )
+
+    assert len(client.calls) == 1
+    assert response["range"]["bar_count"] == 4
+    repaired = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.candle_timestamp == BASE_TIME + timedelta(minutes=5))
+        .one()
+    )
+    assert float(repaired.close_price) == 103.0
+    assert db_session.query(BotBacktest).count() == 1
+
+
+def test_backtest_route_does_not_persist_when_integrity_remains_unresolved(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(BASE_TIME - timedelta(minutes=10)),
+            _candle(BASE_TIME - timedelta(minutes=5)),
+            _candle(BASE_TIME, high_price=99, low_price=98, close_price=100),
+            _candle(BASE_TIME + timedelta(minutes=5)),
+        ]
+    )
+    db_session.commit()
+
+    class EmptyClient:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            return []
+
+    client = EmptyClient()
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main_module.create_trading_bot_backtest(
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=10),
+            ),
+            db=db_session,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "candle_integrity_unresolved" in str(exc_info.value.detail)
+    assert client.calls == 1
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_topbot_backtest_preflight_repairs_every_required_stream(db_session, monkeypatch):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": ["support_resistance"],
+            "minimum_directional_votes": 1,
+            "minimum_score": 70,
+            "minimum_reward_risk": 1.5,
+        },
+    )
+    observed: list[tuple[str, int]] = []
+
+    def record_ensure(*_args, **kwargs):
+        observed.append((kwargs["unit"], kwargs["unit_number"]))
+        assert kwargs["strict_integrity"] is True
+        return []
+
+    monkeypatch.setattr(backtesting_module.bot_service_module, "ensure_market_candles", record_ensure)
+
+    backtesting_module._ensure_backtest_candle_integrity(
+        db_session,
+        user_id=OWNER_ID,
+        config=config,
+        client=object(),
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=20),
+        primary_warmup_bars=25,
+    )
+
+    assert observed == [("minute", 5), ("hour", 4), ("hour", 1)]
 
 
 def test_authenticated_route_reuses_real_strategy_and_never_routes_orders(

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -1666,8 +1666,21 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
             raw_payload={"stop_loss": price - 10, "take_profit": price + 20},
         )
 
-    def unexpected_provider_call(*_args, **_kwargs):
-        raise AssertionError("TopBot backtest invoked a provider path")
+    class StubHistoryClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("configured deliveries must not be re-resolved")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return []
+
+    history_client = StubHistoryClient()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("TopBot backtest invoked an order path")
 
     monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
     monkeypatch.setattr(backtesting_module.bot_service_module, "dispatch_strategy_evaluator", fake_dispatch)
@@ -1678,10 +1691,11 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
         lambda **_kwargs: {"total_score": 85},
     )
     monkeypatch.setattr(
-        ProjectXClient,
-        "from_env",
-        classmethod(lambda cls: unexpected_provider_call()),
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: history_client,
     )
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
     payload = BotBacktestIn(
         start=BASE_TIME,
         end=BASE_TIME + timedelta(minutes=20),
@@ -1696,9 +1710,11 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
     )
     first_validated = BotBacktestOut.model_validate(first)
 
-    assert first_validated.engine_version == "1.2.0"
+    assert first_validated.engine_version == "1.3.0"
     assert first_validated.metrics.trade_count == 1
     assert not any("strategy_not_supported" in warning for warning in first["warnings"])
+    assert history_client.calls
+    assert all(call["contract_id"] == CONTRACT_ID for call in history_client.calls)
 
     one_hour.close_price = 101
     one_hour.high_price = 102
@@ -1753,3 +1769,244 @@ def test_backtest_route_scopes_bots_and_candles_to_authenticated_user(
     assert hidden.value.status_code == 404
     assert hidden.value.detail == "bot_config_not_found"
     assert db_session.query(BotBacktest).count() == 0
+
+
+def test_backtest_input_uses_absent_dates_for_full_history_and_keeps_paired_bounds():
+    full_history = BotBacktestIn()
+    bounded = BotBacktestIn(
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(days=800),
+    )
+
+    assert full_history.start is None
+    assert full_history.end is None
+    assert bounded.end - bounded.start == timedelta(days=800)
+    with pytest.raises(ValueError, match="provided together"):
+        BotBacktestIn(start=BASE_TIME)
+    with pytest.raises(ValueError, match="must be after start"):
+        BotBacktestIn(start=BASE_TIME, end=BASE_TIME)
+
+    mixed_awareness = BotBacktestIn(
+        start="2026-01-01T00:00:00",
+        end="2026-01-02T00:00:00Z",
+    )
+    assert mixed_awareness.start is not None
+    assert mixed_awareness.end is not None
+
+
+def test_full_history_uses_all_fully_closed_exact_contract_bars_without_old_cap(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session, lookback_bars=25)
+    exact_rows = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100 + index)
+        for index in range(6)
+    ]
+    other_delivery = _candle(
+        BASE_TIME - timedelta(minutes=5),
+        contract_id="CON.F.US.MNQ.U26",
+        symbol="MNQ",
+    )
+    inferred_partial = _candle(BASE_TIME + timedelta(minutes=30))
+    inferred_partial.fetched_at = BASE_TIME + timedelta(minutes=32)
+    inferred_partial.raw_payload = {"t": inferred_partial.candle_timestamp.isoformat()}
+    explicit_partial = _candle(
+        BASE_TIME + timedelta(minutes=35),
+        is_partial=True,
+    )
+    not_yet_closed = _candle(
+        BASE_TIME + timedelta(minutes=40),
+    )
+    db_session.add_all(
+        [other_delivery, *exact_rows, inferred_partial, explicit_partial, not_yet_closed]
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(backtesting_module, "MAX_BACKTEST_BARS", 2)
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("backtest invoked an order path")
+
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+
+    row = backtesting_module.create_bot_backtest(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            starting_balance=25_000,
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        now=BASE_TIME + timedelta(minutes=42),
+    )
+    result = backtesting_module.serialize_bot_backtest(row)
+    validated = BotBacktestOut.model_validate(result)
+
+    hard_minimum = backtesting_module._strategy_history_bars(config, hard_minimum=True)
+    first_execution_index = hard_minimum - 1
+    expected_execution = exact_rows[first_execution_index:]
+    assert validated.range.contract_id == CONTRACT_ID
+    assert validated.range.symbol == "MNQ"
+    assert validated.range.timeframe_unit == "minute"
+    assert validated.range.timeframe_unit_number == 5
+    assert validated.range.start == _utc(expected_execution[0].candle_timestamp)
+    assert validated.range.end == backtesting_module._candle_close_time(expected_execution[-1])
+    assert validated.range.bar_count == len(expected_execution)
+    assert validated.range.bar_count > backtesting_module.MAX_BACKTEST_BARS
+    assert _utc(row.requested_start) == BASE_TIME
+    assert _utc(row.requested_end) == BASE_TIME + timedelta(minutes=30)
+    assert result["assumptions"]["live_order_routing"] == "disabled_by_architecture"
+
+
+def test_full_history_route_is_deterministic_and_has_no_public_prepare_step(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session, execution_mode="live", lookback_bars=25)
+    for index in range(6):
+        db_session.add(
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+        )
+    db_session.commit()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("full-history backtest invoked an order path")
+
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+    payload = BotBacktestIn(
+        starting_balance=25_000,
+        commission_per_contract=0,
+        slippage_ticks=0,
+    )
+
+    first = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=payload,
+        db=db_session,
+    )
+    second = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=payload,
+        db=db_session,
+    )
+    first_validated = BotBacktestOut.model_validate(first)
+
+    assert first_validated.range.contract_id == CONTRACT_ID
+    assert first_validated.range.bar_count == 4
+    assert first["range"] == second["range"]
+    assert first["metrics"] == second["metrics"]
+    assert first["input_fingerprint"] == second["input_fingerprint"]
+    assert first["assumptions"]["configured_execution_mode_was_ignored"] == "live"
+    assert "/api/bots/{bot_config_id}/backtests/prepare" not in {
+        route.path for route in main_module.app.routes
+    }
+    assert db_session.query(BotBacktest).count() == 2
+
+
+@pytest.mark.parametrize(
+    "cached_count",
+    [0, 25],
+    ids=["empty-primary-cache", "stale-primary-cache"],
+)
+def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history(
+    db_session,
+    monkeypatch,
+    cached_count,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["sma_cross"]},
+        lookback_bars=25,
+    )
+    provider_bars = [
+        {
+            "timestamp": BASE_TIME + timedelta(minutes=5 * index),
+            "open": 100 + index,
+            "high": 101 + index,
+            "low": 99 + index,
+            "close": 100 + index,
+            "volume": 100,
+            "is_partial": False,
+            "raw_payload": {"isPartial": False},
+        }
+        for index in range(30)
+    ]
+    for bar in provider_bars[:cached_count]:
+        db_session.add(
+            _candle(
+                bar["timestamp"],
+                open_price=bar["open"],
+                high_price=bar["high"],
+                low_price=bar["low"],
+                close_price=bar["close"],
+                volume=bar["volume"],
+            )
+        )
+    db_session.commit()
+
+    class StubFullHistoryClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("full-history discovery must retain the configured delivery")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            start = _utc(kwargs["start"])
+            end = _utc(kwargs["end"])
+            rows = [
+                bar
+                for bar in provider_bars
+                if start <= _utc(bar["timestamp"]) <= end
+            ]
+            return rows[-int(kwargs["limit"]):]
+
+    client = StubFullHistoryClient()
+
+    def unexpected_order_call(*_args, **_kwargs):
+        raise AssertionError("TopBot full-history replay invoked an order path")
+
+    monkeypatch.setattr(backtesting_module, "MAX_PROVIDER_FETCH_BARS", 5)
+    monkeypatch.setattr(
+        backtesting_module,
+        "_MAX_PROVIDER_EMPTY_SPAN",
+        timedelta(minutes=20),
+    )
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: client,
+    )
+    monkeypatch.setattr(bot_service_module, "_submit_order_attempt", unexpected_order_call)
+
+    response = main_module.create_trading_bot_backtest(
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            commission_per_contract=0,
+            slippage_ticks=0,
+        ),
+        db=db_session,
+    )
+    validated = BotBacktestOut.model_validate(response)
+
+    assert client.calls
+    assert all(call["contract_id"] == CONTRACT_ID for call in client.calls)
+    assert validated.range.contract_id == CONTRACT_ID
+    assert validated.range.start == BASE_TIME + timedelta(minutes=120)
+    assert validated.range.end == BASE_TIME + timedelta(minutes=150)
+    assert validated.range.bar_count == 6
+    assert (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
+        .count()
+        == 30
+    )

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -238,6 +238,55 @@ def test_signal_evaluation_receives_only_bars_closed_as_of_each_event():
     assert all(BASE_TIME + timedelta(minutes=15) not in call for call in observed)
 
 
+def test_topbot_defers_replay_when_requested_start_precedes_available_warmup():
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(30)
+    ]
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            strategy_params={"source_strategies": ["sma_cross"]},
+            lookback_bars=25,
+        ),
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=150),
+    )
+
+    assert result["range"]["start"] == (BASE_TIME + timedelta(minutes=120)).isoformat()
+    assert result["range"]["bar_count"] == 6
+    assert any("Deferred replay by 24 candle(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_only_evaluates_signals_inside_the_configured_session():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    bars = [
+        _candle(session_open + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-2, 2)
+    ]
+    evaluated: list[datetime] = []
+
+    def evaluator(candles):
+        evaluated.append(_utc(candles[-1].candle_timestamp))
+        return _hold(candles)
+
+    result = _run(
+        bars,
+        config=_config(
+            strategy_type="topbot_adaptive",
+            trading_start_time="09:30",
+            trading_end_time="15:45",
+        ),
+        evaluator=evaluator,
+        start=session_open - timedelta(minutes=10),
+        end=session_open + timedelta(minutes=10),
+    )
+
+    assert result["range"]["bar_count"] == 4
+    assert evaluated == [session_open, session_open + timedelta(minutes=5)]
+
+
 def test_orb_evaluator_keeps_the_true_session_open_beyond_configured_lookback():
     session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
     bars = [
@@ -948,7 +997,472 @@ def test_topbot_replay_records_missing_auxiliary_stream_as_source_failure():
 
     assert result["metrics"]["trade_count"] == 0
     assert any("asset:hour:1" in warning for warning in result["warnings"])
-    assert any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert not any("TopBot source support_resistance failed" in warning for warning in result["warnings"])
+    assert any("TopBot excluded source(s)" in warning for warning in result["warnings"])
+
+
+def test_topbot_replay_excludes_a_benchmark_that_stops_before_the_replay_tail(
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": ["atr_adjusted_relative_strength"],
+            "minimum_directional_votes": 1,
+        },
+        lookback_bars=25,
+    )
+    bars = [
+        _candle(BASE_TIME + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 4)
+    ]
+    benchmark = _candle(
+        BASE_TIME - timedelta(minutes=5),
+        contract_id="CON.F.US.MES.M26",
+        symbol="F.US.MES",
+    )
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"stale source {identifier} should have been excluded")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(minutes=20),
+        replay_streams={
+            backtesting_module._topbot_benchmark_stream_key(
+                "atr_adjusted_relative_strength"
+            ): [benchmark],
+        },
+    )
+
+    assert result["metrics"]["trade_count"] == 0
+    assert any(
+        "benchmark:atr_adjusted_relative_strength" in warning
+        and "TopBot excluded source(s)" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_benchmark_specs_use_mes_with_the_asset_delivery():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+            "source_strategy_params": {
+                "atr_adjusted_relative_strength": {"benchmark_symbol": "SPY"},
+                "relative_strength_spy": {"benchmark_symbol": "SPY"},
+            },
+        },
+        contract_id="CON.F.US.MNQ.M26",
+    )
+
+    specs = backtesting_module._topbot_stream_specs(config)
+
+    for source in ("atr_adjusted_relative_strength", "relative_strength_spy"):
+        spec = specs[backtesting_module._topbot_benchmark_stream_key(source)]
+        assert spec.contract_id == "CON.F.US.MES.M26"
+        assert spec.symbol == "F.US.MES"
+        assert spec.unit == "minute"
+        assert spec.unit_number == 5
+
+
+def test_topbot_cache_preparation_deduplicates_shared_mes_benchmark(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+
+    class StubClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def search_contracts(self, **_kwargs):
+            raise AssertionError("exact historical deliveries should not be re-resolved")
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return []
+
+    client = StubClient()
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=20),
+        ),
+        client=client,
+    )
+
+    assert prepared == 2
+    assert {call["contract_id"] for call in client.calls} == {
+        CONTRACT_ID,
+        "CON.F.US.MES.M26",
+    }
+    assert sum(call["contract_id"] == "CON.F.US.MES.M26" for call in client.calls) == 1
+
+
+def test_topbot_cache_preparation_skips_streams_that_already_cover_the_replay(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+        lookback_bars=25,
+    )
+    db_session.add_all([_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))])
+    db_session.commit()
+
+    class UnexpectedClient:
+        def retrieve_bars(self, **_kwargs):
+            raise AssertionError("covered streams should not be fetched again")
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_cached_replay_stream_covers",
+        lambda *_args, **_kwargs: True,
+    )
+
+    prepared = backtesting_module.prepare_bot_backtest_data(
+        db_session,
+        user_id=OWNER_ID,
+        bot_config_id=config.id,
+        payload=BotBacktestIn(
+            start=BASE_TIME,
+            end=BASE_TIME + timedelta(minutes=10),
+        ),
+        client=UnexpectedClient(),
+    )
+
+    assert prepared == 0
+
+
+def test_topbot_cache_coverage_rejects_overlapping_candles(db_session):
+    canonical = [
+        _candle(
+            BASE_TIME - timedelta(hours=4 * index),
+            unit="hour",
+            unit_number=4,
+        )
+        for index in range(26, 0, -1)
+    ]
+    overlap = _candle(
+        BASE_TIME - timedelta(hours=6),
+        unit="hour",
+        unit_number=4,
+    )
+    db_session.add_all([*canonical, overlap])
+    db_session.commit()
+
+    assert not backtesting_module._cached_replay_stream_covers(
+        db_session,
+        user_id=OWNER_ID,
+        contract_id=CONTRACT_ID,
+        unit="hour",
+        unit_number=4,
+        fetch_start=BASE_TIME - timedelta(days=7),
+        requested_start=BASE_TIME,
+        first_event=BASE_TIME + timedelta(minutes=5),
+        last_event=BASE_TIME + timedelta(minutes=10),
+        warmup_bars=25,
+    )
+
+
+def test_topbot_replay_excludes_legacy_unmarked_four_hour_tail_snapshot():
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["support_resistance"]},
+    )
+    fetched_after_close = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    canonical = [
+        _candle(
+            timestamp,
+            unit="hour",
+            unit_number=4,
+        )
+        for timestamp in (
+            datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        )
+    ]
+    for row in canonical:
+        row.fetched_at = fetched_after_close
+        row.raw_payload = {"t": row.candle_timestamp.isoformat()}
+    stale_tail = _candle(
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        unit="hour",
+        unit_number=4,
+    )
+    stale_tail.fetched_at = datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc)
+    stale_tail.raw_payload = {"t": stale_tail.candle_timestamp.isoformat()}
+    spec = backtesting_module._topbot_stream_specs(config)[
+        backtesting_module._topbot_asset_stream_key("hour", 4)
+    ]
+
+    rows, excluded = backtesting_module._validate_topbot_replay_stream(
+        [canonical[0], stale_tail, canonical[1]],
+        spec=spec,
+        config=config,
+    )
+
+    assert [_utc(row.candle_timestamp) for row in rows] == [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+    ]
+    assert excluded == 1
+
+
+def test_topbot_cache_preparation_rejects_monthly_primary_candles(db_session):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        timeframe_unit="month",
+        timeframe_unit_number=1,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="TopBot Adaptive does not support month candles",
+    ):
+        backtesting_module.prepare_bot_backtest_data(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=config.id,
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(days=31),
+            ),
+            client=object(),
+        )
+
+
+@pytest.mark.parametrize(
+    "event_start",
+    [
+        datetime(2026, 7, 6, 13, 20, tzinfo=timezone.utc),  # Before 09:30 ET.
+        datetime(2026, 7, 6, 20, 0, tzinfo=timezone.utc),   # After 15:45 ET.
+        datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc),   # Sunday.
+    ],
+)
+def test_topbot_orb_skips_events_outside_the_configured_session(
+    event_start,
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert not any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_does_not_dispatch_during_a_sunday_closure(monkeypatch):
+    event_start = datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        _candle(event_start + timedelta(minutes=5 * index), close_price=100)
+        for index in range(-25, 2)
+    ]
+    one_minute = [
+        _candle(
+            event_start + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(10)
+    ]
+
+    def unexpected_dispatch(identifier, *_args, **_kwargs):
+        raise AssertionError(f"closed-session source {identifier} should not be dispatched")
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        unexpected_dispatch,
+    )
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_orb_still_reports_a_genuinely_missing_session_open():
+    event_start = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["orb_fibonacci_pullback"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(event_start - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(event_start),
+        _candle(event_start + timedelta(minutes=5)),
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=event_start,
+        end=event_start + timedelta(minutes=10),
+    )
+
+    assert any(
+        "TopBot source orb_fibonacci_pullback failed" in warning
+        and "requires the session-opening candle" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_topbot_delayed_orb_excludes_a_truncated_one_minute_tail():
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["delayed_orb_confirmation"]},
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="15:45",
+    )
+    bars = [
+        *[
+            _candle(session_open - timedelta(days=1) + timedelta(minutes=5 * index))
+            for index in range(25)
+        ],
+        _candle(session_open),
+        _candle(session_open + timedelta(minutes=5)),
+    ]
+    one_minute = [
+        _candle(
+            session_open + timedelta(minutes=index),
+            unit="minute",
+            unit_number=1,
+        )
+        for index in range(5)
+    ]
+
+    result = _run(
+        bars,
+        config=config,
+        start=session_open,
+        end=session_open + timedelta(minutes=10),
+        replay_streams={
+            backtesting_module._topbot_asset_stream_key("minute", 1): one_minute,
+        },
+    )
+
+    assert any(
+        "TopBot excluded source(s)" in warning
+        and "delayed_orb_confirmation (asset:minute:1)" in warning
+        for warning in result["warnings"]
+    )
+    assert not any(
+        "TopBot source delayed_orb_confirmation failed" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_futures_gap_detection_ignores_weekends_but_flags_open_session_holes():
+    friday_close = datetime(2026, 7, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)
+    weekend_rows = [_candle(friday_close), _candle(sunday_open)]
+    open_session_rows = [
+        _candle(BASE_TIME),
+        _candle(BASE_TIME + timedelta(minutes=10)),
+    ]
+
+    assert backtesting_module._count_futures_session_gaps(
+        weekend_rows,
+        interval_seconds=300,
+    ) == 0
+    assert backtesting_module._count_futures_session_gaps(
+        open_session_rows,
+        interval_seconds=300,
+    ) == 1
+
+
+def test_backtest_range_reports_actual_stored_coverage():
+    bars = [_candle(BASE_TIME), _candle(BASE_TIME + timedelta(minutes=5))]
+
+    result = _run(
+        bars,
+        evaluator=_hold,
+        start=BASE_TIME,
+        end=BASE_TIME + timedelta(days=1),
+    )
+
+    assert result["range"]["start"] == BASE_TIME.isoformat()
+    assert result["range"]["end"] == (BASE_TIME + timedelta(minutes=10)).isoformat()
+    assert any("Stored candles ended before the requested end" in warning for warning in result["warnings"])
 
 
 def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
@@ -977,11 +1491,14 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             raw_payload={},
         )
 
-    benchmark = _candle(
-        BASE_TIME - timedelta(minutes=5),
-        contract_id="SPY",
-        symbol="SPY",
-    )
+    benchmark = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id="CON.F.US.MES.M26",
+            symbol="F.US.MES",
+        )
+        for index in range(-5, 3)
+    ]
     monkeypatch.setattr(backtesting_module.bot_service_module, "dispatch_strategy_evaluator", fake_dispatch)
 
     result = _run(
@@ -991,7 +1508,12 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
         end=BASE_TIME + timedelta(minutes=15),
         replay_streams={
             backtesting_module._topbot_asset_stream_key("minute", 1): [
-                _candle(BASE_TIME, unit="minute", unit_number=1)
+                _candle(
+                    BASE_TIME + timedelta(minutes=index),
+                    unit="minute",
+                    unit_number=1,
+                )
+                for index in range(15)
             ],
             backtesting_module._topbot_asset_stream_key("hour", 1): [
                 _candle(BASE_TIME - timedelta(hours=1), unit="hour", unit_number=1)
@@ -1004,10 +1526,10 @@ def test_topbot_replay_has_an_adapter_for_every_default_source(monkeypatch):
             ],
             backtesting_module._topbot_benchmark_stream_key(
                 "atr_adjusted_relative_strength"
-            ): [benchmark],
-            backtesting_module._topbot_benchmark_stream_key("relative_strength_spy"): [
-                benchmark
-            ],
+            ): benchmark,
+            backtesting_module._topbot_benchmark_stream_key(
+                "relative_strength_spy"
+            ): benchmark,
         },
     )
 
@@ -1174,7 +1696,7 @@ def test_authenticated_topbot_route_loads_and_fingerprints_synchronized_streams(
     )
     first_validated = BotBacktestOut.model_validate(first)
 
-    assert first_validated.engine_version == "1.1.0"
+    assert first_validated.engine_version == "1.2.0"
     assert first_validated.metrics.trade_count == 1
     assert not any("strategy_not_supported" in warning for warning in first["warnings"])
 

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -2297,6 +2297,66 @@ def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history
     )
 
 
+def test_topbot_full_history_fails_explicitly_before_persisting_when_provider_budget_is_exhausted(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(
+        db_session,
+        strategy_type="topbot_adaptive",
+        strategy_params={"source_strategies": ["sma_cross"]},
+        lookback_bars=25,
+    )
+    provider_bars = [
+        {
+            "timestamp": BASE_TIME + timedelta(minutes=5 * index),
+            "open": 100 + index,
+            "high": 101 + index,
+            "low": 99 + index,
+            "close": 100 + index,
+            "volume": 100,
+            "is_partial": False,
+            "raw_payload": {"isPartial": False},
+        }
+        for index in range(30)
+    ]
+
+    class StubClient:
+        def __init__(self):
+            self.calls: list[dict[str, Any]] = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            start = _utc(kwargs["start"])
+            end = _utc(kwargs["end"])
+            rows = [bar for bar in provider_bars if start <= _utc(bar["timestamp"]) <= end]
+            return rows[-int(kwargs["limit"]):]
+
+    client = StubClient()
+    monkeypatch.setattr(backtesting_module, "MAX_PROVIDER_FETCH_BARS", 2)
+    monkeypatch.setattr(backtesting_module, "MAX_BACKTEST_PROVIDER_REQUESTS", 2)
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: OWNER_ID)
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: client,
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        main_module.create_trading_bot_backtest(
+            bot_config_id=config.id,
+            payload=BotBacktestIn(),
+            db=db_session,
+        )
+
+    assert raised.value.status_code == 400
+    assert "backtest_market_data_request_limit_exceeded" in str(raised.value.detail)
+    assert "no partial backtest was saved" in str(raised.value.detail)
+    assert len(client.calls) == 2
+    assert db_session.query(BotBacktest).count() == 0
+    assert db_session.query(ProjectXMarketCandle).count() == 0
+
+
 def test_prepared_sma_replay_exactly_matches_legacy_evaluator_path():
     prices = [
         100,
@@ -2473,7 +2533,7 @@ def test_incremental_fingerprints_match_legacy_canonical_json_for_unsorted_strea
     )
 
 
-def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
+def test_replay_processes_more_than_twenty_thousand_bars_deterministically_across_over_a_year():
     bar_count = backtesting_module.MAX_BACKTEST_BARS + 1
     oldest = BASE_TIME - timedelta(days=400)
     candles = backtesting_module._ClosedCandleList(
@@ -2490,6 +2550,9 @@ def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
     )
 
     result = _run(candles, evaluator=_hold)
+    repeated = _run(candles, evaluator=_hold)
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    repeated_encoded = json.dumps(repeated, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
     assert candles[-1].candle_timestamp - candles[0].candle_timestamp > timedelta(
         days=366
@@ -2499,6 +2562,8 @@ def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
     assert len(result["equity_curve"]) == bar_count + 1
     assert len(result["drawdown_series"]) == bar_count + 1
     assert result["metrics"]["trade_count"] == 0
+    assert repeated_encoded == encoded
+    assert hashlib.sha256(repeated_encoded).hexdigest() == hashlib.sha256(encoded).hexdigest()
 
 
 def test_resource_budget_failure_occurs_before_backtest_persistence(

--- a/backend/tests/test_bot_backtesting.py
+++ b/backend/tests/test_bot_backtesting.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -2010,3 +2012,774 @@ def test_topbot_full_history_single_post_discovers_and_refreshes_primary_history
         .count()
         == 30
     )
+
+
+def test_prepared_sma_replay_exactly_matches_legacy_evaluator_path():
+    prices = [
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+        98,
+        97,
+        98,
+        99,
+        100,
+        99,
+    ]
+    candles = backtesting_module._ClosedCandleList(
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            open_price=price - 0.25,
+            high_price=price + 0.75,
+            low_price=price - 0.75,
+            close_price=price,
+        )
+        for index, price in enumerate(prices)
+    )
+    config = _config(
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=8,
+        max_trades_per_day=2,
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(candles))
+    run_options = {
+        "config": config,
+        "start": start,
+        "end": end,
+        "starting_balance": 25_000,
+        "commission_per_contract": 1.25,
+        "slippage_ticks": 1.5,
+        "tick_size": 0.25,
+        "tick_value": 0.50,
+    }
+
+    optimized = _run(candles, **run_options)
+    legacy_calls = 0
+
+    def legacy_evaluator(rows: list[ProjectXMarketCandle]) -> SignalResult:
+        nonlocal legacy_calls
+        legacy_calls += 1
+        return bot_service_module.evaluate_sma_cross(
+            rows,
+            fast_period=int(config.fast_period),
+            slow_period=int(config.slow_period),
+        )
+
+    legacy = _run(candles, evaluator=legacy_evaluator, **run_options)
+
+    assert legacy_calls == optimized["range"]["bar_count"]
+    assert optimized["trades"]
+    assert any(float(trade["commission"]) > 0 for trade in optimized["trades"])
+    assert any("max trades per day" in warning for warning in optimized["warnings"])
+    for key in (
+        "range",
+        "metrics",
+        "equity_curve",
+        "drawdown_series",
+        "daily_results",
+        "monthly_results",
+        "trades",
+        "warnings",
+    ):
+        assert optimized[key] == legacy[key]
+    assert optimized == legacy
+
+
+def test_incremental_fingerprints_match_legacy_canonical_json_for_unsorted_streams():
+    primary = [
+        _candle(BASE_TIME + timedelta(minutes=10), close_price=103.25),
+        _candle(BASE_TIME, close_price=101.25),
+        _candle(
+            BASE_TIME + timedelta(minutes=5),
+            close_price=102.25,
+            is_partial=True,
+        ),
+    ]
+    hourly = [
+        _candle(
+            BASE_TIME - timedelta(hours=1),
+            unit="hour",
+            unit_number=1,
+            close_price=99.5,
+        ),
+        _candle(
+            BASE_TIME - timedelta(hours=2),
+            unit="hour",
+            unit_number=1,
+            close_price=98.5,
+        ),
+    ]
+    streams = {"z-primary": primary, "a-hourly": hourly}
+
+    def canonical_row(
+        row: ProjectXMarketCandle,
+        *,
+        stream: str | None = None,
+    ) -> dict[str, Any]:
+        canonical = {
+            "contract_id": str(row.contract_id),
+            "live": bool(row.live),
+            "unit": str(row.unit),
+            "unit_number": int(row.unit_number),
+            "timestamp": _utc(row.candle_timestamp).isoformat(),
+            "open": str(row.open_price),
+            "high": str(row.high_price),
+            "low": str(row.low_price),
+            "close": str(row.close_price),
+            "volume": str(row.volume),
+            "is_partial": bool(row.is_partial),
+        }
+        if stream is not None:
+            canonical = {"stream": stream, **canonical}
+        return canonical
+
+    def legacy_digest(rows: list[dict[str, Any]]) -> str:
+        encoded = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return hashlib.sha256(encoded).hexdigest()
+
+    expected_primary = legacy_digest(
+        [
+            canonical_row(row)
+            for row in sorted(primary, key=lambda value: _utc(value.candle_timestamp))
+            if not bool(row.is_partial)
+        ]
+    )
+    expected_streams = legacy_digest(
+        [
+            canonical_row(row, stream=key)
+            for key in sorted(streams)
+            for row in sorted(
+                streams[key],
+                key=lambda value: _utc(value.candle_timestamp),
+            )
+            if not bool(row.is_partial)
+        ]
+    )
+
+    assert backtesting_module.candle_input_fingerprint(primary) == expected_primary
+    assert (
+        backtesting_module.candle_stream_input_fingerprint(streams)
+        == expected_streams
+    )
+
+
+def test_replay_processes_more_than_twenty_thousand_bars_across_over_a_year():
+    bar_count = backtesting_module.MAX_BACKTEST_BARS + 1
+    oldest = BASE_TIME - timedelta(days=400)
+    candles = backtesting_module._ClosedCandleList(
+        [
+            _candle(oldest, close_price=100),
+            *[
+                _candle(
+                    BASE_TIME + timedelta(minutes=5 * index),
+                    close_price=100 + (index % 3),
+                )
+                for index in range(bar_count - 1)
+            ],
+        ]
+    )
+
+    result = _run(candles, evaluator=_hold)
+
+    assert candles[-1].candle_timestamp - candles[0].candle_timestamp > timedelta(
+        days=366
+    )
+    assert result["range"]["bar_count"] == bar_count
+    assert result["range"]["start"] == oldest.isoformat()
+    assert len(result["equity_curve"]) == bar_count + 1
+    assert len(result["drawdown_series"]) == bar_count + 1
+    assert result["metrics"]["trade_count"] == 0
+
+
+def test_resource_budget_failure_occurs_before_backtest_persistence(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+            for index in range(6)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(backtesting_module, "BACKTEST_MEMORY_BUDGET_BYTES", 1)
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_resource_budget_exceeded.*no partial result was saved",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=int(config.id),
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=30),
+            ),
+            now=BASE_TIME + timedelta(minutes=35),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_projected_loader_avoids_candle_identities_and_matches_orm_replay(
+    db_session,
+):
+    config = _persist_config(
+        db_session,
+        fast_period=2,
+        slow_period=4,
+        lookback_bars=25,
+    )
+    prices = [100, 99, 98, 97, 98, 99, 100, 99, 98, 97, 98, 99]
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                open_price=price - 0.25,
+                close_price=price,
+            )
+            for index, price in enumerate(prices)
+        ]
+    )
+    db_session.commit()
+    config_id = int(config.id)
+    db_session.expunge_all()
+    loaded_config = db_session.query(BotConfig).filter(BotConfig.id == config_id).one()
+
+    projected = backtesting_module._load_primary_closed_candles(
+        db_session,
+        user_id=OWNER_ID,
+        config=loaded_config,
+        closed_by=BASE_TIME + timedelta(minutes=5 * len(prices)),
+    )
+
+    assert projected
+    assert all(type(row) is backtesting_module._ProjectedCandle for row in projected)
+    assert not any(
+        isinstance(value, ProjectXMarketCandle)
+        for value in db_session.identity_map.values()
+    )
+
+    orm_rows = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.user_id == OWNER_ID)
+        .filter(ProjectXMarketCandle.contract_id == CONTRACT_ID)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    start = BASE_TIME + timedelta(minutes=40)
+    end = BASE_TIME + timedelta(minutes=5 * len(prices))
+
+    assert backtesting_module.candle_input_fingerprint(
+        projected
+    ) == backtesting_module.candle_input_fingerprint(orm_rows)
+    assert _run(
+        projected,
+        config=loaded_config,
+        start=start,
+        end=end,
+    ) == _run(
+        orm_rows,
+        config=loaded_config,
+        start=start,
+        end=end,
+    )
+
+
+def test_topbot_cached_replay_exactly_matches_legacy_bisect_reference(
+    monkeypatch,
+):
+    session_open = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "support_resistance",
+                "liquidity_sweep_retest",
+            ],
+            "minimum_directional_votes": 1,
+            "minimum_score": 70,
+            "minimum_reward_risk": 1.5,
+        },
+        lookback_bars=25,
+        trading_start_time="09:30",
+        trading_end_time="11:30",
+    )
+    primary = backtesting_module._ClosedCandleList(
+        _candle(
+            session_open + timedelta(minutes=5 * index),
+            open_price=100,
+            high_price=101,
+            low_price=99,
+            close_price=100,
+        )
+        for index in range(-30, 27)
+    )
+    one_hour = backtesting_module._ClosedCandleList(
+        _candle(
+            datetime(2026, 7, 6, hour, tzinfo=timezone.utc),
+            unit="hour",
+            unit_number=1,
+            close_price=100 + hour / 100,
+        )
+        for hour in range(10, 15)
+    )
+    four_hour = backtesting_module._ClosedCandleList(
+        _candle(
+            datetime(2026, 7, 6, hour, tzinfo=timezone.utc),
+            unit="hour",
+            unit_number=4,
+            close_price=100 + hour / 100,
+        )
+        for hour in (6, 10)
+    )
+    active_run = {"name": "optimized"}
+    dispatch_counts = {"optimized": 0, "reference": 0}
+    observed_slow_states: dict[str, set[tuple[datetime, datetime]]] = {
+        "optimized": set(),
+        "reference": set(),
+    }
+
+    def fake_dispatch(identifier, *args, **kwargs):
+        assert identifier in {"support_resistance", "liquidity_sweep_retest"}
+        higher = kwargs["higher_timeframe_candles"]
+        lower = kwargs["lower_timeframe_candles"]
+        latest_higher = _utc(higher[-1].candle_timestamp)
+        latest_lower = _utc(lower[-1].candle_timestamp)
+        run_name = active_run["name"]
+        dispatch_counts[run_name] += 1
+        observed_slow_states[run_name].add((latest_higher, latest_lower))
+        action = "BUY" if latest_lower.hour % 2 == 0 else "SELL"
+        payload = (
+            {"stop_loss": 90.0, "take_profit": 120.0}
+            if action == "BUY"
+            else {"stop_loss": 110.0, "take_profit": 80.0}
+        )
+        return SignalResult(
+            action=action,
+            reason=f"{identifier} synchronized {action.lower()}",
+            candle_timestamp=latest_lower,
+            price=100.0,
+            raw_payload=payload,
+        )
+
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "dispatch_strategy_evaluator",
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "build_bot_market_analysis",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        backtesting_module.bot_service_module,
+        "build_signal_trade_evaluation",
+        lambda **_kwargs: {"total_score": 85},
+    )
+    run_options = {
+        "config": config,
+        "start": session_open - timedelta(minutes=10),
+        "end": session_open + timedelta(minutes=130),
+        "commission_per_contract": 1.25,
+        "slippage_ticks": 1,
+        "tick_size": 0.25,
+        "tick_value": 0.50,
+        "replay_streams": {
+            backtesting_module._topbot_asset_stream_key("hour", 1): one_hour,
+            backtesting_module._topbot_asset_stream_key("hour", 4): four_hour,
+        },
+    }
+
+    optimized = _run(primary, **run_options)
+    prepared_streams, _excluded = backtesting_module._prepare_topbot_replay_streams(
+        config,
+        primary_candles=primary,
+        replay_streams=run_options["replay_streams"],
+    )
+    in_session_events = [
+        backtesting_module._candle_close_time(row)
+        for row in primary
+        if run_options["start"] <= _utc(row.candle_timestamp)
+        and backtesting_module._candle_close_time(row) <= run_options["end"]
+        and backtesting_module._event_timestamp_is_in_configured_session(
+            config,
+            row.candle_timestamp,
+        )
+    ]
+    cached_evaluations = (
+        backtesting_module._topbot_cached_source_evaluation_counts(
+            config,
+            streams=prepared_streams,
+            event_times=in_session_events,
+            unavailable_sources={},
+        )
+    )
+    assert cached_evaluations == {
+        "support_resistance": 3,
+        "liquidity_sweep_retest": 3,
+    }
+    assert backtesting_module._estimate_topbot_evaluator_operations(
+        config,
+        execution_bars=len(in_session_events),
+        source_evaluations=cached_evaluations,
+        unavailable_sources={},
+    ) < backtesting_module._estimate_topbot_evaluator_operations(
+        config,
+        execution_bars=len(in_session_events),
+    )
+    optimized_signature = (
+        backtesting_module.BacktestEngine._topbot_source_cache_signature
+    )
+
+    def legacy_closed_count(self, key: str, event_time: datetime) -> int:
+        stream = self.topbot_streams.get(key)
+        if stream is None:
+            return 0
+        return backtesting_module.bisect_right(
+            stream.close_times,
+            _utc(event_time),
+        )
+
+    def legacy_stream_history(
+        self,
+        key: str,
+        *,
+        event_time: datetime,
+        limit: int,
+        not_before: datetime | None = None,
+    ) -> list[ProjectXMarketCandle]:
+        stream = self.topbot_streams.get(key)
+        if stream is None or not stream.candles:
+            raise ValueError(f"missing_stored_replay_stream:{key}")
+        end_index = backtesting_module.bisect_right(
+            stream.close_times,
+            _utc(event_time),
+        )
+        start_index = max(0, end_index - max(1, int(limit)))
+        if not_before is not None:
+            start_index = max(
+                start_index,
+                backtesting_module.bisect_left(
+                    stream.start_times,
+                    _utc(not_before),
+                ),
+            )
+        return backtesting_module._ClosedCandleList(
+            stream.candles[start_index:end_index]
+        )
+
+    def legacy_source_signature(
+        self,
+        source_strategy: str,
+        *,
+        source_params: dict[str, Any],
+        event_time: datetime,
+        event_timestamp: datetime,
+    ) -> tuple[Any, ...]:
+        signature = optimized_signature(
+            self,
+            source_strategy,
+            source_params=source_params,
+            event_time=event_time,
+            event_timestamp=event_timestamp,
+        )
+        return (*signature, ("uncached_primary_event", _utc(event_timestamp)))
+
+    def legacy_session_check(self, event_timestamp: datetime) -> bool:
+        return backtesting_module._event_timestamp_is_in_configured_session(
+            self.config,
+            event_timestamp,
+        )
+
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_closed_count",
+        legacy_closed_count,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_stream_history",
+        legacy_stream_history,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_topbot_source_cache_signature",
+        legacy_source_signature,
+    )
+    monkeypatch.setattr(
+        backtesting_module.BacktestEngine,
+        "_event_in_configured_session",
+        legacy_session_check,
+    )
+    active_run["name"] = "reference"
+
+    reference = _run(primary, **run_options)
+
+    assert dispatch_counts == {"optimized": 6, "reference": 50}
+    assert len(observed_slow_states["optimized"]) == 3
+    assert observed_slow_states["optimized"] == observed_slow_states["reference"]
+    assert optimized["trades"]
+    assert optimized["metrics"]["total_commission"] > 0
+    assert optimized == reference
+
+
+def test_donchian_topbot_cache_signature_tracks_position_state():
+    engine = object.__new__(backtesting_module.BacktestEngine)
+    engine._topbot_source_keys = {"donchian_breakout": ()}
+    engine.position = None
+    signature_options = {
+        "source_strategy": "donchian_breakout",
+        "source_params": {},
+        "event_time": BASE_TIME,
+        "event_timestamp": BASE_TIME,
+    }
+
+    flat_signature = engine._topbot_source_cache_signature(**signature_options)
+    engine.position = backtesting_module._OpenTrade(
+        side="long",
+        quantity=2,
+        signal_timestamp=BASE_TIME - timedelta(minutes=5),
+        entry_timestamp=BASE_TIME,
+        entry_price=100,
+        entry_commission=2.50,
+        stop_loss=90,
+        take_profit=120,
+    )
+    long_signature = engine._topbot_source_cache_signature(**signature_options)
+    engine.position.stop_loss = 95
+    adjusted_signature = engine._topbot_source_cache_signature(**signature_options)
+
+    assert flat_signature[-1] == ("position", "flat")
+    assert long_signature[-1][:3] == ("position", "long", 2)
+    assert flat_signature != long_signature
+    assert long_signature != adjusted_signature
+
+
+def test_topbot_loader_shares_one_physical_benchmark_query_group(
+    db_session,
+    monkeypatch,
+):
+    config = _config(
+        strategy_type="topbot_adaptive",
+        strategy_params={
+            "source_strategies": [
+                "atr_adjusted_relative_strength",
+                "relative_strength_spy",
+            ],
+        },
+        lookback_bars=25,
+    )
+    benchmark_contract = "CON.F.US.MES.M26"
+    benchmark_rows = [
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            contract_id=benchmark_contract,
+            symbol="F.US.MES",
+            close_price=5000 + index,
+        )
+        for index in range(-80, 5)
+    ]
+    db_session.add_all(benchmark_rows)
+    db_session.commit()
+    db_session.expunge_all()
+    primary_rows = backtesting_module._ClosedCandleList(
+        _candle(
+            BASE_TIME + timedelta(minutes=5 * index),
+            close_price=20_000 + index,
+        )
+        for index in range(-25, 4)
+    )
+    projected_query_calls = 0
+    real_projected_query = backtesting_module._projected_candle_query
+
+    def projected_query_spy(db):
+        nonlocal projected_query_calls
+        projected_query_calls += 1
+        return real_projected_query(db)
+
+    monkeypatch.setattr(
+        backtesting_module,
+        "_projected_candle_query",
+        projected_query_spy,
+    )
+    start = BASE_TIME
+    end = BASE_TIME + timedelta(minutes=20)
+
+    streams = backtesting_module._load_topbot_replay_streams(
+        db_session,
+        user_id=OWNER_ID,
+        config=config,
+        start=start,
+        end=end,
+        primary_rows=primary_rows,
+    )
+
+    atr_key = backtesting_module._topbot_benchmark_stream_key(
+        "atr_adjusted_relative_strength"
+    )
+    relative_key = backtesting_module._topbot_benchmark_stream_key(
+        "relative_strength_spy"
+    )
+    specs = backtesting_module._topbot_stream_specs(config)
+    assert specs[atr_key].warmup_bars < specs[relative_key].warmup_bars
+    assert projected_query_calls == 1
+    assert streams[atr_key]._topsignal_physical_stream == (
+        "contract",
+        benchmark_contract,
+        "minute",
+        5,
+    )
+    assert (
+        streams[atr_key]._topsignal_physical_stream
+        == streams[relative_key]._topsignal_physical_stream
+    )
+    assert (
+        streams[atr_key]._topsignal_physical_row_count
+        == streams[relative_key]._topsignal_physical_row_count
+    )
+    assert streams[atr_key][-1] is streams[relative_key][-1]
+
+    stored_rows = (
+        db_session.query(ProjectXMarketCandle)
+        .filter(ProjectXMarketCandle.contract_id == benchmark_contract)
+        .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+        .all()
+    )
+    execution_rows = [
+        row
+        for row in stored_rows
+        if _utc(row.candle_timestamp) >= start
+        and _utc(row.candle_timestamp) <= end
+        and backtesting_module._candle_close_time(row) <= end
+    ]
+    max_warmup = max(specs[atr_key].warmup_bars, specs[relative_key].warmup_bars)
+    physical_warmup = [
+        row for row in stored_rows if _utc(row.candle_timestamp) < start
+    ][-(max_warmup + 1) :]
+
+    for key in (atr_key, relative_key):
+        expected = [
+            *physical_warmup[-(specs[key].warmup_bars + 1) :],
+            *execution_rows,
+        ]
+        assert [_utc(row.candle_timestamp) for row in streams[key]] == [
+            _utc(row.candle_timestamp) for row in expected
+        ]
+        assert backtesting_module.candle_input_fingerprint(
+            streams[key]
+        ) == backtesting_module.candle_input_fingerprint(expected)
+
+    assert len(streams[atr_key]) < len(streams[relative_key])
+    assert backtesting_module.candle_input_fingerprint(
+        streams[atr_key]
+    ) != backtesting_module.candle_input_fingerprint(streams[relative_key])
+
+
+def test_evaluator_work_budget_failure_occurs_before_backtest_persistence(
+    db_session,
+    monkeypatch,
+):
+    config = _persist_config(db_session)
+    db_session.add_all(
+        [
+            _candle(
+                BASE_TIME + timedelta(minutes=5 * index),
+                close_price=100 + index,
+            )
+            for index in range(6)
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        backtesting_module,
+        "BACKTEST_EVALUATOR_WORK_BUDGET",
+        1,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_computation_limit_exceeded.*no partial result was saved",
+    ):
+        backtesting_module.create_bot_backtest(
+            db_session,
+            user_id=OWNER_ID,
+            bot_config_id=int(config.id),
+            payload=BotBacktestIn(
+                start=BASE_TIME,
+                end=BASE_TIME + timedelta(minutes=30),
+            ),
+            now=BASE_TIME + timedelta(minutes=35),
+        )
+
+    assert db_session.query(BotBacktest).count() == 0
+
+
+def test_cache_coverage_budget_includes_retained_primary_rows(
+    db_session,
+    monkeypatch,
+):
+    db_session.add(
+        _candle(
+            BASE_TIME - timedelta(hours=1),
+            unit="hour",
+            unit_number=1,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        backtesting_module,
+        "BACKTEST_MEMORY_BUDGET_BYTES",
+        backtesting_module.ESTIMATED_REPLAY_CANDLE_BYTES,
+    )
+
+    with pytest.raises(
+        backtesting_module.BacktestConfigurationError,
+        match="backtest_resource_budget_exceeded",
+    ):
+        backtesting_module._cached_replay_stream_covers(
+            db_session,
+            user_id=OWNER_ID,
+            contract_id=CONTRACT_ID,
+            unit="hour",
+            unit_number=1,
+            fetch_start=BASE_TIME - timedelta(hours=2),
+            requested_start=BASE_TIME,
+            first_event=BASE_TIME,
+            last_event=BASE_TIME,
+            warmup_bars=1,
+            reserved_replay_rows=1,
+        )

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -3242,7 +3242,12 @@ def test_candles_endpoint_returns_local_cache_without_provider_call(monkeypatch)
     )
 
     try:
-        db.add(_make_candle(datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc), 10))
+        db.add_all(
+            [
+                _make_candle(datetime(2026, 4, 1, 9, 55, tzinfo=timezone.utc), 9),
+                _make_candle(datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc), 10),
+            ]
+        )
         db.commit()
 
         payload = main_module.get_projectx_market_candles(
@@ -3256,8 +3261,7 @@ def test_candles_endpoint_returns_local_cache_without_provider_call(monkeypatch)
             db=db,
         )
 
-        assert len(payload) == 1
-        assert payload[0]["close"] == 10.0
+        assert [row["close"] for row in payload] == [9.0, 10.0]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
@@ -3513,7 +3517,7 @@ def test_candles_endpoint_resolves_legacy_symbol_to_cached_contract(monkeypatch)
         payload = main_module.get_projectx_market_candles(
             contract_id="MNQ",
             symbol="MNQ",
-            start=datetime(2026, 4, 1, 9, 55, tzinfo=timezone.utc),
+            start=datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc),
             end=datetime(2026, 4, 1, 10, 5, tzinfo=timezone.utc),
             unit="minute",
             unit_number=5,
@@ -3727,7 +3731,7 @@ def test_candles_endpoint_tries_active_symbol_contract_when_saved_contract_histo
             if kwargs["contract_id"] == "CON.F.US.MNQ.U26":
                 return [
                     {
-                        "timestamp": datetime(2026, 6, 25, 14, 0, tzinfo=timezone.utc),
+                        "timestamp": datetime(2026, 5, 13, 14, 0, tzinfo=timezone.utc),
                         "open": 20,
                         "high": 21,
                         "low": 19,
@@ -3889,7 +3893,7 @@ def test_candles_endpoint_refresh_replaces_cached_window(monkeypatch):
         engine.dispose()
 
 
-def test_candles_endpoint_partial_refresh_does_not_prune_closed_cache(monkeypatch):
+def test_candles_endpoint_rejects_stale_partial_without_pruning_closed_cache(monkeypatch):
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -3954,7 +3958,6 @@ def test_candles_endpoint_partial_refresh_does_not_prune_closed_cache(monkeypatc
         assert [_as_test_utc(row.candle_timestamp) for row in cached_rows] == [
             datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc),
             datetime(2026, 4, 1, 10, 1, tzinfo=timezone.utc),
-            datetime(2026, 4, 1, 10, 2, tzinfo=timezone.utc),
         ]
     finally:
         db.close()
@@ -4046,11 +4049,12 @@ def test_dry_run_evaluation_logs_order_attempt_without_submitting():
         place_order_called = False
 
         def retrieve_bars(self, **_kwargs):
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4146,7 +4150,7 @@ def test_macd_support_resistance_evaluation_serializes_trailing_stop_plan_into_o
     SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     db = SessionLocal()
 
-    base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    base = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0) - timedelta(hours=20)
     higher_timeframe = [
         _make_hour_candle(base + timedelta(hours=index * 4), close=120 + index, low=118 + index, high=122 + index, unit_number=4)
         for index in range(5)
@@ -4267,7 +4271,7 @@ def test_donchian_reversal_uses_double_size_to_flip_position_without_risk_block(
 
     class StubClient:
         def retrieve_bars(self, **_kwargs):
-            base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=105)
             rows = [
                 {"timestamp": base + timedelta(minutes=index * 5), "open": 100, "high": 102, "low": 98, "close": 100, "volume": 1}
                 for index in range(20)
@@ -4384,11 +4388,12 @@ def test_live_evaluation_is_blocked_without_explicit_confirmation():
 
     class StubClient:
         def retrieve_bars(self, **_kwargs):
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4500,11 +4505,12 @@ def test_evaluation_uses_resolved_contract_for_decision_and_order_attempt():
 
         def retrieve_bars(self, **kwargs):
             assert kwargs["contract_id"] == "CON.F.US.MNQ.M26"
+            base = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(minutes=5)
             return [
-                {"timestamp": _dt(3), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(2), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
-                {"timestamp": _dt(1), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
-                {"timestamp": _dt(0), "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
+                {"timestamp": base - timedelta(minutes=15), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=10), "open": 10, "high": 10, "low": 10, "close": 10, "volume": 1},
+                {"timestamp": base - timedelta(minutes=5), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 1},
+                {"timestamp": base, "open": 20, "high": 20, "low": 20, "close": 20, "volume": 1},
             ]
 
         def place_order(self, **_kwargs):
@@ -4670,7 +4676,7 @@ def test_stop_without_active_run_links_lifecycle_decision_to_created_run():
         engine.dispose()
 
 
-def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypatch):
+def test_candles_endpoint_automatically_repairs_interior_gap(monkeypatch):
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -4682,15 +4688,38 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
 
     user_id = "00000000-0000-0000-0000-000000000000"
     monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: user_id)
-    monkeypatch.setattr(
-        main_module,
-        "_projectx_client_for_user",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("provider should not be called")),
-    )
+    base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return [
+                {
+                    "timestamp": base + timedelta(minutes=10),
+                    "open": 11.5,
+                    "high": 11.8,
+                    "low": 11.2,
+                    "close": 11.6,
+                    "volume": 5,
+                },
+                {
+                    "timestamp": base + timedelta(minutes=15),
+                    "open": 11.6,
+                    "high": 12.0,
+                    "low": 11.4,
+                    "close": 11.9,
+                    "volume": 6,
+                },
+            ]
+
+    client = StubClient()
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
 
     try:
         fetched_at = datetime.now(timezone.utc)
-        base = fetched_at.replace(second=0, microsecond=0) - timedelta(minutes=30)
         # Interior hole: base+10m and base+15m are missing.
         for offset, close in ((0, 10), (5, 11), (20, 12), (25, 13)):
             db.add(_make_candle(base + timedelta(minutes=offset), close, fetched_at=fetched_at))
@@ -4707,9 +4736,8 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
             db=db,
         )
 
-        # Documents the fast path: a covering, fresh cache is returned as-is even
-        # when it has interior holes. Backfill requires repair=True.
-        assert len(payload) == 4
+        assert len(client.calls) == 1
+        assert [row["close"] for row in payload] == [10.0, 11.0, 11.6, 11.9, 12.0, 13.0]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -97,7 +97,7 @@ def test_app_lifespan_does_not_run_backtest_warming(monkeypatch):
     )
     monkeypatch.setattr(
         main_module,
-        "prepare_bot_backtest_data",
+        "create_bot_backtest",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("backtest warming must remain request-scoped")
         ),

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from threading import Barrier
@@ -3079,6 +3080,32 @@ def test_concurrent_partial_and_closed_candle_upserts_always_leave_closed_row(tm
         engine.dispose()
 
 
+def test_identical_concurrent_candle_requests_share_one_provider_call():
+    worker_count = 8
+    barrier = Barrier(worker_count)
+    calls = 0
+
+    def retrieve():
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        return [{"timestamp": datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc), "close": 101}]
+
+    def request():
+        barrier.wait(timeout=5)
+        return bot_service_module._retrieve_market_bars_singleflight(
+            ("user", "CON.F.US.MNQ.M26", "minute", 5),
+            retrieve,
+        )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        results = [future.result(timeout=5) for future in [pool.submit(request) for _ in range(worker_count)]]
+
+    assert calls == 1
+    assert all(result == results[0] for result in results)
+    assert len({id(result) for result in results}) == worker_count
+
+
 def test_fetch_market_candles_deduplicates_provider_timestamps():
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
@@ -5123,6 +5150,72 @@ def test_candles_endpoint_does_not_repair_a_weekend_market_closure(monkeypatch):
         )
 
         assert [row["timestamp"] for row in payload] == [friday_last_bar, sunday_first_bar]
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("last_before_close", "first_after_close"),
+    [
+        (
+            datetime(2026, 7, 6, 20, 10, tzinfo=timezone.utc),
+            datetime(2026, 7, 6, 20, 30, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2026, 7, 3, 16, 55, tzinfo=timezone.utc),
+            datetime(2026, 7, 5, 22, 0, tzinfo=timezone.utc),
+        ),
+    ],
+    ids=["daily-equity-halt", "independence-day-early-close"],
+)
+def test_candles_endpoint_does_not_repair_scheduled_equity_closures(
+    monkeypatch,
+    last_before_close,
+    first_after_close,
+):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    user_id = "00000000-0000-0000-0000-000000000000"
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: user_id)
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("a scheduled equity closure must not trigger repair")
+        ),
+    )
+
+    try:
+        fetched_at = datetime.now(timezone.utc)
+        db.add_all(
+            [
+                _make_candle(last_before_close, 100, fetched_at=fetched_at),
+                _make_candle(first_after_close, 101, fetched_at=fetched_at),
+            ]
+        )
+        db.commit()
+
+        payload = main_module.get_projectx_market_candles(
+            contract_id="CON.F.US.MNQ.M26",
+            symbol="MNQ",
+            start=last_before_close,
+            end=first_after_close + timedelta(minutes=5),
+            unit="minute",
+            unit_number=5,
+            limit=10,
+            refresh=False,
+            db=db,
+        )
+
+        assert [row["timestamp"] for row in payload] == [last_before_close, first_after_close]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -1,5 +1,8 @@
+import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from threading import Barrier
 
 import pytest
 from fastapi import HTTPException
@@ -66,6 +69,47 @@ import app.services.bot_service as bot_service_module
 
 def _dt(minutes_ago: int) -> datetime:
     return datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+
+
+def test_app_lifespan_does_not_run_backtest_warming(monkeypatch):
+    lifecycle_calls = []
+
+    monkeypatch.setattr(
+        main_module,
+        "guard_against_local_database_url",
+        lambda: lifecycle_calls.append("guard"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "log_runtime_connection_targets",
+        lambda: lifecycle_calls.append("log"),
+    )
+    monkeypatch.setattr(main_module, "init_db", lambda: lifecycle_calls.append("init"))
+    monkeypatch.setattr(
+        main_module,
+        "_start_streaming_runtime_if_enabled",
+        lambda: lifecycle_calls.append("stream_start"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "_stop_streaming_runtime",
+        lambda: lifecycle_calls.append("stream_stop"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "prepare_bot_backtest_data",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("backtest warming must remain request-scoped")
+        ),
+    )
+
+    async def run_lifespan():
+        async with main_module.app_lifespan(main_module.app):
+            lifecycle_calls.append("ready")
+
+    asyncio.run(run_lifespan())
+
+    assert lifecycle_calls == ["guard", "log", "init", "stream_start", "ready", "stream_stop"]
 
 
 def _make_candle(timestamp: datetime, close: float, **overrides) -> ProjectXMarketCandle:
@@ -2862,19 +2906,20 @@ def test_relative_strength_vs_spy_fetches_symbol_and_mes_five_minute_candles():
 
 def test_postgres_market_candle_upserts_are_batched(monkeypatch):
     batch_sizes: list[int] = []
-
-    class Excluded:
-        def __getattr__(self, name):
-            return name
+    conflict_updates = []
+    table = ProjectXMarketCandle.__table__
+    excluded = bot_service_module.postgresql_insert(table).excluded
 
     class Insert:
-        excluded = Excluded()
+        def __init__(self):
+            self.excluded = excluded
 
         def values(self, batch):
             batch_sizes.append(len(batch))
             return self
 
-        def on_conflict_do_update(self, **_kwargs):
+        def on_conflict_do_update(self, **kwargs):
+            conflict_updates.append(kwargs)
             return self
 
     class StubDb:
@@ -2891,6 +2936,147 @@ def test_postgres_market_candle_upserts_are_batched(monkeypatch):
 
     assert batch_sizes == [1_000, 1_000, 501]
     assert db.execute_count == 3
+    assert all(update["where"] is not None for update in conflict_updates)
+    where_sql = str(conflict_updates[0]["where"])
+    assert "projectx_market_candles.is_partial IS true" in where_sql
+    assert "excluded.is_partial IS false" in where_sql
+
+
+@pytest.mark.parametrize("partial_first", [False, True])
+def test_same_batch_partial_duplicate_never_replaces_closed_bar(partial_first):
+    timestamp = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    partial = {"timestamp": timestamp, "close": 999, "is_partial": True}
+    closed = {"timestamp": timestamp, "close": 101, "is_partial": False}
+
+    bars = [partial, closed] if partial_first else [closed, partial]
+    normalized = bot_service_module._dedupe_market_candle_bars(bars)
+
+    assert len(normalized) == 1
+    assert normalized[0]["is_partial"] is False
+    assert normalized[0]["close"] == 101
+
+
+def test_market_candle_upsert_promotes_partial_and_never_regresses_closed_or_other_user():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    timestamp = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    owner = "00000000-0000-0000-0000-000000000000"
+    other_user = "00000000-0000-0000-0000-000000000001"
+
+    def store(*, user_id, close, is_partial):
+        rows = bot_service_module.store_market_candles(
+            db,
+            user_id=user_id,
+            contract_id="CON.F.US.MNQ.M26",
+            symbol="MNQ",
+            live=False,
+            unit="minute",
+            unit_number=5,
+            bars=[
+                {
+                    "timestamp": timestamp,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": close,
+                    "is_partial": is_partial,
+                    "raw_payload": {"close": close},
+                }
+            ],
+        )
+        db.commit()
+        return rows[0]
+
+    try:
+        assert store(user_id=owner, close=100, is_partial=True).is_partial is True
+        promoted = store(user_id=owner, close=101, is_partial=False)
+        assert promoted.is_partial is False
+        assert float(promoted.close_price) == 101
+
+        protected = store(user_id=owner, close=999, is_partial=True)
+        assert protected.is_partial is False
+        assert float(protected.close_price) == 101
+        assert protected.raw_payload == {"close": 101}
+
+        other = store(user_id=other_user, close=202, is_partial=True)
+        assert other.is_partial is True
+        assert float(other.close_price) == 202
+
+        owner_row = (
+            db.query(ProjectXMarketCandle)
+            .filter(ProjectXMarketCandle.user_id == owner)
+            .one()
+        )
+        assert owner_row.is_partial is False
+        assert float(owner_row.close_price) == 101
+        assert db.query(ProjectXMarketCandle).count() == 2
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def test_concurrent_partial_and_closed_candle_upserts_always_leave_closed_row(tmp_path):
+    engine = create_engine(
+        f"sqlite+pysqlite:///{tmp_path / 'candles.db'}",
+        connect_args={"check_same_thread": False, "timeout": 10},
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    timestamp = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    barrier = Barrier(2)
+
+    def write(close, is_partial):
+        db = SessionLocal()
+        try:
+            barrier.wait(timeout=5)
+            bot_service_module.store_market_candles(
+                db,
+                user_id="00000000-0000-0000-0000-000000000000",
+                contract_id="CON.F.US.MNQ.M26",
+                symbol="MNQ",
+                live=False,
+                unit="minute",
+                unit_number=5,
+                bars=[
+                    {
+                        "timestamp": timestamp,
+                        "open": close,
+                        "high": close,
+                        "low": close,
+                        "close": close,
+                        "volume": close,
+                        "is_partial": is_partial,
+                    }
+                ],
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(write, 999, True), pool.submit(write, 101, False)]
+            for future in futures:
+                future.result(timeout=15)
+
+        db = SessionLocal()
+        try:
+            row = db.query(ProjectXMarketCandle).one()
+            assert row.is_partial is False
+            assert float(row.close_price) == 101
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
 
 
 def test_fetch_market_candles_deduplicates_provider_timestamps():
@@ -4827,7 +5013,7 @@ def test_stop_without_active_run_links_lifecycle_decision_to_created_run():
         engine.dispose()
 
 
-def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypatch):
+def test_candles_endpoint_automatically_repairs_open_session_interior_gap(monkeypatch):
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -4839,15 +5025,32 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
 
     user_id = "00000000-0000-0000-0000-000000000000"
     monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: user_id)
-    monkeypatch.setattr(
-        main_module,
-        "_projectx_client_for_user",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("provider should not be called")),
-    )
+    base = datetime(2026, 7, 8, 14, 0, tzinfo=timezone.utc)
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+
+        def retrieve_bars(self, **kwargs):
+            self.calls.append(kwargs)
+            return [
+                {
+                    "timestamp": base + timedelta(minutes=offset),
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 5,
+                    "is_partial": False,
+                }
+                for offset, close in ((10, 11.5), (15, 11.75))
+            ]
+
+    client = StubClient()
+    monkeypatch.setattr(main_module, "_projectx_client_for_user", lambda *_args, **_kwargs: client)
 
     try:
         fetched_at = datetime.now(timezone.utc)
-        base = fetched_at.replace(second=0, microsecond=0) - timedelta(minutes=30)
         # Interior hole: base+10m and base+15m are missing.
         for offset, close in ((0, 10), (5, 11), (20, 12), (25, 13)):
             db.add(_make_candle(base + timedelta(minutes=offset), close, fetched_at=fetched_at))
@@ -4864,13 +5067,79 @@ def test_candles_endpoint_serves_cache_with_interior_gap_without_repair(monkeypa
             db=db,
         )
 
-        # Documents the fast path: a covering, fresh cache is returned as-is even
-        # when it has interior holes. Backfill requires repair=True.
-        assert len(payload) == 4
+        assert len(client.calls) == 1
+        assert client.calls[0]["start"] == base
+        assert [row["timestamp"] for row in payload] == [
+            base + timedelta(minutes=offset)
+            for offset in (0, 5, 10, 15, 20, 25)
+        ]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
         engine.dispose()
+
+
+def test_candles_endpoint_does_not_repair_a_weekend_market_closure(monkeypatch):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user_id = "00000000-0000-0000-0000-000000000000"
+    monkeypatch.setattr(main_module, "get_authenticated_user_id", lambda: user_id)
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("a scheduled weekend closure must not trigger repair")
+        ),
+    )
+    friday_last_bar = datetime(2026, 7, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_first_bar = datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)
+
+    try:
+        fetched_at = datetime.now(timezone.utc)
+        db.add_all(
+            [
+                _make_candle(friday_last_bar, 100, fetched_at=fetched_at),
+                _make_candle(sunday_first_bar, 101, fetched_at=fetched_at),
+            ]
+        )
+        db.commit()
+
+        payload = main_module.get_projectx_market_candles(
+            contract_id="CON.F.US.MNQ.M26",
+            start=friday_last_bar,
+            end=sunday_first_bar + timedelta(minutes=5),
+            unit="minute",
+            unit_number=5,
+            limit=10,
+            refresh=False,
+            db=db,
+        )
+
+        assert [row["timestamp"] for row in payload] == [friday_last_bar, sunday_first_bar]
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def test_daily_candle_cache_treats_a_weekend_as_covered():
+    friday = _make_candle(datetime(2026, 7, 10, 0, 0, tzinfo=timezone.utc), 100)
+    monday = _make_candle(datetime(2026, 7, 13, 0, 0, tzinfo=timezone.utc), 101)
+
+    assert bot_service_module.market_candle_cache_covers_request(
+        [friday, monday],
+        start=friday.candle_timestamp,
+        unit="day",
+        unit_number=1,
+        limit=10,
+    )
 
 
 def test_candles_endpoint_repair_backfills_interior_gap_without_pruning(monkeypatch):

--- a/backend/tests/test_bot_service.py
+++ b/backend/tests/test_bot_service.py
@@ -2704,8 +2704,8 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2724,7 +2724,7 @@ def test_relative_strength_vs_spy_generates_buy_signal_on_pullback():
     )
 
     assert signal.action == "BUY"
-    assert "BUY on relative strength vs SPY" in signal.reason
+    assert "BUY on relative strength vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] > signal.price
     assert signal.raw_payload["stop_loss"] < signal.price
@@ -2763,8 +2763,8 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
             _make_candle(
                 timestamp,
                 benchmark_closes[index],
-                contract_id="CON.F.US.SPY.M26",
-                symbol="SPY",
+                contract_id="CON.F.US.MES.M26",
+                symbol="F.US.MES",
                 open_price=benchmark_previous_close,
                 low_price=min(benchmark_previous_close, benchmark_closes[index]) - 0.1,
                 high_price=max(benchmark_previous_close, benchmark_closes[index]) + 0.1,
@@ -2783,13 +2783,13 @@ def test_relative_strength_vs_spy_generates_sell_signal_on_failed_bounce():
     )
 
     assert signal.action == "SELL"
-    assert "SELL on relative weakness vs SPY" in signal.reason
+    assert "SELL on relative weakness vs MES" in signal.reason
     assert signal.raw_payload["relative_volume"] > 2
     assert signal.raw_payload["take_profit"] < signal.price
     assert signal.raw_payload["stop_loss"] > signal.price
 
 
-def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
+def test_relative_strength_vs_spy_fetches_symbol_and_mes_five_minute_candles():
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -2804,8 +2804,8 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             self.calls = []
 
         def search_contracts(self, *, search_text: str, live: bool = False):
-            if search_text == "SPY":
-                return [{"id": "CON.F.US.SPY.M26", "symbol_id": "SPY", "active_contract": True}]
+            if search_text == "MES":
+                return [{"id": "CON.F.US.MES.M26", "symbol_id": "F.US.MES", "active_contract": True}]
             return []
 
         def retrieve_bars(self, **kwargs):
@@ -2849,15 +2849,48 @@ def test_relative_strength_vs_spy_fetches_symbol_and_spy_five_minute_candles():
             strategy_params={"benchmark_symbol": "SPY"},
         )
 
-        assert rows == {"5m": [], "SPY": []}
+        assert rows == {"5m": [], "benchmark": []}
         assert [(call["contract_id"], call["unit"], call["unit_number"], call["limit"]) for call in client.calls] == [
             ("CON.F.US.MNQ.M26", 2, 5, 50),
-            ("CON.F.US.SPY.M26", 2, 5, 50),
+            ("CON.F.US.MES.M26", 2, 5, 50),
         ]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
         engine.dispose()
+
+
+def test_postgres_market_candle_upserts_are_batched(monkeypatch):
+    batch_sizes: list[int] = []
+
+    class Excluded:
+        def __getattr__(self, name):
+            return name
+
+    class Insert:
+        excluded = Excluded()
+
+        def values(self, batch):
+            batch_sizes.append(len(batch))
+            return self
+
+        def on_conflict_do_update(self, **_kwargs):
+            return self
+
+    class StubDb:
+        def __init__(self):
+            self.execute_count = 0
+
+        def execute(self, _statement):
+            self.execute_count += 1
+
+    monkeypatch.setattr(bot_service_module, "postgresql_insert", lambda _table: Insert())
+    db = StubDb()
+
+    bot_service_module._upsert_market_candle_rows(db, values=[{} for _ in range(2_501)])
+
+    assert batch_sizes == [1_000, 1_000, 501]
+    assert db.execute_count == 3
 
 
 def test_fetch_market_candles_deduplicates_provider_timestamps():
@@ -2912,6 +2945,89 @@ def test_fetch_market_candles_deduplicates_provider_timestamps():
         assert rows[0].close_price == 13.0
         assert rows[0].volume == 2.0
         assert db.query(ProjectXMarketCandle).count() == 1
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def test_authoritative_market_candle_refresh_prunes_displaced_cached_bars():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    user_id = "00000000-0000-0000-0000-000000000000"
+    outside = datetime(2026, 4, 26, 18, 0, tzinfo=timezone.utc)
+    stale = [
+        datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc),
+    ]
+    authoritative = [
+        datetime(2026, 4, 26, 22, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 2, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 6, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 27, 14, 0, tzinfo=timezone.utc),
+    ]
+
+    class StubClient:
+        def retrieve_bars(self, **_kwargs):
+            return [
+                {
+                    "timestamp": timestamp,
+                    "open": 100,
+                    "high": 102,
+                    "low": 99,
+                    "close": 101,
+                    "volume": 10,
+                    "is_partial": False,
+                }
+                for timestamp in authoritative
+            ]
+
+    try:
+        db.add_all(
+            [
+                _make_candle(
+                    timestamp,
+                    100,
+                    user_id=user_id,
+                    unit="hour",
+                    unit_number=4,
+                )
+                for timestamp in [outside, *stale]
+            ]
+        )
+        db.commit()
+
+        rows = fetch_and_store_market_candles(
+            db,
+            user_id=user_id,
+            client=StubClient(),
+            contract_id="CON.F.US.MNQ.M26",
+            symbol="MNQ",
+            live=False,
+            start=authoritative[0],
+            end=authoritative[-1] + timedelta(hours=4),
+            unit="hour",
+            unit_number=4,
+            limit=500,
+            preserve_cached_history=True,
+            authoritative_refresh=True,
+        )
+
+        assert [_as_test_utc(row.candle_timestamp) for row in rows] == authoritative
+        cached_timestamps = [
+            _as_test_utc(row.candle_timestamp)
+            for row in db.query(ProjectXMarketCandle)
+            .order_by(ProjectXMarketCandle.candle_timestamp.asc())
+            .all()
+        ]
+        assert cached_timestamps == [outside, *authoritative]
     finally:
         db.close()
         Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
@@ -3037,6 +3153,47 @@ def test_create_bot_config_rejects_invalid_ema_scalping_timeframe():
         )
 
         with pytest.raises(ValueError, match="3-minute or 5-minute timeframe"):
+            create_bot_config(db, user_id=user_id, payload=payload)
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine, tables=tables)
+        engine.dispose()
+
+
+def test_create_bot_config_rejects_monthly_topbot_timeframe():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [Account.__table__, BotConfig.__table__]
+    Base.metadata.create_all(bind=engine, tables=tables)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user_id = "00000000-0000-0000-0000-000000000000"
+    try:
+        db.add(
+            Account(
+                user_id=user_id,
+                provider="projectx",
+                external_id="9001",
+                name="Practice 9001",
+                account_state="ACTIVE",
+                can_trade=True,
+                is_visible=True,
+            )
+        )
+        db.flush()
+        payload = _make_bot_create_payload(name="Monthly TopBot").model_copy(
+            update={
+                "strategy_type": "topbot_adaptive",
+                "timeframe_unit": "month",
+                "timeframe_unit_number": 1,
+            }
+        )
+
+        with pytest.raises(ValueError, match="does not support month candles"):
             create_bot_config(db, user_id=user_id, payload=payload)
     finally:
         db.close()

--- a/backend/tests/test_candle_integrity.py
+++ b/backend/tests/test_candle_integrity.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+from app.db import Base
+from app.models import ProjectXMarketCandle
+from app.services.bot_service import ensure_market_candles, store_market_candles
+from app.services.candle_integrity import (
+    _reset_request_state_for_tests,
+    audit_candle_rows,
+    normalize_provider_bars,
+    retrieve_bars_singleflight,
+)
+from app.services.projectx_client import ProjectXClientError
+
+
+USER_ID = "00000000-0000-0000-0000-000000000000"
+CONTRACT_ID = "CON.F.US.MNQ.M26"
+BASE = datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def reset_request_state():
+    _reset_request_state_for_tests()
+    yield
+    _reset_request_state_for_tests()
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine, tables=[ProjectXMarketCandle.__table__])
+        engine.dispose()
+
+
+def _bar(timestamp: datetime, close: float = 100.0, **overrides):
+    bar = {
+        "timestamp": timestamp,
+        "open": close - 0.25,
+        "high": close + 0.5,
+        "low": close - 0.5,
+        "close": close,
+        "volume": 10.0,
+        "is_partial": False,
+    }
+    bar.update(overrides)
+    return bar
+
+
+def _row(timestamp: datetime, close: float = 100.0, **overrides):
+    values = {
+        "user_id": USER_ID,
+        "contract_id": CONTRACT_ID,
+        "symbol": "MNQ",
+        "live": False,
+        "unit": "minute",
+        "unit_number": 5,
+        "candle_timestamp": timestamp,
+        "open_price": close - 0.25,
+        "high_price": close + 0.5,
+        "low_price": close - 0.5,
+        "close_price": close,
+        "volume": 10.0,
+        "is_partial": False,
+    }
+    values.update(overrides)
+    return ProjectXMarketCandle(**values)
+
+
+def _audit(rows, *, start=BASE, end=BASE + timedelta(minutes=15), include_partial=False):
+    return audit_candle_rows(
+        rows,
+        start=start,
+        end=end,
+        unit="minute",
+        unit_number=5,
+        limit=100,
+        include_partial_bar=include_partial,
+        symbol="MNQ",
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_duplicate_timestamp_prefers_closed_valid_bar_independent_of_order(reverse):
+    closed = _bar(BASE, close=101.0)
+    partial = _bar(BASE, close=999.0, is_partial=True)
+    rows = [partial, closed] if reverse else [closed, partial]
+
+    report = _audit(rows, end=BASE + timedelta(minutes=5), include_partial=True)
+
+    assert report.issue_codes == ("duplicate_candle_timestamp",)
+    assert len(report.valid_rows) == 1
+    assert report.valid_rows[0]["close"] == 101.0
+
+
+@pytest.mark.parametrize(
+    ("overrides", "issue"),
+    [
+        ({"high": 99.0}, "invalid_candle_high"),
+        ({"low": 100.25}, "invalid_candle_low"),
+        ({"open": 0.0}, "non_positive_ohlc"),
+        ({"close": float("nan")}, "non_finite_close"),
+        ({"volume": -1.0}, "negative_candle_volume"),
+    ],
+)
+def test_invalid_ohlcv_is_excluded_and_scheduled_for_repair(overrides, issue):
+    bar = _bar(BASE)
+    bar.update(overrides)
+    report = _audit([bar], end=BASE + timedelta(minutes=5))
+
+    assert issue in report.issue_codes
+    assert report.valid_rows == ()
+    assert report.repair_ranges
+
+
+def test_overlap_is_detected_and_only_one_bar_survives():
+    report = _audit(
+        [_bar(BASE), _bar(BASE + timedelta(minutes=1), close=101)],
+        end=BASE + timedelta(minutes=10),
+    )
+
+    assert "overlapping_candles" in report.issue_codes
+    assert len(report.valid_rows) == 1
+    assert report.valid_rows[0]["timestamp"] == BASE
+
+
+def test_open_session_gap_and_incomplete_tail_are_detected():
+    report = _audit(
+        [_bar(BASE), _bar(BASE + timedelta(minutes=10))],
+        end=BASE + timedelta(minutes=20),
+    )
+
+    assert "missing_candle" in report.issue_codes
+    assert [(item.start, item.end) for item in report.missing_ranges] == [
+        (BASE + timedelta(minutes=5), BASE + timedelta(minutes=10)),
+        (BASE + timedelta(minutes=15), BASE + timedelta(minutes=20)),
+    ]
+
+
+def test_large_second_gap_uses_bounded_broad_repair_window():
+    end = BASE + timedelta(hours=8)
+    report = audit_candle_rows(
+        [_bar(BASE), _bar(end)],
+        start=BASE,
+        end=end + timedelta(seconds=1),
+        unit="second",
+        unit_number=1,
+        limit=50_000,
+        include_partial_bar=False,
+        symbol="MNQ",
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert "missing_candle" in report.issue_codes
+    assert report.repair_ranges
+    assert len(report.repair_ranges) <= 8
+
+
+def test_daily_maintenance_gap_is_not_repaired():
+    # 2026-04-01 is EDT: 17:00-18:00 ET is 21:00-22:00 UTC.
+    before_close = datetime(2026, 4, 1, 20, 55, tzinfo=timezone.utc)
+    reopen = datetime(2026, 4, 1, 22, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(before_close), _bar(reopen)],
+        start=before_close,
+        end=reopen + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_weekend_gap_is_not_repaired():
+    friday_close = datetime(2026, 4, 10, 20, 55, tzinfo=timezone.utc)
+    sunday_open = datetime(2026, 4, 12, 22, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(friday_close), _bar(sunday_open)],
+        start=friday_close,
+        end=sunday_open + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_holiday_early_close_gap_is_not_repaired():
+    # MLK Day 2026 closes at 13:00 ET (18:00 UTC) and reopens at 18:00 ET.
+    before_close = datetime(2026, 1, 19, 17, 55, tzinfo=timezone.utc)
+    reopen = datetime(2026, 1, 19, 23, 0, tzinfo=timezone.utc)
+    report = _audit(
+        [_bar(before_close), _bar(reopen)],
+        start=before_close,
+        end=reopen + timedelta(minutes=5),
+    )
+
+    assert "missing_candle" not in report.issue_codes
+
+
+def test_stale_partial_is_excluded_and_scheduled_for_authoritative_replacement():
+    report = _audit(
+        [_bar(BASE, is_partial=True)],
+        end=BASE + timedelta(minutes=5),
+        include_partial=True,
+    )
+
+    assert report.valid_rows == ()
+    assert report.stale_partial_rows
+    assert "stale_partial_candle" in report.issue_codes
+
+
+def test_current_partial_is_allowed_until_its_bucket_closes():
+    report = audit_candle_rows(
+        [_bar(BASE, is_partial=True)],
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        include_partial_bar=True,
+        symbol="MNQ",
+        as_of=BASE + timedelta(minutes=2),
+    )
+
+    assert report.is_complete
+    assert len(report.valid_rows) == 1
+    assert len(report.current_partial_rows) == 1
+
+
+def test_provider_duplicate_normalization_prefers_closed_bar():
+    normalized = normalize_provider_bars(
+        [_bar(BASE, close=999, is_partial=True), _bar(BASE, close=101)],
+        unit="minute",
+        unit_number=5,
+        request_end=BASE + timedelta(minutes=5),
+        include_partial_bar=True,
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert len(normalized) == 1
+    assert normalized[0]["close"] == 101
+    assert normalized[0]["is_partial"] is False
+
+
+def test_provider_normalization_rejects_bars_outside_requested_closed_window():
+    normalized = normalize_provider_bars(
+        [
+            _bar(BASE - timedelta(minutes=5)),
+            _bar(BASE),
+            _bar(BASE + timedelta(minutes=5)),
+        ],
+        unit="minute",
+        unit_number=5,
+        request_start=BASE,
+        request_end=BASE + timedelta(minutes=5),
+        include_partial_bar=False,
+        as_of=datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+    assert [row["timestamp"] for row in normalized] == [BASE]
+
+
+def test_singleflight_deduplicates_concurrent_provider_requests():
+    call_count = 0
+    guard = Lock()
+
+    def retrieve():
+        nonlocal call_count
+        with guard:
+            call_count += 1
+        time.sleep(0.1)
+        return [_bar(BASE)]
+
+    def invoke():
+        return retrieve_bars_singleflight(key=("same",), retrieve=retrieve)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(lambda _index: invoke(), range(4)))
+
+    assert call_count == 1
+    assert [result[0]["timestamp"] for result in results] == [BASE] * 4
+
+
+def test_transient_retries_are_capped_and_nontransient_errors_are_not_retried():
+    transient_calls = 0
+
+    def transient():
+        nonlocal transient_calls
+        transient_calls += 1
+        raise ProjectXClientError("timeout", status_code=504)
+
+    with pytest.raises(ProjectXClientError):
+        retrieve_bars_singleflight(key=("transient",), retrieve=transient)
+    assert transient_calls == 3
+
+    permanent_calls = 0
+
+    def permanent():
+        nonlocal permanent_calls
+        permanent_calls += 1
+        raise ProjectXClientError("bad request", status_code=400)
+
+    with pytest.raises(ProjectXClientError):
+        retrieve_bars_singleflight(key=("permanent",), retrieve=permanent)
+    assert permanent_calls == 1
+
+
+def test_closed_database_row_cannot_be_downgraded_by_partial(db_session):
+    store_market_candles(
+        db_session,
+        user_id=USER_ID,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        unit="minute",
+        unit_number=5,
+        bars=[_bar(BASE, close=101)],
+    )
+    db_session.flush()
+    store_market_candles(
+        db_session,
+        user_id=USER_ID,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        unit="minute",
+        unit_number=5,
+        bars=[_bar(BASE, close=999, is_partial=True)],
+    )
+    db_session.flush()
+
+    row = db_session.query(ProjectXMarketCandle).one()
+    assert row.is_partial is False
+    assert float(row.close_price) == 101.0
+
+
+def test_stale_partial_is_replaced_in_place_by_closed_provider_bar(db_session):
+    db_session.add(_row(BASE, close=100, is_partial=True))
+    db_session.flush()
+
+    class Client:
+        def retrieve_bars(self, **_kwargs):
+            return [_bar(BASE, close=102, is_partial=False)]
+
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=Client(),
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+
+    assert len(rows) == 1
+    assert db_session.query(ProjectXMarketCandle).count() == 1
+    assert rows[0].is_partial is False
+    assert float(rows[0].close_price) == 102.0
+
+
+def test_empty_provider_response_never_creates_synthetic_gap_bar(db_session):
+    db_session.add_all([_row(BASE), _row(BASE + timedelta(minutes=10), close=102)])
+    db_session.flush()
+
+    class Client:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            return []
+
+    client = Client()
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=15),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+    repeated_rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=15),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+    )
+
+    assert client.calls == 1
+    assert [
+        row.candle_timestamp.replace(tzinfo=row.candle_timestamp.tzinfo or timezone.utc)
+        for row in rows
+    ] == [BASE, BASE + timedelta(minutes=10)]
+    assert len(repeated_rows) == 2
+    assert db_session.query(ProjectXMarketCandle).count() == 2
+
+
+def test_provider_failure_uses_vetted_cache_after_exact_retry_cap(db_session):
+    db_session.add(_row(BASE, close=101))
+    db_session.flush()
+
+    class Client:
+        calls = 0
+
+        def retrieve_bars(self, **_kwargs):
+            self.calls += 1
+            raise ProjectXClientError("timeout", status_code=504)
+
+    client = Client()
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=client,
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        force_refresh=True,
+    )
+
+    assert client.calls == 3
+    assert len(rows) == 1
+    assert float(rows[0].close_price) == 101.0
+
+
+def test_invalid_provider_bar_cannot_overwrite_good_cache(db_session):
+    db_session.add(_row(BASE, close=101))
+    db_session.flush()
+
+    class Client:
+        def retrieve_bars(self, **_kwargs):
+            return [_bar(BASE, close=999, high=998)]
+
+    rows = ensure_market_candles(
+        db_session,
+        user_id=USER_ID,
+        client=Client(),
+        contract_id=CONTRACT_ID,
+        symbol="MNQ",
+        live=False,
+        start=BASE,
+        end=BASE + timedelta(minutes=5),
+        unit="minute",
+        unit_number=5,
+        limit=10,
+        force_refresh=True,
+    )
+
+    assert len(rows) == 1
+    assert float(rows[0].close_price) == 101.0

--- a/backend/tests/test_projectx_client.py
+++ b/backend/tests/test_projectx_client.py
@@ -311,6 +311,11 @@ def test_retrieve_bars_infers_an_unmarked_intraday_tail_is_partial():
     assert len(included) == 1
     assert included[0]["is_partial"] is True
 
+    closed_request = {**request, "end": datetime(2026, 4, 27, 4, 0, tzinfo=timezone.utc)}
+    closed = client.retrieve_bars(**closed_request, include_partial_bar=False)
+    assert len(closed) == 1
+    assert closed[0]["is_partial"] is False
+
 
 def test_place_order_uses_projectx_order_place_payload():
     class StubClient(ProjectXClient):

--- a/backend/tests/test_projectx_client.py
+++ b/backend/tests/test_projectx_client.py
@@ -276,6 +276,42 @@ def test_retrieve_bars_normalizes_and_sorts_ohlcv_rows():
     assert rows[1]["close"] == 104.0
 
 
+def test_retrieve_bars_infers_an_unmarked_intraday_tail_is_partial():
+    class StubClient(ProjectXClient):
+        def __init__(self):
+            super().__init__(base_url="https://example.test", username="demo", api_key="demo")
+
+        def _request(self, method, path, *, payload=None, with_auth):
+            return {
+                "bars": [
+                    {
+                        "t": "2026-04-27T00:00:00Z",
+                        "o": 100,
+                        "h": 102,
+                        "l": 99,
+                        "c": 101,
+                        "v": 10,
+                    }
+                ]
+            }
+
+    client = StubClient()
+    request = {
+        "contract_id": "CON.F.US.MNQ.M26",
+        "live": False,
+        "start": datetime(2026, 4, 27, 0, 0, tzinfo=timezone.utc),
+        "end": datetime(2026, 4, 27, 3, 39, tzinfo=timezone.utc),
+        "unit": 3,
+        "unit_number": 4,
+        "limit": 500,
+    }
+
+    assert client.retrieve_bars(**request, include_partial_bar=False) == []
+    included = client.retrieve_bars(**request, include_partial_bar=True)
+    assert len(included) == 1
+    assert included[0]["is_partial"] is True
+
+
 def test_place_order_uses_projectx_order_place_payload():
     class StubClient(ProjectXClient):
         def __init__(self):

--- a/backend/tests/test_trading_day.py
+++ b/backend/tests/test_trading_day.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from app.services.trading_day import trading_day_key
+from app.services.trading_day import futures_session_is_open, trading_day_key
 
 
 def test_trading_day_key_keeps_559pm_et_on_same_day():
@@ -16,3 +16,10 @@ def test_trading_day_key_rolls_600pm_et_to_next_day():
 def test_trading_day_key_rolls_monday_609pm_et_to_tuesday():
     # Reported case: Monday 2026-03-02 18:09 ET should bucket as Tuesday.
     assert trading_day_key(datetime(2026, 3, 2, 23, 9, tzinfo=timezone.utc)) == "2026-03-03"
+
+
+def test_futures_session_open_excludes_daily_maintenance_and_weekend_closures():
+    assert futures_session_is_open(datetime(2026, 7, 10, 20, 59, tzinfo=timezone.utc)) is True
+    assert futures_session_is_open(datetime(2026, 7, 10, 21, 0, tzinfo=timezone.utc)) is False
+    assert futures_session_is_open(datetime(2026, 7, 12, 21, 59, tzinfo=timezone.utc)) is False
+    assert futures_session_is_open(datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)) is True

--- a/backend/tests/test_trading_day.py
+++ b/backend/tests/test_trading_day.py
@@ -1,6 +1,12 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 
-from app.services.trading_day import trading_day_key
+from app.services.trading_day import (
+    futures_holiday_schedule,
+    futures_session_intervals_utc,
+    is_expected_futures_candle,
+    is_futures_market_open,
+    trading_day_key,
+)
 
 
 def test_trading_day_key_keeps_559pm_et_on_same_day():
@@ -16,3 +22,129 @@ def test_trading_day_key_rolls_600pm_et_to_next_day():
 def test_trading_day_key_rolls_monday_609pm_et_to_tuesday():
     # Reported case: Monday 2026-03-02 18:09 ET should bucket as Tuesday.
     assert trading_day_key(datetime(2026, 3, 2, 23, 9, tzinfo=timezone.utc)) == "2026-03-03"
+
+
+def test_cme_equity_session_excludes_daily_halt_and_maintenance():
+    symbol = "F.US.MNQ"
+
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 14, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 20, 29, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 9, 21, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 9, 22, 0, tzinfo=timezone.utc), symbol=symbol)
+
+
+def test_cme_equity_session_excludes_weekend():
+    symbol = "CON.F.US.MNQ.M26"
+
+    assert is_futures_market_open(datetime(2026, 6, 5, 20, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 5, 21, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 6, 15, 0, tzinfo=timezone.utc), symbol=symbol)
+    assert not is_futures_market_open(datetime(2026, 6, 7, 21, 59, tzinfo=timezone.utc), symbol=symbol)
+    assert is_futures_market_open(datetime(2026, 6, 7, 22, 0, tzinfo=timezone.utc), symbol=symbol)
+
+
+def test_cme_equity_sunday_open_is_dst_safe():
+    # March 1 is EST (18:00 ET == 23:00 UTC); March 8 is EDT
+    # (18:00 ET == 22:00 UTC) after the spring transition.
+    assert not is_futures_market_open(datetime(2026, 3, 1, 22, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 3, 1, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 3, 8, 21, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 3, 8, 22, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+    # The November 1 fall transition returns the Sunday open to 23:00 UTC.
+    assert not is_futures_market_open(datetime(2026, 11, 1, 22, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 11, 1, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+
+def test_cme_equity_recurring_holiday_rules_report_full_and_early_closes():
+    mlk = futures_holiday_schedule(date(2026, 1, 19), symbol="MNQ")
+    good_friday = futures_holiday_schedule(date(2026, 4, 3), symbol="MNQ")
+    independence_eve = futures_holiday_schedule(date(2024, 7, 3), symbol="MNQ")
+    independence_day = futures_holiday_schedule(date(2024, 7, 4), symbol="MNQ")
+    thanksgiving = futures_holiday_schedule(date(2026, 11, 26), symbol="MNQ")
+    thanksgiving_friday = futures_holiday_schedule(date(2026, 11, 27), symbol="MNQ")
+    christmas_eve = futures_holiday_schedule(date(2026, 12, 24), symbol="MNQ")
+    christmas = futures_holiday_schedule(date(2026, 12, 25), symbol="MNQ")
+
+    assert mlk is not None and mlk.early_close == time(13, 0) and not mlk.full_close
+    assert good_friday is not None and good_friday.early_close == time(9, 15)
+    assert independence_eve is not None and independence_eve.early_close == time(13, 15)
+    assert independence_day is not None and independence_day.early_close == time(13, 0)
+    assert thanksgiving is not None and thanksgiving.early_close == time(13, 0)
+    assert thanksgiving_friday is not None and thanksgiving_friday.early_close == time(13, 15)
+    assert christmas_eve is not None and christmas_eve.early_close == time(13, 15)
+    assert christmas is not None and christmas.full_close and christmas.early_close is None
+
+
+def test_cme_equity_holiday_closes_are_applied_to_market_open_checks():
+    # MLK Day closes at 13:00 ET and the next trading date opens at 18:00 ET.
+    assert is_futures_market_open(datetime(2026, 1, 19, 17, 59, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 1, 19, 18, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert is_futures_market_open(datetime(2026, 1, 19, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+    # Good Friday closes at 09:15 ET in the contemporary schedule.
+    assert is_futures_market_open(datetime(2026, 4, 3, 13, 14, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 4, 3, 13, 15, tzinfo=timezone.utc), symbol="MNQ")
+
+    # Christmas is a full close: the prior-evening session never opens.
+    assert not is_futures_market_open(datetime(2026, 12, 24, 23, 0, tzinfo=timezone.utc), symbol="MNQ")
+    assert not is_futures_market_open(datetime(2026, 12, 25, 16, 0, tzinfo=timezone.utc), symbol="MNQ")
+
+
+def test_cme_equity_session_intervals_are_half_open_and_exclude_halt():
+    assert futures_session_intervals_utc(date(2026, 6, 9), symbol="MNQ") == (
+        (
+            datetime(2026, 6, 8, 22, 0, tzinfo=timezone.utc),
+            datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc),
+            datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc),
+        ),
+    )
+    assert futures_session_intervals_utc(date(2026, 12, 25), symbol="MNQ") == ()
+
+
+def test_expected_candle_requires_bucket_to_overlap_open_session_time():
+    def expected(start: datetime, end: datetime) -> bool:
+        return is_expected_futures_candle(start, end, symbol="MNQ")
+
+    # A bucket wholly inside the equity halt or maintenance break is scheduled empty.
+    assert not expected(
+        datetime(2026, 6, 9, 20, 15, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 20, 30, tzinfo=timezone.utc),
+    )
+    assert not expected(
+        datetime(2026, 6, 9, 21, 0, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 22, 0, tzinfo=timezone.utc),
+    )
+
+    # A larger candle that has any actual session time remains expected.
+    assert expected(
+        datetime(2026, 6, 9, 20, 10, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 20, 20, tzinfo=timezone.utc),
+    )
+    assert expected(
+        datetime(2026, 6, 9, 21, 55, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 22, 5, tzinfo=timezone.utc),
+    )
+
+    assert not expected(
+        datetime(2026, 6, 6, 12, 0, tzinfo=timezone.utc),
+        datetime(2026, 6, 7, 18, 0, tzinfo=timezone.utc),
+    )
+    assert not expected(
+        datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc),
+        datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc),
+    )
+
+
+def test_known_non_equity_symbol_does_not_inherit_equity_only_halt_or_holidays():
+    # Product-specific special schedules differ. Until a metals calendar is
+    # modeled, MGC gets only the common Globex week and 17:00-18:00 maintenance.
+    assert is_futures_market_open(datetime(2026, 6, 9, 20, 20, tzinfo=timezone.utc), symbol="F.US.MGC")
+    assert futures_holiday_schedule(date(2026, 1, 19), symbol="MGC") is None

--- a/backend/tests/test_trading_day.py
+++ b/backend/tests/test_trading_day.py
@@ -23,3 +23,33 @@ def test_futures_session_open_excludes_daily_maintenance_and_weekend_closures():
     assert futures_session_is_open(datetime(2026, 7, 10, 21, 0, tzinfo=timezone.utc)) is False
     assert futures_session_is_open(datetime(2026, 7, 12, 21, 59, tzinfo=timezone.utc)) is False
     assert futures_session_is_open(datetime(2026, 7, 12, 22, 0, tzinfo=timezone.utc)) is True
+
+
+def test_equity_schedule_excludes_the_daily_halt_without_assuming_it_for_unknown_products():
+    before_halt = datetime(2026, 7, 6, 20, 14, tzinfo=timezone.utc)
+    halt = datetime(2026, 7, 6, 20, 15, tzinfo=timezone.utc)
+    after_halt = datetime(2026, 7, 6, 20, 30, tzinfo=timezone.utc)
+
+    assert futures_session_is_open(before_halt, symbol="MNQ") is True
+    assert futures_session_is_open(halt, symbol="CON.F.US.MNQ.U26") is False
+    assert futures_session_is_open(after_halt, symbol="F.US.MNQ") is True
+    assert futures_session_is_open(halt, symbol="UNKNOWN") is True
+
+
+def test_equity_schedule_excludes_modern_holiday_closures():
+    assert futures_session_is_open(
+        datetime(2026, 4, 3, 13, 14, tzinfo=timezone.utc),
+        symbol="MNQ",
+    ) is True
+    assert futures_session_is_open(
+        datetime(2026, 4, 3, 13, 15, tzinfo=timezone.utc),
+        symbol="MNQ",
+    ) is False
+    assert futures_session_is_open(
+        datetime(2026, 7, 3, 17, 0, tzinfo=timezone.utc),
+        symbol="MNQ",
+    ) is False
+    assert futures_session_is_open(
+        datetime(2026, 12, 25, 15, 0, tzinfo=timezone.utc),
+        symbol="MNQ",
+    ) is False

--- a/backend/tools/benchmark_backtesting.py
+++ b/backend/tools/benchmark_backtesting.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""Reproducible performance harness for TopSignal's backtest engine.
+
+The timed passes exclude synthetic candle construction, semantic hashing, and
+SQLite setup/seeding.  ``tracemalloc`` is deliberately run in a separate pass
+because its instrumentation materially changes wall-clock timings.
+
+Examples (run from the repository root):
+
+    python backend/tools/benchmark_backtesting.py
+    python backend/tools/benchmark_backtesting.py --bars 20000 50000 --repeats 5
+    python backend/tools/benchmark_backtesting.py --bars 20000 --lookback-bars 200 --fast-period 20 --slow-period 50
+    python backend/tools/benchmark_backtesting.py --bars 5000 --sqlite-public
+    python backend/tools/benchmark_backtesting.py --bars 100 --repeats 1 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import platform
+import statistics
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+BACKEND_ROOT = Path(
+    os.environ.get("TOPSIGNAL_BENCHMARK_BACKEND_ROOT")
+    or Path(__file__).resolve().parents[1]
+).resolve()
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+# App settings require a syntactically valid database URL at import time.  The
+# benchmark's optional database case still creates and owns a separate SQLite
+# engine; it never connects through this setting.
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+OWNER_ID = "11111111-1111-1111-1111-111111111111"
+CONTRACT_ID = "CON.F.US.MNQ.BENCH"
+SYMBOL = "MNQ"
+INTERVAL = timedelta(minutes=5)
+START = datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+FAST_PERIOD = 9
+SLOW_PERIOD = 21
+MINIMUM_BARS = SLOW_PERIOD + 2
+DEFAULT_BARS = 5_000
+DEFAULT_REPEATS = 3
+DEFAULT_WARMUPS = 1
+SEMANTIC_KEYS = (
+    "range",
+    "metrics",
+    "equity_curve",
+    "drawdown_series",
+    "daily_results",
+    "monthly_results",
+    "trades",
+    "warnings",
+)
+
+Result = dict[str, Any]
+Runner = Callable[[], Result]
+
+
+@dataclass(frozen=True)
+class AppApi:
+    """Late-bound application objects so ``--help`` needs only the stdlib."""
+
+    engine_version: str
+    Base: Any
+    BotBacktest: Any
+    BotBacktestIn: Any
+    BotConfig: Any
+    ProjectXMarketCandle: Any
+    SignalResult: Any
+    create_bot_backtest: Callable[..., Any]
+    run_backtest: Callable[..., Result]
+
+
+@dataclass(frozen=True)
+class Observation:
+    seconds: float
+    digest: str
+    output_bars: int
+    trade_count: int
+    warning_count: int
+
+
+@dataclass
+class SqlCounter:
+    """Count statements issued only while one public API sample is running."""
+
+    statements: int = 0
+    selects: int = 0
+    candle_selects: int = 0
+
+    def reset(self) -> None:
+        self.statements = 0
+        self.selects = 0
+        self.candle_selects = 0
+
+    def before_cursor_execute(
+        self,
+        _connection: Any,
+        _cursor: Any,
+        statement: str,
+        _parameters: Any,
+        _context: Any,
+        _executemany: bool,
+    ) -> None:
+        self.statements += 1
+        normalized = " ".join(str(statement).upper().split())
+        is_select = normalized.startswith("SELECT") or normalized.startswith("WITH")
+        if is_select:
+            self.selects += 1
+            if "PROJECTX_MARKET_CANDLES" in normalized:
+                self.candle_selects += 1
+
+    def snapshot(self) -> dict[str, int]:
+        return {
+            "statements": self.statements,
+            "selects": self.selects,
+            "candle_selects": self.candle_selects,
+        }
+
+
+def _load_app_api() -> AppApi:
+    from app.bot_schemas import BotBacktestIn
+    from app.db import Base
+    from app.models import BotBacktest, BotConfig, ProjectXMarketCandle
+    from app.services.bot_backtesting import (
+        BACKTEST_ENGINE_VERSION,
+        create_bot_backtest,
+        run_backtest,
+    )
+    from app.services.bot_service import SignalResult
+
+    return AppApi(
+        engine_version=BACKTEST_ENGINE_VERSION,
+        Base=Base,
+        BotBacktest=BotBacktest,
+        BotBacktestIn=BotBacktestIn,
+        BotConfig=BotConfig,
+        ProjectXMarketCandle=ProjectXMarketCandle,
+        SignalResult=SignalResult,
+        create_bot_backtest=create_bot_backtest,
+        run_backtest=run_backtest,
+    )
+
+
+def _positive_int(text: str) -> int:
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return value
+
+
+def _nonnegative_int(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark deterministic real-SMA and scripted-HOLD backtests. "
+            "Input construction and semantic hashing are excluded from wall timings."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--bars",
+        nargs="+",
+        type=_positive_int,
+        default=[DEFAULT_BARS],
+        metavar="N",
+        help=(
+            f"one or more synthetic input sizes (minimum {MINIMUM_BARS}); "
+            "use 20000 and/or 50000 for full-history scaling runs"
+        ),
+    )
+    parser.add_argument(
+        "--repeats",
+        type=_positive_int,
+        default=DEFAULT_REPEATS,
+        help="timed samples per case",
+    )
+    parser.add_argument(
+        "--warmups",
+        type=_nonnegative_int,
+        default=DEFAULT_WARMUPS,
+        help="untimed warmup passes per case",
+    )
+    parser.add_argument(
+        "--case",
+        choices=("all", "sma", "hold"),
+        default="all",
+        help="engine-only case selection",
+    )
+    parser.add_argument(
+        "--lookback-bars",
+        type=_positive_int,
+        default=25,
+        help="configured rolling evaluator history",
+    )
+    parser.add_argument(
+        "--fast-period",
+        type=_positive_int,
+        default=FAST_PERIOD,
+        help="SMA fast period",
+    )
+    parser.add_argument(
+        "--slow-period",
+        type=_positive_int,
+        default=SLOW_PERIOD,
+        help="SMA slow period",
+    )
+    parser.add_argument(
+        "--sqlite-public",
+        action="store_true",
+        help=(
+            "also exercise create_bot_backtest through an in-memory SQLite database "
+            "and report SQL/candle SELECT counts"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the text summary",
+    )
+    return parser
+
+
+def _config(
+    api: AppApi,
+    *,
+    persisted: bool,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> Any:
+    return api.BotConfig(
+        id=None if persisted else 1,
+        user_id=OWNER_ID,
+        account_id=9001,
+        name="Backtest benchmark",
+        provider="projectx",
+        enabled=False,
+        execution_mode="dry_run",
+        strategy_type="sma_cross",
+        strategy_params={},
+        contract_id=CONTRACT_ID,
+        symbol=SYMBOL,
+        timeframe_unit="minute",
+        timeframe_unit_number=5,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+        order_size=2,
+        max_contracts=10,
+        max_daily_loss=1_000_000,
+        max_trades_per_day=10_000,
+        max_open_position=10,
+        allowed_contracts=[CONTRACT_ID],
+        trading_start_time="00:00",
+        trading_end_time="23:59",
+        cooldown_seconds=0,
+        max_data_staleness_seconds=3_600,
+        allow_market_depth=False,
+    )
+
+
+def _generate_candles(api: AppApi, bar_count: int) -> list[Any]:
+    """Build tick-aligned candles using integer arithmetic only."""
+
+    candles: list[Any] = []
+    previous_close_ticks = 40_000
+    for index in range(bar_count):
+        phase = index % 80
+        triangle = phase if phase <= 40 else 80 - phase
+        wave_ticks = (triangle - 20) * 3
+        drift_ticks = (index // 240) % 20
+        close_ticks = 40_000 + wave_ticks + drift_ticks
+        open_ticks = previous_close_ticks + ((index % 3) - 1)
+        wick_ticks = 2 + (index % 4)
+        high_ticks = max(open_ticks, close_ticks) + wick_ticks
+        low_ticks = min(open_ticks, close_ticks) - wick_ticks
+        timestamp = START + INTERVAL * index
+        candles.append(
+            api.ProjectXMarketCandle(
+                user_id=OWNER_ID,
+                contract_id=CONTRACT_ID,
+                symbol=SYMBOL,
+                live=False,
+                unit="minute",
+                unit_number=5,
+                candle_timestamp=timestamp,
+                open_price=open_ticks * 0.25,
+                high_price=high_ticks * 0.25,
+                low_price=low_ticks * 0.25,
+                close_price=close_ticks * 0.25,
+                volume=100 + ((index * 37) % 900),
+                is_partial=False,
+                source="benchmark",
+                raw_payload=None,
+                fetched_at=timestamp + INTERVAL,
+            )
+        )
+        previous_close_ticks = close_ticks
+    return candles
+
+
+def _scripted_hold(api: AppApi) -> Callable[[list[Any]], Any]:
+    def evaluate(candles: list[Any]) -> Any:
+        latest = candles[-1]
+        timestamp = latest.candle_timestamp
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        else:
+            timestamp = timestamp.astimezone(timezone.utc)
+        return api.SignalResult(
+            action="HOLD",
+            reason="deterministic benchmark hold",
+            candle_timestamp=timestamp,
+            price=float(latest.close_price),
+            raw_payload={"benchmark_case": "scripted_hold"},
+        )
+
+    return evaluate
+
+
+def _direct_runner(
+    api: AppApi,
+    candles: list[Any],
+    *,
+    scripted_hold: bool,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> Runner:
+    config = _config(
+        api,
+        persisted=False,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+    )
+    start = candles[0].candle_timestamp
+    end = candles[-1].candle_timestamp + INTERVAL
+    evaluator = _scripted_hold(api) if scripted_hold else None
+
+    def run() -> Result:
+        return api.run_backtest(
+            config=config,
+            candles=candles,
+            start=start,
+            end=end,
+            starting_balance=50_000,
+            commission_per_contract=1.25,
+            slippage_ticks=1,
+            tick_size=0.25,
+            tick_value=0.50,
+            force_close_at_end=True,
+            signal_evaluator=evaluator,
+        )
+
+    return run
+
+
+def _semantic_json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        normalized = (
+            value.replace(tzinfo=timezone.utc)
+            if value.tzinfo is None
+            else value.astimezone(timezone.utc)
+        )
+        return normalized.isoformat()
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    raise TypeError(f"unsupported semantic value: {type(value).__name__}")
+
+
+def _semantic_digest(result: Result) -> str:
+    missing = [key for key in SEMANTIC_KEYS if key not in result]
+    if missing:
+        raise KeyError(f"backtest result is missing semantic fields: {', '.join(missing)}")
+    semantic = {key: result[key] for key in SEMANTIC_KEYS}
+    canonical = json.dumps(
+        semantic,
+        allow_nan=False,
+        default=_semantic_json_default,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _observe(result: Result, seconds: float) -> Observation:
+    result_range = result.get("range") if isinstance(result.get("range"), dict) else {}
+    metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+    warnings = result.get("warnings") if isinstance(result.get("warnings"), list) else []
+    return Observation(
+        seconds=seconds,
+        digest=_semantic_digest(result),
+        output_bars=int(result_range.get("bar_count", 0)),
+        trade_count=int(metrics.get("trade_count", 0)),
+        warning_count=len(warnings),
+    )
+
+
+def _assert_equivalent(name: str, observations: Sequence[Observation]) -> Observation:
+    if not observations:
+        raise RuntimeError(f"{name}: benchmark produced no observations")
+    reference = observations[0]
+    for observation in observations[1:]:
+        if observation.digest != reference.digest:
+            raise RuntimeError(
+                f"{name}: semantic hash changed between benchmark passes "
+                f"({reference.digest} != {observation.digest})"
+            )
+        if (
+            observation.output_bars,
+            observation.trade_count,
+            observation.warning_count,
+        ) != (
+            reference.output_bars,
+            reference.trade_count,
+            reference.warning_count,
+        ):
+            raise RuntimeError(f"{name}: result summary changed between benchmark passes")
+    return reference
+
+
+def _distribution(values: Sequence[float | int]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("cannot summarize an empty distribution")
+    return {
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def _benchmark_runner(
+    *,
+    name: str,
+    input_bars: int,
+    runner: Runner,
+    repeats: int,
+    warmups: int,
+    sql_counter: SqlCounter | None = None,
+) -> dict[str, Any]:
+    observations: list[Observation] = []
+    sql_samples: list[dict[str, int]] = []
+
+    for _ in range(warmups):
+        gc.collect()
+        if sql_counter is not None:
+            sql_counter.reset()
+        observations.append(_observe(runner(), seconds=0.0))
+
+    timed: list[Observation] = []
+    for _ in range(repeats):
+        gc.collect()
+        if sql_counter is not None:
+            sql_counter.reset()
+        started = time.perf_counter()
+        result = runner()
+        elapsed = time.perf_counter() - started
+        if sql_counter is not None:
+            sql_samples.append(sql_counter.snapshot())
+        observation = _observe(result, seconds=elapsed)
+        observations.append(observation)
+        timed.append(observation)
+
+    # This is intentionally not a timed sample.  Starting tracemalloc only
+    # after input construction reports incremental engine/public-path memory.
+    gc.collect()
+    if sql_counter is not None:
+        sql_counter.reset()
+    tracemalloc.start()
+    try:
+        memory_result = runner()
+        _current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    memory_sql = sql_counter.snapshot() if sql_counter is not None else None
+    memory_observation = _observe(memory_result, seconds=0.0)
+    observations.append(memory_observation)
+
+    reference = _assert_equivalent(name, observations)
+    wall_samples = [observation.seconds for observation in timed]
+    wall = _distribution(wall_samples)
+    output: dict[str, Any] = {
+        "name": name,
+        "input_bars": input_bars,
+        "output_bars": reference.output_bars,
+        "trade_count": reference.trade_count,
+        "warning_count": reference.warning_count,
+        "warmups": warmups,
+        "timed_repeats": repeats,
+        "wall_seconds": {
+            "median": round(float(wall["median"]), 9),
+            "min": round(float(wall["min"]), 9),
+            "max": round(float(wall["max"]), 9),
+            "samples": [round(value, 9) for value in wall_samples],
+        },
+        "median_seconds_per_1000_input_bars": round(
+            float(wall["median"]) * 1_000 / input_bars,
+            9,
+        ),
+        "tracemalloc_peak_bytes": peak_bytes,
+        "tracemalloc_peak_mib": round(peak_bytes / (1024 * 1024), 3),
+        "semantic_sha256": reference.digest,
+        "semantic_fields": list(SEMANTIC_KEYS),
+    }
+    if sql_counter is not None:
+        output["sql_counts"] = {
+            "timed_samples": sql_samples,
+            "statements": _distribution(
+                [sample["statements"] for sample in sql_samples]
+            ),
+            "selects": _distribution([sample["selects"] for sample in sql_samples]),
+            "candle_selects": _distribution(
+                [sample["candle_selects"] for sample in sql_samples]
+            ),
+            "memory_pass": memory_sql,
+        }
+    return output
+
+
+def _candle_mapping(candle: Any) -> dict[str, Any]:
+    return {
+        "user_id": candle.user_id,
+        "contract_id": candle.contract_id,
+        "symbol": candle.symbol,
+        "live": candle.live,
+        "unit": candle.unit,
+        "unit_number": candle.unit_number,
+        "candle_timestamp": candle.candle_timestamp,
+        "open_price": candle.open_price,
+        "high_price": candle.high_price,
+        "low_price": candle.low_price,
+        "close_price": candle.close_price,
+        "volume": candle.volume,
+        "is_partial": candle.is_partial,
+        "source": candle.source,
+        "raw_payload": candle.raw_payload,
+        "fetched_at": candle.fetched_at,
+    }
+
+
+def _sqlite_public_runner(
+    api: AppApi,
+    candles: list[Any],
+    *,
+    lookback_bars: int,
+    fast_period: int,
+    slow_period: int,
+) -> tuple[Runner, SqlCounter, Callable[[], None]]:
+    """Create a seeded SQLite session; setup work is outside all samples."""
+
+    from sqlalchemy import create_engine, event
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [
+        api.BotConfig.__table__,
+        api.ProjectXMarketCandle.__table__,
+        api.BotBacktest.__table__,
+    ]
+    api.Base.metadata.create_all(bind=engine, tables=tables)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = SessionLocal()
+    config = _config(
+        api,
+        persisted=True,
+        lookback_bars=lookback_bars,
+        fast_period=fast_period,
+        slow_period=slow_period,
+    )
+    session.add(config)
+    session.flush()
+    config_id = int(config.id)
+
+    insert_candle = api.ProjectXMarketCandle.__table__.insert()
+    chunk_size = 1_000
+    for offset in range(0, len(candles), chunk_size):
+        stop = min(len(candles), offset + chunk_size)
+        batch = [_candle_mapping(candles[index]) for index in range(offset, stop)]
+        session.execute(insert_candle, batch)
+    session.commit()
+
+    payload = api.BotBacktestIn(
+        starting_balance=50_000,
+        commission_per_contract=1.25,
+        slippage_ticks=1,
+        force_close_at_end=True,
+    )
+    captured_now = candles[-1].candle_timestamp + INTERVAL
+    counter = SqlCounter()
+    event.listen(engine, "before_cursor_execute", counter.before_cursor_execute)
+
+    def run() -> Result:
+        row = api.create_bot_backtest(
+            session,
+            user_id=OWNER_ID,
+            bot_config_id=config_id,
+            payload=payload,
+            now=captured_now,
+        )
+        return row.result_snapshot
+
+    def close() -> None:
+        event.remove(engine, "before_cursor_execute", counter.before_cursor_execute)
+        session.close()
+        api.Base.metadata.drop_all(bind=engine, tables=reversed(tables))
+        engine.dispose()
+
+    return run, counter, close
+
+
+def _unique_bar_counts(values: Sequence[int]) -> list[int]:
+    output: list[int] = []
+    for value in values:
+        if value not in output:
+            output.append(value)
+    return output
+
+
+def _run_benchmarks(args: argparse.Namespace) -> dict[str, Any]:
+    api = _load_app_api()
+    cases: list[dict[str, Any]] = []
+    bar_counts = _unique_bar_counts(args.bars)
+    for bar_count in bar_counts:
+        candles = _generate_candles(api, bar_count)
+        if args.case in {"all", "sma"}:
+            cases.append(
+                _benchmark_runner(
+                    name="direct_real_sma",
+                    input_bars=bar_count,
+                    runner=_direct_runner(
+                        api,
+                        candles,
+                        scripted_hold=False,
+                        lookback_bars=args.lookback_bars,
+                        fast_period=args.fast_period,
+                        slow_period=args.slow_period,
+                    ),
+                    repeats=args.repeats,
+                    warmups=args.warmups,
+                )
+            )
+        if args.case in {"all", "hold"}:
+            cases.append(
+                _benchmark_runner(
+                    name="direct_scripted_hold",
+                    input_bars=bar_count,
+                    runner=_direct_runner(
+                        api,
+                        candles,
+                        scripted_hold=True,
+                        lookback_bars=args.lookback_bars,
+                        fast_period=args.fast_period,
+                        slow_period=args.slow_period,
+                    ),
+                    repeats=args.repeats,
+                    warmups=args.warmups,
+                )
+            )
+        if args.sqlite_public:
+            runner, counter, close = _sqlite_public_runner(
+                api,
+                candles,
+                lookback_bars=args.lookback_bars,
+                fast_period=args.fast_period,
+                slow_period=args.slow_period,
+            )
+            try:
+                cases.append(
+                    _benchmark_runner(
+                        name="sqlite_public_create_bot_backtest_sma",
+                        input_bars=bar_count,
+                        runner=runner,
+                        repeats=args.repeats,
+                        warmups=args.warmups,
+                        sql_counter=counter,
+                    )
+                )
+            finally:
+                close()
+
+    return {
+        "benchmark": "topsignal_backtest_engine",
+        "backend_root": str(BACKEND_ROOT),
+        "engine_version": api.engine_version,
+        "python": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "timer": "time.perf_counter wall seconds",
+        "methodology": {
+            "deterministic_input": (
+                "five-minute tick-aligned triangular price series; integer construction"
+            ),
+            "excluded_from_wall_time": [
+                "synthetic candle generation",
+                "garbage collection immediately before each sample",
+                "semantic SHA256 serialization",
+                "SQLite schema creation and candle seeding",
+            ],
+            "memory": (
+                "separate tracemalloc pass; input candles and SQLite seed state pre-exist tracing"
+            ),
+            "semantic_sha256_fields": list(SEMANTIC_KEYS),
+            "strategy_parameters": {
+                "lookback_bars": args.lookback_bars,
+                "fast_period": args.fast_period,
+                "slow_period": args.slow_period,
+            },
+        },
+        "cases": cases,
+    }
+
+
+def _print_text(report: dict[str, Any]) -> None:
+    print("TopSignal backtest benchmark")
+    print(
+        f"engine={report['engine_version']} python={report['python']} "
+        f"implementation={report['python_implementation']}"
+    )
+    print(
+        "wall timings exclude input generation, pre-sample GC, semantic hashing, "
+        "and SQLite setup/seeding"
+    )
+    print("tracemalloc peak comes from a separate, untimed pass")
+    for case in report["cases"]:
+        wall = case["wall_seconds"]
+        print()
+        print(
+            f"{case['name']} bars={case['input_bars']} output_bars={case['output_bars']} "
+            f"trades={case['trade_count']} warnings={case['warning_count']}"
+        )
+        print(
+            "  wall_seconds "
+            f"median={wall['median']:.6f} min={wall['min']:.6f} max={wall['max']:.6f} "
+            f"samples={wall['samples']}"
+        )
+        print(
+            f"  tracemalloc_peak={case['tracemalloc_peak_mib']:.3f} MiB "
+            f"({case['tracemalloc_peak_bytes']} bytes)"
+        )
+        print(f"  semantic_sha256={case['semantic_sha256']}")
+        sql_counts = case.get("sql_counts")
+        if sql_counts is not None:
+            statements = sql_counts["statements"]
+            selects = sql_counts["selects"]
+            candle_selects = sql_counts["candle_selects"]
+            print(
+                "  SQL/sample "
+                f"statements median={statements['median']} min={statements['min']} "
+                f"max={statements['max']}; selects median={selects['median']}; "
+                f"candle_selects median={candle_selects['median']}"
+            )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.fast_period >= args.slow_period:
+        parser.error("--fast-period must be less than --slow-period")
+    minimum_bars = args.slow_period + 2
+    too_small = [value for value in args.bars if value < minimum_bars]
+    if too_small:
+        parser.error(
+            f"--bars must be at least {minimum_bars} for the real SMA warmup; "
+            f"received {', '.join(str(value) for value in too_small)}"
+        )
+    report = _run_benchmarks(args)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/full-history-backtest-agent5.md
+++ b/docs/full-history-backtest-agent5.md
@@ -1,0 +1,31 @@
+# Full-history backtest integration boundary
+
+## Integration base
+
+- Feature branch: `feature/full-history-backtest`
+- Preserved parent: `74cc070` (`Integrate bot performance agent work for review`)
+- Agent 5 should branch from the final feature commit communicated after verification, not from `74cc070` directly.
+
+## Shared interfaces and assumptions
+
+- `BotBacktestIn.start` and `.end` are an optional pair. Omitting both requests full history; supplying both preserves bounded compatibility and test coverage. Supplying only one is invalid.
+- `create_bot_backtest(..., client: ProjectXClient | None = None, now: datetime | None = None)` is the single service entrypoint. `now` captures one deterministic closure boundary for tests and the whole request.
+- The primary replay query is always scoped to user, non-live data, the configured `contract_id`, and the configured timeframe. It must never resolve, roll, or merge futures deliveries.
+- Full-history resolution excludes explicit and inferred partial rows, then uses the earliest eligible stored bar through the latest bar whose nominal close is at or before the captured boundary.
+- TopBot full-history requests first discover and persist the exact configured primary delivery, paging backward and forward until provider exhaustion; empty and stale caches cannot define the reported range. Provider failures propagate instead of masquerading as complete cached history.
+- `run_backtest` remains provider-free and order-routing-free. TopBot data acquisition happens before it, inside the same public POST request.
+- Successful results report actual execution coverage in `range`: `contract_id`, `symbol`, `timeframe_unit`, `timeframe_unit_number`, `start`, `end`, and `bar_count`.
+- Fixed 366-day and 20,000 execution-bar caps were removed. No successful result may be a limited prefix; later resource controls must either process the complete resolved input or fail explicitly before persistence.
+
+## Ownership boundary for Agent 5
+
+Build upon these feature-owned seams in `backend/app/services/bot_backtesting.py`:
+
+- `_ResolvedBacktestWindow`, `_load_primary_closed_candles`, `_requested_backtest_bounds`, `_resolve_backtest_window`, and the exact-primary discovery helpers
+- Public orchestration in `prepare_bot_backtest_data` and `create_bot_backtest`
+- Actual range provenance returned by `BacktestEngine.run`
+- `_validate_settings` range policy and `_assumptions_snapshot` market-data wording
+
+Avoid changing those public contracts or response field names without coordinating first. Agent 5 owns follow-on performance work inside replay/preparation/query internals, measured resource controls, pagination or batching, and equivalence/resource-safety tests. Preserve exact-contract filtering, the single captured closure boundary, the one-call TopBot workflow, and fail-before-persist semantics.
+
+Frontend consumers depend on a single `POST /api/bots/{id}/backtests`; `/backtests/prepare` is intentionally not public.

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -17,11 +17,17 @@ import {
   writeStoredAccountId,
 } from "../lib/accountSelection";
 import { getSelectableAccounts, refreshTrades } from "../lib/appShellApi";
+import { warmSelectedBot } from "../lib/api";
 import { sortAccountsForSelection } from "../lib/accountOrdering";
 import { getDemoAccountLabel, getDemoUserEmail, useDemoMode } from "../lib/demoMode";
 import { ACCOUNT_TRADES_SYNCED_EVENT, type AccountTradesSyncedDetail } from "../lib/tradeSyncEvents";
 import type { AccountInfo } from "../lib/types";
 import { getCurrentUserEmailSync, hasSupabaseConfig, signOutSupabase } from "../lib/supabase";
+
+export interface AppShellOutletContext {
+  accounts: AccountInfo[];
+  accountsLoading: boolean;
+}
 
 function AppShellRouteFallback() {
   return (
@@ -95,6 +101,31 @@ export function AppShell() {
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    const runWarmup = () => {
+      if (!cancelled) {
+        void warmSelectedBot().catch(() => {
+          // Background warming is best-effort and must never affect app startup.
+        });
+      }
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      const requestId = window.requestIdleCallback(runWarmup, { timeout: 2_000 });
+      return () => {
+        cancelled = true;
+        window.cancelIdleCallback(requestId);
+      };
+    }
+
+    const timeoutId = window.setTimeout(runWarmup, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
   const queryAccountId = parseAccountId(new URLSearchParams(location.search).get(ACCOUNT_QUERY_PARAM));
   const orderedAccounts = useMemo(() => sortAccountsForSelection(accounts), [accounts]);
   const persistedMainAccountId = orderedAccounts.find((account) => account.is_main)?.id ?? null;
@@ -123,6 +154,10 @@ export function AppShell() {
   const currentUserEmail = getCurrentUserEmailSync();
   const currentUserEmailDisplay = getDemoUserEmail(currentUserEmail);
   const isTradesRoute = location.pathname.startsWith("/trades");
+  const outletContext = useMemo<AppShellOutletContext>(
+    () => ({ accounts: orderedAccounts, accountsLoading }),
+    [accountsLoading, orderedAccounts],
+  );
 
   function handleAccountChange(rawValue: string) {
     const nextAccountId = parseAccountId(rawValue);
@@ -275,7 +310,7 @@ export function AppShell() {
         )}
       >
         <Suspense fallback={<AppShellRouteFallback />}>
-          <Outlet />
+          <Outlet context={outletContext} />
         </Suspense>
       </main>
     </div>

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -23,6 +23,11 @@ import { ACCOUNT_TRADES_SYNCED_EVENT, type AccountTradesSyncedDetail } from "../
 import type { AccountInfo } from "../lib/types";
 import { getCurrentUserEmailSync, hasSupabaseConfig, signOutSupabase } from "../lib/supabase";
 
+export interface AppShellOutletContext {
+  accounts: AccountInfo[];
+  accountsLoading: boolean;
+}
+
 function AppShellRouteFallback() {
   return (
     <div className="space-y-5 pb-8">
@@ -123,6 +128,10 @@ export function AppShell() {
   const currentUserEmail = getCurrentUserEmailSync();
   const currentUserEmailDisplay = getDemoUserEmail(currentUserEmail);
   const isTradesRoute = location.pathname.startsWith("/trades");
+  const outletContext = useMemo<AppShellOutletContext>(
+    () => ({ accounts: orderedAccounts, accountsLoading }),
+    [accountsLoading, orderedAccounts],
+  );
 
   function handleAccountChange(rawValue: string) {
     const nextAccountId = parseAccountId(rawValue);
@@ -275,7 +284,7 @@ export function AppShell() {
         )}
       >
         <Suspense fallback={<AppShellRouteFallback />}>
-          <Outlet />
+          <Outlet context={outletContext} />
         </Suspense>
       </main>
     </div>

--- a/frontend/src/lib/api.performance.test.ts
+++ b/frontend/src/lib/api.performance.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountInfo, BotConfig, ProjectXMarketCandle } from "./types";
+
+vi.mock("./supabase", () => ({
+  getAccessToken: vi.fn(async () => null),
+}));
+
+const SELECTED_BOT_STORAGE_KEY = "topsignal.bot.selected-config-id";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function installStorage(): Map<string, string> {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    clear: vi.fn(() => values.clear()),
+  });
+  return values;
+}
+
+function makeAccount(id: number, accountState: AccountInfo["account_state"]): AccountInfo {
+  return {
+    id,
+    name: `Account ${id}`,
+    provider_name: "projectx",
+    custom_display_name: null,
+    balance: 50_000,
+    status: accountState,
+    account_state: accountState,
+    is_main: id === 1,
+    can_trade: accountState === "ACTIVE",
+    is_visible: accountState !== "HIDDEN",
+    last_trade_at: null,
+  };
+}
+
+function makeBot(id: number, overrides: Partial<BotConfig> = {}): BotConfig {
+  return {
+    id,
+    name: `Bot ${id}`,
+    account_id: 1,
+    provider: "projectx",
+    enabled: true,
+    execution_mode: "dry_run",
+    strategy_type: "sma_cross",
+    strategy_params: {},
+    contract_id: `CONTRACT-${id}`,
+    symbol: "MNQ",
+    timeframe_unit: "minute",
+    timeframe_unit_number: 5,
+    lookback_bars: 100,
+    fast_period: 9,
+    slow_period: 21,
+    order_size: 1,
+    max_contracts: 1,
+    max_daily_loss: 500,
+    max_trades_per_day: 5,
+    max_open_position: 1,
+    allowed_contracts: [],
+    trading_start_time: "09:30",
+    trading_end_time: "16:00",
+    cooldown_seconds: 0,
+    max_data_staleness_seconds: 60,
+    allow_market_depth: false,
+    created_at: "2026-07-10T12:00:00Z",
+    updated_at: "2026-07-10T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("api request reuse", () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    storage = installStorage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("deduplicates concurrent config lists and serves later reads from cache", async () => {
+    const networkResponse = deferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>(() => networkResponse.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const { botsApi } = await import("./api");
+    const payload = { items: [makeBot(7)], total: 1 };
+
+    const first = botsApi.listConfigs(41);
+    const second = botsApi.listConfigs(41);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    networkResponse.resolve(jsonResponse(payload));
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(secondResult).toBe(firstResult);
+    await expect(botsApi.listConfigs(41)).resolves.toBe(firstResult);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a failed config request so the next caller can retry", async () => {
+    const payload = { items: [makeBot(8)], total: 1 };
+    let attempt = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      attempt += 1;
+      return attempt === 1
+        ? jsonResponse({ detail: "temporarily unavailable" }, 503)
+        : jsonResponse(payload);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { botsApi } = await import("./api");
+
+    await expect(botsApi.listConfigs()).rejects.toThrow("temporarily unavailable");
+    await expect(botsApi.listConfigs()).resolves.toEqual(payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates the config list cache after a successful mutation", async () => {
+    const original = makeBot(7);
+    const updated = makeBot(7, { name: "Updated bot" });
+    let listReads = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/bots" && init?.method === "GET") {
+        listReads += 1;
+        return jsonResponse({ items: [listReads === 1 ? original : updated], total: 1 });
+      }
+      if (url.pathname === "/api/bots/7" && init?.method === "PATCH") {
+        return jsonResponse(updated);
+      }
+      throw new Error(`Unexpected request: ${init?.method} ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { botsApi } = await import("./api");
+
+    await expect(botsApi.listConfigs()).resolves.toEqual({ items: [original], total: 1 });
+    await expect(botsApi.listConfigs()).resolves.toEqual({ items: [original], total: 1 });
+    expect(listReads).toBe(1);
+
+    await botsApi.updateConfig(7, { name: updated.name });
+    await expect(botsApi.listConfigs()).resolves.toEqual({ items: [updated], total: 1 });
+
+    expect(listReads).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("shares account list in-flight work and cache across account consumers", async () => {
+    const accounts = [makeAccount(1, "ACTIVE"), makeAccount(2, "LOCKED_OUT"), makeAccount(3, "HIDDEN")];
+    const networkResponse = deferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>(() => networkResponse.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const { accountsApi } = await import("./api");
+
+    const allAccounts = accountsApi.getAccounts({ showInactive: true, showMissing: false });
+    const selectableAccounts = accountsApi.getSelectableAccounts();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    networkResponse.resolve(jsonResponse(accounts));
+    await expect(allAccounts).resolves.toEqual(accounts);
+    await expect(selectableAccounts).resolves.toEqual(accounts.slice(0, 2));
+
+    await expect(accountsApi.getAccounts({ showInactive: true, showMissing: false })).resolves.toEqual(accounts);
+    await expect(accountsApi.getSelectableAccounts()).resolves.toEqual(accounts.slice(0, 2));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const requestedUrl = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(requestedUrl.pathname).toBe("/api/accounts");
+    expect(requestedUrl.searchParams.get("show_inactive")).toBe("true");
+    expect(requestedUrl.searchParams.get("show_missing")).toBe("false");
+  });
+
+  it("keeps a shared candle request alive when one consumer aborts", async () => {
+    const candles: ProjectXMarketCandle[] = [
+      {
+        id: 1,
+        contract_id: "CONTRACT-7",
+        symbol: "MNQ",
+        live: false,
+        unit: "minute",
+        unit_number: 5,
+        timestamp: "2026-07-10T14:30:00Z",
+        open: 20_000,
+        high: 20_010,
+        low: 19_995,
+        close: 20_005,
+        volume: 100,
+        is_partial: false,
+        fetched_at: "2026-07-10T14:31:00Z",
+      },
+    ];
+    const networkResponse = deferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>(() => networkResponse.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const { botsApi } = await import("./api");
+    const query = {
+      contractId: "CONTRACT-7",
+      symbol: "MNQ",
+      start: "2026-07-10T13:00:00Z",
+      end: "2026-07-10T15:00:00Z",
+      unit: "minute" as const,
+      unitNumber: 5,
+      limit: 500,
+    };
+    const controller = new AbortController();
+    const nearbyQuery = {
+      ...query,
+      start: "2026-07-10T13:00:01Z",
+      end: "2026-07-10T15:00:01Z",
+    };
+
+    const abortingConsumer = botsApi.getCandles(query, { signal: controller.signal });
+    const survivingConsumer = botsApi.getCandles(nearbyQuery);
+    controller.abort();
+
+    await expect(abortingConsumer).rejects.toMatchObject({ name: "AbortError" });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    networkResponse.resolve(jsonResponse(candles));
+
+    await expect(survivingConsumer).resolves.toEqual(candles);
+    await expect(botsApi.getCandles(nearbyQuery)).resolves.toEqual(candles);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.signal).toBeUndefined();
+  });
+
+  it("warms only the selected bot, configured timeframe first, with unique bounded strategy timeframes", async () => {
+    storage.set(SELECTED_BOT_STORAGE_KEY, "22");
+    const unselectedBot = makeBot(11, { contract_id: "UNSELECTED-CONTRACT" });
+    const selectedBot = makeBot(22, {
+      contract_id: "SELECTED-CONTRACT",
+      timeframe_unit: "minute",
+      timeframe_unit_number: 5,
+      strategy_type: "topbot_adaptive",
+      strategy_params: {
+        source_strategies: [
+          "support_resistance",
+          "relative_strength_spy",
+          "supertrend_pivot",
+          "delayed_orb_confirmation",
+        ],
+      },
+    });
+    const configuredCandleResponse = deferred<Response>();
+    const candleUrls: URL[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/bots") {
+        return jsonResponse({ items: [unselectedBot, selectedBot], total: 2 });
+      }
+      if (url.pathname === "/api/projectx/candles") {
+        candleUrls.push(url);
+        if (candleUrls.length === 1) {
+          return configuredCandleResponse.promise;
+        }
+        return jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { botsApi } = await import("./api");
+
+    const firstWarmup = botsApi.warmSelected();
+    const secondWarmup = botsApi.warmSelected();
+    expect(secondWarmup).toBe(firstWarmup);
+
+    await vi.waitFor(() => expect(candleUrls).toHaveLength(1));
+    expect(candleUrls[0].searchParams.get("contract_id")).toBe("SELECTED-CONTRACT");
+    expect(candleUrls[0].searchParams.get("unit")).toBe("minute");
+    expect(candleUrls[0].searchParams.get("unit_number")).toBe("5");
+
+    configuredCandleResponse.resolve(jsonResponse([]));
+    await firstWarmup;
+
+    expect(candleUrls).toHaveLength(4);
+    expect(candleUrls.every((url) => url.searchParams.get("contract_id") === "SELECTED-CONTRACT")).toBe(true);
+    const warmedTimeframes = candleUrls.map(
+      (url) => `${url.searchParams.get("unit")}:${url.searchParams.get("unit_number")}`,
+    );
+    expect(warmedTimeframes[0]).toBe("minute:5");
+    expect(new Set(warmedTimeframes)).toEqual(new Set(["minute:5", "hour:1", "hour:4", "day:1"]));
+  });
+});

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi, botsApi, buildProjectXCandleRequestKey } from "./api";
+import { accountsApi, botsApi, buildProjectXCandleRequestKey, buildUserScopedProjectXCandleRequestKey } from "./api";
 import { getAccessToken } from "./supabase";
 
 function installDemoModeStorage(enabled: boolean) {
@@ -252,6 +252,21 @@ describe("botsApi", () => {
     expect(buildProjectXCandleRequestKey({ ...query, includePartialBar: true })).not.toBe(normal);
     expect(buildProjectXCandleRequestKey({ ...query, repair: true })).not.toBe(normal);
     expect(buildProjectXCandleRequestKey({ ...query, refresh: true })).not.toBe(normal);
+  });
+
+  it("never shares an identical candle request across authenticated cache scopes", () => {
+    const query = {
+      contractId: "CON.F.US.MNQ.M26",
+      unit: "minute" as const,
+      unitNumber: 5,
+      start: "2026-07-10T14:00:00.000Z",
+      end: "2026-07-10T15:00:00.000Z",
+      limit: 300,
+    };
+
+    expect(buildUserScopedProjectXCandleRequestKey("user:one", query)).not.toBe(
+      buildUserScopedProjectXCandleRequestKey("user:two", query),
+    );
   });
 });
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi, botsApi } from "./api";
+import { accountsApi, botsApi, buildProjectXCandleRequestKey } from "./api";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -168,5 +168,48 @@ describe("botsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual(payload);
+  });
+
+  it("deduplicates closed-history identities within the same candle bucket", () => {
+    const base = {
+      contractId: " con.f.us.mnq.m26 ",
+      symbol: " mnq ",
+      unit: "minute" as const,
+      unitNumber: 5,
+      limit: 300,
+      includePartialBar: false,
+    };
+
+    expect(
+      buildProjectXCandleRequestKey({
+        ...base,
+        start: "2026-07-10T13:00:01.000Z",
+        end: "2026-07-10T14:04:01.000Z",
+      }),
+    ).toBe(
+      buildProjectXCandleRequestKey({
+        ...base,
+        contractId: "CON.F.US.MNQ.M26",
+        symbol: "MNQ",
+        start: "2026-07-10T13:00:59.000Z",
+        end: "2026-07-10T14:04:59.000Z",
+      }),
+    );
+  });
+
+  it("keeps partial, repair, and authoritative refresh requests distinct", () => {
+    const query = {
+      contractId: "CON.F.US.MNQ.M26",
+      unit: "minute" as const,
+      unitNumber: 1,
+      start: "2026-07-10T14:00:00.000Z",
+      end: "2026-07-10T14:05:00.000Z",
+      limit: 5,
+    };
+    const normal = buildProjectXCandleRequestKey(query);
+
+    expect(buildProjectXCandleRequestKey({ ...query, includePartialBar: true })).not.toBe(normal);
+    expect(buildProjectXCandleRequestKey({ ...query, repair: true })).not.toBe(normal);
+    expect(buildProjectXCandleRequestKey({ ...query, refresh: true })).not.toBe(normal);
   });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,7 +4,7 @@ vi.mock("./supabase", () => ({
   getAccessToken: vi.fn(async () => null),
 }));
 
-import { accountsApi } from "./api";
+import { accountsApi, botsApi } from "./api";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -109,5 +109,64 @@ describe("accountsApi", () => {
     expect(trades.length).toBe(summary.trade_count);
     expect(calendar.length).toBeGreaterThan(10);
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("botsApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ id: 17 }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("posts backtests to the plural backend route", async () => {
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.runBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
+  });
+
+  it("prepares TopBot replay data through the dedicated cache route", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const payload = {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-08T23:59:59.999Z",
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    };
+
+    await botsApi.prepareBacktest(42, payload);
+
+    const fetchMock = vi.mocked(fetch);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual(payload);
   });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -130,10 +130,8 @@ describe("botsApi", () => {
     vi.clearAllMocks();
   });
 
-  it("posts backtests to the plural backend route", async () => {
+  it("posts one date-free full-history request to the plural backend route", async () => {
     const payload = {
-      start: "2026-07-01T00:00:00.000Z",
-      end: "2026-07-08T23:59:59.999Z",
       starting_balance: 50_000,
       commission_per_contract: 1.2,
       slippage_ticks: 1,
@@ -148,25 +146,7 @@ describe("botsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual(payload);
-  });
-
-  it("prepares TopBot replay data through the dedicated cache route", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
-    const payload = {
-      start: "2026-07-01T00:00:00.000Z",
-      end: "2026-07-08T23:59:59.999Z",
-      starting_balance: 50_000,
-      commission_per_contract: 1.2,
-      slippage_ticks: 1,
-      force_close_at_end: true,
-    };
-
-    await botsApi.prepareBacktest(42, payload);
-
-    const fetchMock = vi.mocked(fetch);
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests/prepare");
-    expect(init?.method).toBe("POST");
-    expect(JSON.parse(String(init?.body))).toEqual(payload);
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("start");
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("end");
   });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -171,6 +171,23 @@ describe("botsApi", () => {
     vi.clearAllMocks();
   });
 
+  it("binds the bot list and cache scope to one captured authentication token", async () => {
+    const token = jwt("user-one");
+    vi.mocked(getAccessToken).mockResolvedValue(token);
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ items: [], total: 0 }));
+
+    const result = await botsApi.listConfigsWithCacheScope();
+
+    expect(result).toEqual({
+      configs: { items: [], total: 0 },
+      cacheScope: "user:https%3A%2F%2Fauth.example.test:user-one",
+    });
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetch).mock.calls[0][1]?.headers).toMatchObject({
+      Authorization: `Bearer ${token}`,
+    });
+  });
+
   it("posts one date-free full-history request to the plural backend route", async () => {
     const payload = {
       starting_balance: 50_000,

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -5,6 +5,7 @@ vi.mock("./supabase", () => ({
 }));
 
 import { accountsApi, botsApi } from "./api";
+import { getAccessToken } from "./supabase";
 
 function installDemoModeStorage(enabled: boolean) {
   vi.stubGlobal("localStorage", {
@@ -17,6 +18,7 @@ function installDemoModeStorage(enabled: boolean) {
 
 describe("accountsApi", () => {
   beforeEach(() => {
+    vi.mocked(getAccessToken).mockResolvedValue(null);
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -110,10 +112,49 @@ describe("accountsApi", () => {
     expect(calendar.length).toBeGreaterThan(10);
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it("deduplicates within one user while isolating cache and in-flight work across auth switches", async () => {
+    installDemoModeStorage(false);
+    const tokenOne = jwt("user-one");
+    const tokenTwo = jwt("user-two");
+    const pending = new Map<string, (response: Response) => void>();
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? "";
+      return new Promise<Response>((resolve) => pending.set(authorization, resolve));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.mocked(getAccessToken).mockResolvedValue(tokenOne);
+    const userOneFirst = accountsApi.getAccounts({ showInactive: true, showMissing: true });
+    const userOneDeduped = accountsApi.getAccounts({ showInactive: true, showMissing: true });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    vi.mocked(getAccessToken).mockResolvedValue(tokenTwo);
+    const userTwoFirst = accountsApi.getAccounts({ showInactive: true, showMissing: true });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    pending.get(`Bearer ${tokenTwo}`)?.(jsonResponse([{ id: 2, account_state: "ACTIVE" }]));
+    await expect(userTwoFirst).resolves.toEqual([{ id: 2, account_state: "ACTIVE" }]);
+    pending.get(`Bearer ${tokenOne}`)?.(jsonResponse([{ id: 1, account_state: "ACTIVE" }]));
+    await expect(Promise.all([userOneFirst, userOneDeduped])).resolves.toEqual([
+      [{ id: 1, account_state: "ACTIVE" }],
+      [{ id: 1, account_state: "ACTIVE" }],
+    ]);
+
+    await expect(accountsApi.getAccounts({ showInactive: true, showMissing: true })).resolves.toEqual([
+      { id: 2, account_state: "ACTIVE" },
+    ]);
+    vi.mocked(getAccessToken).mockResolvedValue(tokenOne);
+    await expect(accountsApi.getAccounts({ showInactive: true, showMissing: true })).resolves.toEqual([
+      { id: 1, account_state: "ACTIVE" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("botsApi", () => {
   beforeEach(() => {
+    vi.mocked(getAccessToken).mockResolvedValue(null);
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -132,7 +173,7 @@ describe("botsApi", () => {
 
   it("posts backtests to the plural backend route", async () => {
     const payload = {
-      start: "2026-07-01T00:00:00.000Z",
+      start: "2019-01-01T00:00:00.000Z",
       end: "2026-07-08T23:59:59.999Z",
       starting_balance: 50_000,
       commission_per_contract: 1.2,
@@ -148,6 +189,9 @@ describe("botsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/bots/42/backtests");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual(payload);
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("limit");
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("max_bars");
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("confirm_live_order_routing");
   });
 
   it("prepares TopBot replay data through the dedicated cache route", async () => {
@@ -170,3 +214,16 @@ describe("botsApi", () => {
     expect(JSON.parse(String(init?.body))).toEqual(payload);
   });
 });
+
+function jwt(subject: string): string {
+  const header = globalThis.btoa(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const payload = globalThis.btoa(JSON.stringify({ iss: "https://auth.example.test", sub: subject }));
+  return `${header}.${payload}.signature`;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,6 +69,10 @@ import { getAccessToken } from "./supabase";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8000";
 const ACCOUNTS_CACHE_TTL_MS = 10 * 60_000;
 const ACCOUNT_READ_CACHE_TTL_MS = 10 * 60_000;
+const BOT_CONFIG_CACHE_TTL_MS = 60_000;
+const BOT_ACTIVITY_CACHE_TTL_MS = 5_000;
+const BOT_CANDLE_CACHE_TTL_MS = 30_000;
+const SELECTED_BOT_STORAGE_KEY = "topsignal.bot.selected-config-id";
 const BACKTEST_REQUEST_TIMEOUT_MS = 5 * 60_000;
 
 type QueryValue = string | number | boolean | null | undefined;
@@ -148,13 +152,68 @@ function getTimedCachedRequest<T>(options: TimedCachedRequestOptions<T>): Promis
   });
 
   inFlight.set(cacheKey, request);
-  void request.finally(() => {
+  const clearInFlight = () => {
     if (inFlight.get(cacheKey) === request) {
       inFlight.delete(cacheKey);
     }
-  });
+  };
+  void request.then(clearInFlight, clearInFlight);
 
   return request;
+}
+
+function getSharedInFlightRequest<T>(
+  inFlight: Map<string, Promise<T>>,
+  cacheKey: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  const pendingRequest = inFlight.get(cacheKey);
+  if (pendingRequest) {
+    return pendingRequest;
+  }
+  const request = load();
+  inFlight.set(cacheKey, request);
+  const clearInFlight = () => {
+    if (inFlight.get(cacheKey) === request) {
+      inFlight.delete(cacheKey);
+    }
+  };
+  void request.then(clearInFlight, clearInFlight);
+  return request;
+}
+
+function abortError(): Error {
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function withConsumerAbort<T>(request: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return request;
+  }
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = () => reject(abortError());
+    signal.addEventListener("abort", handleAbort, { once: true });
+    void request.then(
+      (value) => {
+        signal.removeEventListener("abort", handleAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", handleAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function requestCacheScope(): "demo" | "live" {
+  return isDemoModeEnabled() ? "demo" : "live";
 }
 
 function buildUrl(path: string, query?: Record<string, QueryValue>) {
@@ -484,7 +543,7 @@ function resolveGetAccountsOptions(optionsOrOnlyActive?: GetAccountsOptions | bo
 }
 
 function accountsQueryCacheKey(options: Required<GetAccountsOptions>) {
-  return `${options.showInactive ? 1 : 0}:${options.showMissing ? 1 : 0}`;
+  return `${requestCacheScope()}:${options.showInactive ? 1 : 0}:${options.showMissing ? 1 : 0}`;
 }
 
 function getAccountCacheVersion(accountId: number) {
@@ -574,36 +633,20 @@ function invalidateAccountsListCaches() {
 
 function getAccountsFromApi(options: Required<GetAccountsOptions>): Promise<AccountInfo[]> {
   const cacheKey = accountsQueryCacheKey(options);
-  const now = Date.now();
-  const cached = accountsCacheByQuery.get(cacheKey);
-  if (!options.bypassCache && cached && cached.expiresAtMs > now) {
-    return Promise.resolve(cached.value);
-  }
-
-  const inFlight = inFlightAccountsByQuery.get(cacheKey);
-  if (!options.bypassCache && inFlight) {
-    return inFlight;
-  }
-
-  const request = requestJson<AccountInfo[]>("/api/accounts", {
-    query: {
-      show_inactive: options.showInactive,
-      show_missing: options.showMissing,
-    },
-  })
-    .then((accounts) => {
-      accountsCacheByQuery.set(cacheKey, {
-        value: accounts,
-        expiresAtMs: Date.now() + ACCOUNTS_CACHE_TTL_MS,
-      });
-      return accounts;
-    })
-    .finally(() => {
-      inFlightAccountsByQuery.delete(cacheKey);
-    });
-
-  inFlightAccountsByQuery.set(cacheKey, request);
-  return request;
+  return getTimedCachedRequest({
+    cache: accountsCacheByQuery,
+    inFlight: inFlightAccountsByQuery,
+    cacheKey,
+    ttlMs: ACCOUNTS_CACHE_TTL_MS,
+    bypassCache: options.bypassCache,
+    load: () =>
+      requestJson<AccountInfo[]>("/api/accounts", {
+        query: {
+          show_inactive: options.showInactive,
+          show_missing: options.showMissing,
+        },
+      }),
+  });
 }
 
 function getAccountsCached(optionsOrOnlyActive?: GetAccountsOptions | boolean): Promise<AccountInfo[]> {
@@ -943,6 +986,319 @@ interface CandleQuery {
   repair?: boolean;
 }
 
+interface BotConfigListOptions {
+  bypassCache?: boolean;
+}
+
+export interface BotWarmupTimeframe {
+  unit: BotTimeframeUnit;
+  unitNumber: number;
+}
+
+const BOT_WARMUP_MAX_TIMEFRAMES = 4;
+const BOT_CHART_MIN_BARS = 300;
+const BOT_CHART_MAX_BARS = 2_000;
+const BOT_CHART_LOOKBACK_MULTIPLIER = 3;
+const BOT_TIMEFRAME_SECONDS: Record<BotTimeframeUnit, number> = {
+  second: 1,
+  minute: 60,
+  hour: 60 * 60,
+  day: 24 * 60 * 60,
+  week: 7 * 24 * 60 * 60,
+  month: 31 * 24 * 60 * 60,
+};
+
+const botConfigsCacheByQuery = new Map<string, TimedCache<BotConfigListResponse>>();
+const inFlightBotConfigsByQuery = new Map<string, Promise<BotConfigListResponse>>();
+const botActivityCacheByQuery = new Map<string, TimedCache<BotActivity>>();
+const inFlightBotActivityByQuery = new Map<string, Promise<BotActivity>>();
+const botCandlesCacheByQuery = new Map<string, TimedCache<ProjectXMarketCandle[]>>();
+const inFlightBotCandlesByQuery = new Map<string, Promise<ProjectXMarketCandle[]>>();
+let selectedBotWarmupRequest: Promise<void> | null = null;
+
+function normalizeTimeframe(unit: BotTimeframeUnit, unitNumber: number): BotWarmupTimeframe {
+  return {
+    unit,
+    unitNumber: Math.max(1, Math.trunc(unitNumber)),
+  };
+}
+
+function deriveLowerTimeframe(unit: BotTimeframeUnit, unitNumber: number): BotWarmupTimeframe {
+  const totalSeconds = BOT_TIMEFRAME_SECONDS[unit] * Math.max(1, Math.trunc(unitNumber));
+  const units: BotTimeframeUnit[] = ["month", "week", "day", "hour", "minute"];
+  for (const divisor of [4, 3, 5, 2]) {
+    if (totalSeconds % divisor !== 0) {
+      continue;
+    }
+    const candidateSeconds = totalSeconds / divisor;
+    for (const candidateUnit of units) {
+      const seconds = BOT_TIMEFRAME_SECONDS[candidateUnit];
+      if (candidateSeconds % seconds === 0) {
+        return normalizeTimeframe(candidateUnit, candidateSeconds / seconds);
+      }
+    }
+    if (unit === "second") {
+      return normalizeTimeframe("second", candidateSeconds);
+    }
+  }
+  return normalizeTimeframe(unit, unitNumber);
+}
+
+function addWarmupTimeframe(target: BotWarmupTimeframe[], timeframe: BotWarmupTimeframe) {
+  const normalized = normalizeTimeframe(timeframe.unit, timeframe.unitNumber);
+  if (target.some((item) => item.unit === normalized.unit && item.unitNumber === normalized.unitNumber)) {
+    return;
+  }
+  if (target.length < BOT_WARMUP_MAX_TIMEFRAMES) {
+    target.push(normalized);
+  }
+}
+
+function addStrategyWarmupTimeframes(
+  target: BotWarmupTimeframe[],
+  bot: BotConfig,
+  strategyType: BotConfig["strategy_type"],
+) {
+  if (strategyType === "topbot_adaptive") {
+    for (const sourceStrategy of bot.strategy_params?.source_strategies ?? []) {
+      if (sourceStrategy !== "topbot_adaptive") {
+        addStrategyWarmupTimeframes(target, bot, sourceStrategy);
+      }
+      if (target.length >= BOT_WARMUP_MAX_TIMEFRAMES) {
+        break;
+      }
+    }
+    return;
+  }
+  if (strategyType === "delayed_orb_confirmation") {
+    addWarmupTimeframe(target, { unit: "minute", unitNumber: 1 });
+    return;
+  }
+  if (strategyType === "support_resistance" || strategyType === "liquidity_sweep_retest" || strategyType === "macd_support_resistance") {
+    addWarmupTimeframe(target, { unit: "hour", unitNumber: 1 });
+    addWarmupTimeframe(target, { unit: "hour", unitNumber: 4 });
+    return;
+  }
+  if (strategyType === "supertrend_pivot") {
+    addWarmupTimeframe(target, { unit: "day", unitNumber: 1 });
+    return;
+  }
+  if (strategyType === "fvg_sweep_mss") {
+    addWarmupTimeframe(target, deriveLowerTimeframe(bot.timeframe_unit, bot.timeframe_unit_number));
+    return;
+  }
+  if (strategyType === "relative_strength_spy" || strategyType === "opening_rvol_breakout" || strategyType === "vwap_gap_retrace") {
+    addWarmupTimeframe(target, { unit: "minute", unitNumber: 5 });
+  }
+}
+
+export function getBotWarmupTimeframes(bot: BotConfig): BotWarmupTimeframe[] {
+  const timeframes: BotWarmupTimeframe[] = [];
+  addWarmupTimeframe(timeframes, { unit: bot.timeframe_unit, unitNumber: bot.timeframe_unit_number });
+  addStrategyWarmupTimeframes(timeframes, bot, bot.strategy_type);
+  return timeframes;
+}
+
+export function readSelectedBotConfigId(): number | null {
+  try {
+    if (typeof localStorage === "undefined") {
+      return null;
+    }
+    const value = Number.parseInt(localStorage.getItem(SELECTED_BOT_STORAGE_KEY) ?? "", 10);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function rememberSelectedBotConfigId(botConfigId: number | null): void {
+  try {
+    if (typeof localStorage === "undefined") {
+      return;
+    }
+    if (botConfigId && Number.isFinite(botConfigId) && botConfigId > 0) {
+      localStorage.setItem(SELECTED_BOT_STORAGE_KEY, String(Math.trunc(botConfigId)));
+    } else {
+      localStorage.removeItem(SELECTED_BOT_STORAGE_KEY);
+    }
+  } catch {
+    // Selection persistence is only an optimization hint.
+  }
+}
+
+function botConfigCacheKey(accountId?: number): string {
+  return `${requestCacheScope()}:${accountId ?? "all"}`;
+}
+
+function invalidateBotConfigCaches() {
+  botConfigsCacheByQuery.clear();
+  inFlightBotConfigsByQuery.clear();
+}
+
+function botActivityCacheKey(botConfigId: number, limit: number): string {
+  return `${requestCacheScope()}:${botConfigId}:${limit}`;
+}
+
+function invalidateBotActivityCaches(botConfigId?: number) {
+  if (typeof botConfigId !== "number") {
+    botActivityCacheByQuery.clear();
+    inFlightBotActivityByQuery.clear();
+    return;
+  }
+  const prefix = `${requestCacheScope()}:${botConfigId}:`;
+  clearMapByPrefix(botActivityCacheByQuery, prefix);
+  clearMapByPrefix(inFlightBotActivityByQuery, prefix);
+}
+
+function listBotConfigs(accountId?: number, options: BotConfigListOptions = {}): Promise<BotConfigListResponse> {
+  const cacheKey = botConfigCacheKey(accountId);
+  return getTimedCachedRequest({
+    cache: botConfigsCacheByQuery,
+    inFlight: inFlightBotConfigsByQuery,
+    cacheKey,
+    ttlMs: BOT_CONFIG_CACHE_TTL_MS,
+    bypassCache: options.bypassCache,
+    load: () =>
+      requestJson<BotConfigListResponse>("/api/bots", {
+        query: {
+          account_id: accountId,
+        },
+      }),
+  });
+}
+
+function getBotActivity(botConfigId: number, limit = 50): Promise<BotActivity> {
+  const normalizedLimit = Math.max(1, Math.trunc(limit));
+  const cacheKey = botActivityCacheKey(botConfigId, normalizedLimit);
+  return getTimedCachedRequest({
+    cache: botActivityCacheByQuery,
+    inFlight: inFlightBotActivityByQuery,
+    cacheKey,
+    ttlMs: BOT_ACTIVITY_CACHE_TTL_MS,
+    load: () =>
+      requestJson<BotActivity>(`/api/bots/${botConfigId}/activity`, {
+        query: {
+          limit: normalizedLimit,
+        },
+      }),
+  });
+}
+
+function normalizedCandleBoundary(value: string | undefined, bucketMs: number): string {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? String(Math.floor(parsed / bucketMs)) : value ?? "";
+}
+
+function botCandleCacheKey(query: CandleQuery): string {
+  const unit = query.unit ?? "minute";
+  const unitNumber = Math.max(1, Math.trunc(query.unitNumber ?? 5));
+  const bucketMs = BOT_TIMEFRAME_SECONDS[unit] * unitNumber * 1_000;
+  return [
+    requestCacheScope(),
+    query.contractId.trim(),
+    query.symbol?.trim().toUpperCase() ?? "",
+    query.live ?? false,
+    unit,
+    unitNumber,
+    Math.max(1, Math.trunc(query.limit ?? 500)),
+    query.includePartialBar ?? false,
+    query.refresh ?? false,
+    query.repair ?? false,
+    normalizedCandleBoundary(query.start, bucketMs),
+    normalizedCandleBoundary(query.end, bucketMs),
+  ].join("|");
+}
+
+function requestBotCandles(query: CandleQuery, options: RequestSignalOptions = {}): Promise<ProjectXMarketCandle[]> {
+  if (options.signal?.aborted) {
+    return Promise.reject(abortError());
+  }
+  const request = (signal?: AbortSignal) =>
+    requestJson<ProjectXMarketCandle[]>("/api/projectx/candles", {
+      query: {
+        contract_id: query.contractId,
+        symbol: query.symbol,
+        start: query.start,
+        end: query.end,
+        live: query.live ?? false,
+        unit: query.unit ?? "minute",
+        unit_number: query.unitNumber ?? 5,
+        limit: query.limit ?? 500,
+        include_partial_bar: query.includePartialBar ?? false,
+        refresh: query.refresh ?? false,
+        repair: query.repair ?? false,
+      },
+      signal,
+    });
+
+  const cacheKey = botCandleCacheKey(query);
+  const canCache = !query.live && !query.includePartialBar && !query.refresh && !query.repair;
+  const sharedRequest = canCache
+    ? getTimedCachedRequest({
+        cache: botCandlesCacheByQuery,
+        inFlight: inFlightBotCandlesByQuery,
+        cacheKey,
+        ttlMs: BOT_CANDLE_CACHE_TTL_MS,
+        load: () => request(),
+      })
+    : getSharedInFlightRequest(inFlightBotCandlesByQuery, cacheKey, () => request());
+  return withConsumerAbort(sharedRequest, options.signal);
+}
+
+function buildBotWarmupCandleQuery(bot: BotConfig, timeframe: BotWarmupTimeframe, now = new Date()): CandleQuery {
+  const unitNumber = Math.max(1, Math.trunc(timeframe.unitNumber));
+  const timeframeSeconds = BOT_TIMEFRAME_SECONDS[timeframe.unit] * unitNumber;
+  const lookbackBars = Math.max(1, Math.trunc(bot.lookback_bars));
+  const limit = Math.min(BOT_CHART_MAX_BARS, Math.max(BOT_CHART_MIN_BARS, lookbackBars * 4));
+  const end = Number.isFinite(now.getTime()) ? now : new Date();
+  const start = new Date(end.getTime() - timeframeSeconds * limit * BOT_CHART_LOOKBACK_MULTIPLIER * 1_000);
+  return {
+    contractId: bot.contract_id,
+    symbol: bot.symbol ?? undefined,
+    start: start.toISOString(),
+    end: end.toISOString(),
+    live: false,
+    unit: timeframe.unit,
+    unitNumber,
+    limit,
+    includePartialBar: false,
+    refresh: false,
+  };
+}
+
+async function runSelectedBotWarmup(): Promise<void> {
+  const configs = await listBotConfigs();
+  if (configs.items.length === 0) {
+    return;
+  }
+  const selectedId = readSelectedBotConfigId();
+  const selectedBot = configs.items.find((config) => config.id === selectedId) ?? configs.items[0];
+  const [configuredTimeframe, ...requiredTimeframes] = getBotWarmupTimeframes(selectedBot);
+  if (!configuredTimeframe) {
+    return;
+  }
+
+  await requestBotCandles(buildBotWarmupCandleQuery(selectedBot, configuredTimeframe)).catch(() => undefined);
+  await Promise.allSettled(
+    requiredTimeframes.map((timeframe) => requestBotCandles(buildBotWarmupCandleQuery(selectedBot, timeframe))),
+  );
+}
+
+export function warmSelectedBot(): Promise<void> {
+  if (selectedBotWarmupRequest) {
+    return selectedBotWarmupRequest;
+  }
+  const request = runSelectedBotWarmup();
+  selectedBotWarmupRequest = request;
+  const clearWarmup = () => {
+    if (selectedBotWarmupRequest === request) {
+      selectedBotWarmupRequest = null;
+    }
+  };
+  void request.then(clearWarmup, clearWarmup);
+  return request;
+}
+
 interface MarketPriceStreamQuery {
   contractId: string;
   symbol?: string;
@@ -1124,64 +1480,62 @@ export const botsApi = {
         live: query.live ?? false,
       },
     }),
-  getCandles: (query: CandleQuery, options: RequestSignalOptions = {}) =>
-    requestJson<ProjectXMarketCandle[]>("/api/projectx/candles", {
-      query: {
-        contract_id: query.contractId,
-        symbol: query.symbol,
-        start: query.start,
-        end: query.end,
-        live: query.live ?? false,
-        unit: query.unit ?? "minute",
-        unit_number: query.unitNumber ?? 5,
-        limit: query.limit ?? 500,
-        include_partial_bar: query.includePartialBar ?? false,
-        refresh: query.refresh ?? false,
-        repair: query.repair ?? false,
-      },
-      signal: options.signal,
-    }),
-  listConfigs: (accountId?: number) =>
-    requestJson<BotConfigListResponse>("/api/bots", {
-      query: {
-        account_id: accountId,
-      },
-    }),
+  getCandles: requestBotCandles,
+  listConfigs: listBotConfigs,
   createConfig: (payload: BotConfigInput) =>
     requestJson<BotConfig>("/api/bots", {
       method: "POST",
       body: payload,
+    }).then((config) => {
+      invalidateBotConfigCaches();
+      return config;
     }),
   updateConfig: (botConfigId: number, payload: BotConfigUpdateInput) =>
     requestJson<BotConfig>(`/api/bots/${botConfigId}`, {
       method: "PATCH",
       body: payload,
+    }).then((config) => {
+      invalidateBotConfigCaches();
+      invalidateBotActivityCaches(botConfigId);
+      return config;
     }),
   deleteConfig: (botConfigId: number) =>
     requestJson<void>(`/api/bots/${botConfigId}`, {
       method: "DELETE",
+    }).then((result) => {
+      invalidateBotConfigCaches();
+      invalidateBotActivityCaches(botConfigId);
+      if (readSelectedBotConfigId() === botConfigId) {
+        rememberSelectedBotConfigId(null);
+      }
+      return result;
     }),
   start: (botConfigId: number, options: BotStartOptions = {}) =>
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/start`, {
       method: "POST",
       body: botStartPayload(options),
+    }).then((evaluation) => {
+      invalidateBotActivityCaches(botConfigId);
+      return evaluation;
     }),
   evaluate: (botConfigId: number, options: BotStartOptions = { dryRun: true }) =>
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
+    }).then((evaluation) => {
+      invalidateBotActivityCaches(botConfigId);
+      return evaluation;
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>
     requestJson<BotEvaluation["run"]>(`/api/bots/${botConfigId}/stop`, {
       method: "POST",
+    }).then((run) => {
+      invalidateBotActivityCaches(botConfigId);
+      return run;
     }),
-  getActivity: (botConfigId: number, limit = 50) =>
-    requestJson<BotActivity>(`/api/bots/${botConfigId}/activity`, {
-      query: {
-        limit,
-      },
-    }),
+  getActivity: getBotActivity,
+  warmSelected: warmSelectedBot,
   evaluateTradePlan: (payload: TradePlanEvaluationInput) =>
     requestJson<TradeEvaluationResult>("/api/trade-plan/evaluate", {
       method: "POST",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,6 +78,8 @@ interface RequestJsonOptions {
   query?: Record<string, QueryValue>;
   body?: unknown;
   signal?: AbortSignal;
+  /** Reuse the token captured while selecting a user-scoped cache lane. */
+  accessTokenOverride?: string | null;
 }
 
 interface RequestMultipartOptions {
@@ -123,6 +125,16 @@ interface TimedCachedRequestOptions<T> {
   bypassCache?: boolean;
 }
 
+interface UserScopedTimedCachedRequestOptions<T> extends Omit<TimedCachedRequestOptions<T>, "cacheKey" | "load"> {
+  cacheKey: string;
+  load: (accessToken: string | null) => Promise<T>;
+}
+
+interface RequestAuthContext {
+  accessToken: string | null;
+  cacheScope: string;
+}
+
 function getTimedCachedRequest<T>(options: TimedCachedRequestOptions<T>): Promise<T> {
   const { cache, inFlight, cacheKey, ttlMs, load, bypassCache = false } = options;
   if (!bypassCache) {
@@ -148,13 +160,93 @@ function getTimedCachedRequest<T>(options: TimedCachedRequestOptions<T>): Promis
   });
 
   inFlight.set(cacheKey, request);
-  void request.finally(() => {
+  const clearIfCurrent = () => {
     if (inFlight.get(cacheKey) === request) {
       inFlight.delete(cacheKey);
     }
-  });
+  };
+  // Avoid a detached `finally()` promise: if `request` rejects, that child
+  // promise would otherwise surface an unhandled rejection even when the
+  // caller handles the original request.
+  void request.then(clearIfCurrent, clearIfCurrent);
 
   return request;
+}
+
+async function getUserScopedTimedCachedRequest<T>(options: UserScopedTimedCachedRequestOptions<T>): Promise<T> {
+  const auth = await getRequestAuthContext();
+  return getTimedCachedRequest({
+    ...options,
+    cacheKey: `${options.cacheKey}|scope:${auth.cacheScope}`,
+    load: () => options.load(auth.accessToken),
+  });
+}
+
+/**
+ * Stable, non-secret namespace for browser caches. Supabase access tokens are
+ * JWTs, so issuer + subject remain stable across token refreshes without ever
+ * storing the credential itself. Opaque-token fallback is intentionally
+ * session-scoped rather than exposing or persisting the token.
+ */
+export async function getAuthenticatedCacheScope(): Promise<string> {
+  return (await getRequestAuthContext()).cacheScope;
+}
+
+async function getRequestAuthContext(): Promise<RequestAuthContext> {
+  if (isDemoModeEnabled()) {
+    return { accessToken: null, cacheScope: "demo" };
+  }
+
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    return { accessToken: null, cacheScope: "anonymous" };
+  }
+
+  return {
+    accessToken,
+    cacheScope: getJwtUserScope(accessToken) ?? await getOpaqueTokenScope(accessToken),
+  };
+}
+
+function getJwtUserScope(accessToken: string): string | null {
+  const payload = accessToken.split(".")[1];
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const normalized = payload.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const decoded = JSON.parse(globalThis.atob(padded)) as { iss?: unknown; sub?: unknown };
+    if (typeof decoded.sub !== "string" || decoded.sub.trim() === "") {
+      return null;
+    }
+    const issuer = typeof decoded.iss === "string" ? decoded.iss : "supabase";
+    return `user:${encodeURIComponent(issuer)}:${encodeURIComponent(decoded.sub)}`;
+  } catch {
+    return null;
+  }
+}
+
+async function getOpaqueTokenScope(accessToken: string): Promise<string> {
+  if (globalThis.crypto?.subtle) {
+    const bytes = new TextEncoder().encode(accessToken);
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+    const fingerprint = Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, "0")).join("");
+    return `opaque:${fingerprint}`;
+  }
+
+  // Legacy-browser fallback. This never persists the credential itself; two
+  // independent 32-bit accumulators make accidental cross-user collisions
+  // vanishingly unlikely until Web Crypto is available.
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let index = 0; index < accessToken.length; index += 1) {
+    const value = accessToken.charCodeAt(index);
+    left = Math.imul(left ^ value, 0x01000193) >>> 0;
+    right = Math.imul(right ^ value, 0x85ebca6b) >>> 0;
+  }
+  return `opaque:${left.toString(16).padStart(8, "0")}${right.toString(16).padStart(8, "0")}`;
 }
 
 function buildUrl(path: string, query?: Record<string, QueryValue>) {
@@ -282,7 +374,7 @@ function normalizeJournalImage(image: JournalEntryImage): JournalEntryImage {
 }
 
 async function requestJson<T>(path: string, options: RequestJsonOptions = {}): Promise<T> {
-  const { method = "GET", query, body, signal } = options;
+  const { method = "GET", query, body, signal, accessTokenOverride } = options;
   if (method !== "GET" && isDemoModeEnabled()) {
     throw new ApiError("Demo mode is read-only. Turn it off to sync or save changes.", 409, null, null);
   }
@@ -292,7 +384,7 @@ async function requestJson<T>(path: string, options: RequestJsonOptions = {}): P
       return demoResponse.data;
     }
   }
-  const accessToken = await getAccessToken();
+  const accessToken = accessTokenOverride === undefined ? await getAccessToken() : accessTokenOverride;
   const url = buildUrl(path, query);
   const perfContext: RequestPerfContext = {
     method,
@@ -574,36 +666,21 @@ function invalidateAccountsListCaches() {
 
 function getAccountsFromApi(options: Required<GetAccountsOptions>): Promise<AccountInfo[]> {
   const cacheKey = accountsQueryCacheKey(options);
-  const now = Date.now();
-  const cached = accountsCacheByQuery.get(cacheKey);
-  if (!options.bypassCache && cached && cached.expiresAtMs > now) {
-    return Promise.resolve(cached.value);
-  }
-
-  const inFlight = inFlightAccountsByQuery.get(cacheKey);
-  if (!options.bypassCache && inFlight) {
-    return inFlight;
-  }
-
-  const request = requestJson<AccountInfo[]>("/api/accounts", {
-    query: {
-      show_inactive: options.showInactive,
-      show_missing: options.showMissing,
-    },
-  })
-    .then((accounts) => {
-      accountsCacheByQuery.set(cacheKey, {
-        value: accounts,
-        expiresAtMs: Date.now() + ACCOUNTS_CACHE_TTL_MS,
-      });
-      return accounts;
-    })
-    .finally(() => {
-      inFlightAccountsByQuery.delete(cacheKey);
-    });
-
-  inFlightAccountsByQuery.set(cacheKey, request);
-  return request;
+  return getUserScopedTimedCachedRequest({
+    cache: accountsCacheByQuery,
+    inFlight: inFlightAccountsByQuery,
+    cacheKey,
+    ttlMs: ACCOUNTS_CACHE_TTL_MS,
+    bypassCache: options.bypassCache,
+    load: (accessToken) =>
+      requestJson<AccountInfo[]>("/api/accounts", {
+        query: {
+          show_inactive: options.showInactive,
+          show_missing: options.showMissing,
+        },
+        accessTokenOverride: accessToken,
+      }),
+  });
 }
 
 function getAccountsCached(optionsOrOnlyActive?: GetAccountsOptions | boolean): Promise<AccountInfo[]> {
@@ -735,15 +812,16 @@ export const accountsApi = {
       symbol: requestQuery.symbol,
       include_lifecycle: requestQuery.include_lifecycle,
     });
-    return getTimedCachedRequest({
+    return getUserScopedTimedCachedRequest({
       cache: accountTradesCacheByQuery,
       inFlight: inFlightAccountTradesByQuery,
       cacheKey,
       ttlMs: ACCOUNT_READ_CACHE_TTL_MS,
       bypassCache: Boolean(query.refresh),
-      load: () =>
+      load: (accessToken) =>
         requestJson<AccountTrade[]>(`/api/accounts/${accountId}/trades`, {
           query: requestQuery,
+          accessTokenOverride: accessToken,
         }),
     });
   },
@@ -759,15 +837,16 @@ export const accountsApi = {
       end: requestQuery.end,
       pointsBasis: requestQuery.pointsBasis,
     });
-    return getTimedCachedRequest({
+    return getUserScopedTimedCachedRequest({
       cache: accountSummaryCacheByQuery,
       inFlight: inFlightAccountSummaryByQuery,
       cacheKey,
       ttlMs: ACCOUNT_READ_CACHE_TTL_MS,
       bypassCache: Boolean(query.refresh),
-      load: () =>
+      load: (accessToken) =>
         requestJson<AccountSummary>(`/api/accounts/${accountId}/summary`, {
           query: requestQuery,
+          accessTokenOverride: accessToken,
         }),
     });
   },
@@ -781,15 +860,16 @@ export const accountsApi = {
       start: requestQuery.start,
       end: requestQuery.end,
     });
-    return getTimedCachedRequest({
+    return getUserScopedTimedCachedRequest({
       cache: accountSummaryWithPointBasesCacheByQuery,
       inFlight: inFlightAccountSummaryWithPointBasesByQuery,
       cacheKey,
       ttlMs: ACCOUNT_READ_CACHE_TTL_MS,
       bypassCache: Boolean(query.refresh),
-      load: () =>
+      load: (accessToken) =>
         requestJson<AccountSummaryWithPointBases>(`/api/accounts/${accountId}/summary-with-point-bases`, {
           query: requestQuery,
+          accessTokenOverride: accessToken,
         }),
     });
   },
@@ -805,15 +885,16 @@ export const accountsApi = {
       end: requestQuery.end,
       all_time: requestQuery.all_time,
     });
-    return getTimedCachedRequest({
+    return getUserScopedTimedCachedRequest({
       cache: accountPnlCalendarCacheByQuery,
       inFlight: inFlightAccountPnlCalendarByQuery,
       cacheKey,
       ttlMs: ACCOUNT_READ_CACHE_TTL_MS,
       bypassCache: Boolean(query.refresh),
-      load: () =>
+      load: (accessToken) =>
         requestJson<AccountPnlCalendarDay[]>(`/api/accounts/${accountId}/pnl-calendar`, {
           query: requestQuery,
+          accessTokenOverride: accessToken,
         }),
     });
   },
@@ -861,14 +942,15 @@ export const accountsApi = {
       include_archived: query.include_archived,
     };
     const cacheKey = accountJournalReadQueryCacheKey(accountId, requestQuery);
-    return getTimedCachedRequest({
+    return getUserScopedTimedCachedRequest({
       cache: accountJournalDaysCacheByQuery,
       inFlight: inFlightAccountJournalDaysByQuery,
       cacheKey,
       ttlMs: ACCOUNT_READ_CACHE_TTL_MS,
-      load: () =>
+      load: (accessToken) =>
         requestJson<JournalDaysResponse>(`/api/accounts/${accountId}/journal/days`, {
           query: requestQuery,
+          accessTokenOverride: accessToken,
         }),
     });
   },
@@ -975,8 +1057,16 @@ function botStartPayload(options: BotStartOptions = {}) {
 export function streamProjectXMarketPrice(query: MarketPriceStreamQuery, callbacks: MarketPriceStreamCallbacks): () => void {
   const controller = new AbortController();
   let closed = false;
+  const guardedCallbacks: MarketPriceStreamCallbacks = {
+    ...callbacks,
+    onPrice: (price) => {
+      if (!closed) {
+        callbacks.onPrice(price);
+      }
+    },
+  };
 
-  void runProjectXMarketPriceStream(query, callbacks, controller.signal).catch((error) => {
+  void runProjectXMarketPriceStream(query, guardedCallbacks, controller.signal).catch((error) => {
     if (!closed && !isAbortError(error)) {
       callbacks.onError?.(error);
     }
@@ -1036,12 +1126,19 @@ async function runProjectXMarketPriceStream(
       const frame = buffer.slice(0, boundary);
       buffer = buffer.slice(boundary + 2);
       const price = parseMarketPriceSseFrame(frame);
-      if (price) {
+      if (price && marketPriceMatchesStreamQuery(price, query)) {
         callbacks.onPrice(price);
       }
       boundary = buffer.indexOf("\n\n");
     }
   }
+}
+
+function marketPriceMatchesStreamQuery(price: ProjectXMarketPrice, query: MarketPriceStreamQuery): boolean {
+  if (query.symbol && price.symbol) {
+    return price.symbol.trim().toUpperCase() === query.symbol.trim().toUpperCase();
+  }
+  return price.contract_id.trim().toUpperCase() === query.contractId.trim().toUpperCase();
 }
 
 function parseMarketPriceSseFrame(frame: string): ProjectXMarketPrice | null {
@@ -1097,9 +1194,23 @@ function isAbortError(value: unknown): boolean {
   return value instanceof Error && value.name === "AbortError";
 }
 
-async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput): Promise<BotBacktestResult> {
+async function runBacktestRequest(
+  botConfigId: number,
+  payload: BotBacktestInput,
+  options: RequestSignalOptions = {},
+): Promise<BotBacktestResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), BACKTEST_REQUEST_TIMEOUT_MS);
+  let timedOut = false;
+  const abortFromCaller = () => controller.abort();
+  if (options.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, BACKTEST_REQUEST_TIMEOUT_MS);
   try {
     return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtests`, {
       method: "POST",
@@ -1107,12 +1218,13 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
       signal: controller.signal,
     });
   } catch (error) {
-    if (isAbortError(error)) {
+    if (isAbortError(error) && timedOut) {
       throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
     }
     throw error;
   } finally {
     clearTimeout(timeoutId);
+    options.signal?.removeEventListener("abort", abortFromCaller);
   }
 }
 
@@ -1171,21 +1283,23 @@ export const botsApi = {
       method: "POST",
       body: botStartPayload(options),
     }),
-  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
+  prepareBacktest: (botConfigId: number, payload: BotBacktestInput, options: RequestSignalOptions = {}) =>
     requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
       method: "POST",
       body: payload,
+      signal: options.signal,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>
     requestJson<BotEvaluation["run"]>(`/api/bots/${botConfigId}/stop`, {
       method: "POST",
     }),
-  getActivity: (botConfigId: number, limit = 50) =>
+  getActivity: (botConfigId: number, limit = 50, options: RequestSignalOptions = {}) =>
     requestJson<BotActivity>(`/api/bots/${botConfigId}/activity`, {
       query: {
         limit,
       },
+      signal: options.signal,
     }),
   evaluateTradePlan: (payload: TradePlanEvaluationInput) =>
     requestJson<TradeEvaluationResult>("/api/trade-plan/evaluate", {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1108,7 +1108,7 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
     });
   } catch (error) {
     if (isAbortError(error)) {
-      throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
+      throw new Error("Full-history backtest timed out after 15 minutes. Try again after the server finishes preparing candles.");
     }
     throw error;
   } finally {
@@ -1170,11 +1170,6 @@ export const botsApi = {
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
-    }),
-  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
-    requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
-      method: "POST",
-      body: payload,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1302,6 +1302,16 @@ export const botsApi = {
         account_id: accountId,
       },
     }),
+  listConfigsWithCacheScope: async (accountId?: number) => {
+    const auth = await getRequestAuthContext();
+    const configs = await requestJson<BotConfigListResponse>("/api/bots", {
+      query: {
+        account_id: accountId,
+      },
+      accessTokenOverride: auth.accessToken,
+    });
+    return { configs, cacheScope: auth.cacheScope };
+  },
   createConfig: (payload: BotConfigInput) =>
     requestJson<BotConfig>("/api/bots", {
       method: "POST",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,7 +69,7 @@ import { getAccessToken } from "./supabase";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8000";
 const ACCOUNTS_CACHE_TTL_MS = 10 * 60_000;
 const ACCOUNT_READ_CACHE_TTL_MS = 10 * 60_000;
-const BACKTEST_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const BACKTEST_REQUEST_TIMEOUT_MS = 15 * 60_000;
 
 type QueryValue = string | number | boolean | null | undefined;
 
@@ -1101,14 +1101,14 @@ async function runBacktestRequest(botConfigId: number, payload: BotBacktestInput
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), BACKTEST_REQUEST_TIMEOUT_MS);
   try {
-    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtest`, {
+    return await requestJson<BotBacktestResult>(`/api/bots/${botConfigId}/backtests`, {
       method: "POST",
       body: payload,
       signal: controller.signal,
     });
   } catch (error) {
     if (isAbortError(error)) {
-      throw new Error("Backtest timed out after 5 minutes. Try again after the server finishes caching candles, or narrow the date range.");
+      throw new Error("Backtest timed out after 15 minutes. Try again after the server finishes caching candles, or narrow the date range.");
     }
     throw error;
   } finally {
@@ -1170,6 +1170,11 @@ export const botsApi = {
     requestJson<BotEvaluation>(`/api/bots/${botConfigId}/evaluate`, {
       method: "POST",
       body: botStartPayload(options),
+    }),
+  prepareBacktest: (botConfigId: number, payload: BotBacktestInput) =>
+    requestJson<void>(`/api/bots/${botConfigId}/backtests/prepare`, {
+      method: "POST",
+      body: payload,
     }),
   runBacktest: runBacktestRequest,
   stop: (botConfigId: number) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1069,6 +1069,10 @@ export function buildProjectXCandleRequestKey(query: CandleQuery): string {
   return `projectx-candles:${toSortedQueryCacheKey(params)}`;
 }
 
+export function buildUserScopedProjectXCandleRequestKey(cacheScope: string, query: CandleQuery): string {
+  return `scope:${encodeURIComponent(cacheScope)}|${buildProjectXCandleRequestKey(query)}`;
+}
+
 function normalizeCandleRequestTimestamp(value: string | undefined, intervalMs: number): string | undefined {
   if (!value) {
     return value;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -928,7 +928,7 @@ interface ContractSearchQuery {
   live?: boolean;
 }
 
-interface CandleQuery {
+export interface CandleQuery {
   contractId: string;
   symbol?: string;
   start?: string;
@@ -941,6 +941,61 @@ interface CandleQuery {
   refresh?: boolean;
   /** Force a full-window upstream fetch to backfill missing bars without pruning cache. */
   repair?: boolean;
+}
+
+const CANDLE_UNIT_MS: Record<BotTimeframeUnit, number> = {
+  second: 1_000,
+  minute: 60_000,
+  hour: 60 * 60_000,
+  day: 24 * 60 * 60_000,
+  week: 7 * 24 * 60 * 60_000,
+  month: 31 * 24 * 60 * 60_000,
+};
+
+function projectXCandleQueryParams(query: CandleQuery): Record<string, QueryValue> {
+  return {
+    contract_id: query.contractId,
+    symbol: query.symbol,
+    start: query.start,
+    end: query.end,
+    live: query.live ?? false,
+    unit: query.unit ?? "minute",
+    unit_number: query.unitNumber ?? 5,
+    limit: query.limit ?? 500,
+    include_partial_bar: query.includePartialBar ?? false,
+    refresh: query.refresh ?? false,
+    repair: query.repair ?? false,
+  };
+}
+
+/**
+ * Stable identity for deduplicating equivalent candle reads. Closed-candle
+ * ranges are bucketed to their chart interval: two callers within the same
+ * active bar need the same closed history even if their `Date` values differ by
+ * a few milliseconds. Partial/live reads retain exact timestamps.
+ */
+export function buildProjectXCandleRequestKey(query: CandleQuery): string {
+  const params = projectXCandleQueryParams(query);
+  if (!(query.includePartialBar ?? false)) {
+    const unit = query.unit ?? "minute";
+    const intervalMs = CANDLE_UNIT_MS[unit] * Math.max(1, Math.trunc(query.unitNumber ?? 5));
+    params.start = normalizeCandleRequestTimestamp(query.start, intervalMs);
+    params.end = normalizeCandleRequestTimestamp(query.end, intervalMs);
+  }
+  params.contract_id = query.contractId.trim().toUpperCase();
+  params.symbol = query.symbol?.trim().toUpperCase();
+  return `projectx-candles:${toSortedQueryCacheKey(params)}`;
+}
+
+function normalizeCandleRequestTimestamp(value: string | undefined, intervalMs: number): string | undefined {
+  if (!value) {
+    return value;
+  }
+  const timestampMs = Date.parse(value);
+  if (!Number.isFinite(timestampMs) || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return value;
+  }
+  return new Date(Math.floor(timestampMs / intervalMs) * intervalMs).toISOString();
 }
 
 interface MarketPriceStreamQuery {
@@ -1126,19 +1181,7 @@ export const botsApi = {
     }),
   getCandles: (query: CandleQuery, options: RequestSignalOptions = {}) =>
     requestJson<ProjectXMarketCandle[]>("/api/projectx/candles", {
-      query: {
-        contract_id: query.contractId,
-        symbol: query.symbol,
-        start: query.start,
-        end: query.end,
-        live: query.live ?? false,
-        unit: query.unit ?? "minute",
-        unit_number: query.unitNumber ?? 5,
-        limit: query.limit ?? 500,
-        include_partial_bar: query.includePartialBar ?? false,
-        refresh: query.refresh ?? false,
-        repair: query.repair ?? false,
-      },
+      query: projectXCandleQueryParams(query),
       signal: options.signal,
     }),
   listConfigs: (accountId?: number) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1190,8 +1190,8 @@ export interface BotEvaluation {
 }
 
 export interface BotBacktestInput {
-  start: string;
-  end: string;
+  start?: string;
+  end?: string;
   starting_balance: number;
   commission_per_contract: number;
   slippage_ticks: number;
@@ -1202,6 +1202,10 @@ export interface BotBacktestRange {
   start: string;
   end: string;
   bar_count: number;
+  contract_id: string;
+  symbol: string | null;
+  timeframe_unit: BotTimeframeUnit;
+  timeframe_unit_number: number;
 }
 
 export interface BotBacktestAssumptions {

--- a/frontend/src/pages/bot/BotBacktestPanel.test.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { BotBacktestBreakdown, BotBacktestResult } from "../../lib/types";
-import { BacktestResults } from "./BotBacktestPanel";
+import { BacktestResults, BotBacktestPanel } from "./BotBacktestPanel";
 
 const breakdown: BotBacktestBreakdown = {
   trade_count: 1,
@@ -24,7 +24,15 @@ const result: BotBacktestResult = {
   engine_version: "1.0.0",
   input_fingerprint: "test-fingerprint",
   created_at: "2026-02-02T18:00:00Z",
-  range: { start: "2026-01-01T00:00:00Z", end: "2026-01-31T23:59:59Z", bar_count: 500 },
+  range: {
+    start: "2026-01-02T14:30:00Z",
+    end: "2026-01-30T21:00:00Z",
+    bar_count: 500,
+    contract_id: "CON.F.US.MNQ.H26",
+    symbol: "MNQ",
+    timeframe_unit: "minute",
+    timeframe_unit_number: 5,
+  },
   config_snapshot: { strategy_type: "sma_cross", fast_period: 9, slow_period: 21 },
   assumptions: {
     fill_model: "next_bar_open",
@@ -121,9 +129,26 @@ describe("BacktestResults", () => {
     expect(markup).toContain("Sample-quality warnings");
     expect(markup).toContain("Only one trade occurred");
     expect(markup).toContain("Backtest equity and drawdown chart");
+    expect(markup).toContain("MNQ (CON.F.US.MNQ.H26)");
+    expect(markup).toContain("5-minute");
+    expect(markup).toContain("500 closed bars");
+    expect(markup).toContain("Jan 2, 2026");
+    expect(markup).toContain("Jan 30, 2026");
     expect(markup).toContain("next bar open");
     expect(markup).toContain("External routing disabled");
     expect(markup).toContain("Trade ledger");
     expect(markup).toContain("take profit");
+  });
+});
+
+describe("BotBacktestPanel", () => {
+  it("offers one full-history action without date inputs", () => {
+    const markup = renderToStaticMarkup(<BotBacktestPanel bot={null} />);
+
+    expect(markup).toContain("Run Full History Backtest");
+    expect(markup).toContain("No order routing");
+    expect(markup).not.toContain("Start date");
+    expect(markup).not.toContain("End date");
+    expect(markup).not.toContain('type="date"');
   });
 });

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -21,6 +21,7 @@ import {
   BACKTEST_DRAWDOWN_TOP,
   BACKTEST_EQUITY_HEIGHT,
   BACKTEST_EQUITY_TOP,
+  buildBacktestPayload,
   buildBacktestChartPaths,
   validateBacktestForm,
   type BotBacktestFormState,
@@ -43,15 +44,11 @@ const integerFormatter = new Intl.NumberFormat("en-US", {
 const timestampFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
+  year: "numeric",
   hour: "2-digit",
   minute: "2-digit",
+  timeZoneName: "short",
   timeZone: EASTERN_TIME_ZONE,
-});
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-  timeZone: "UTC",
 });
 
 interface BotBacktestPanelProps {
@@ -87,18 +84,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     setRunning(true);
     setError(null);
     try {
-      const payload = {
-        start: `${form.startDate}T00:00:00.000Z`,
-        end: `${form.endDate}T23:59:59.999Z`,
-        starting_balance: Number(form.startingBalance),
-        commission_per_contract: Number(form.commissionPerContract),
-        slippage_ticks: Number(form.slippageTicks),
-        force_close_at_end: true,
-      };
-      if (bot.strategy_type === "topbot_adaptive") {
-        await botsApi.prepareBacktest(bot.id, payload);
-      }
-      const nextResult = await botsApi.runBacktest(bot.id, payload);
+      const nextResult = await botsApi.runBacktest(bot.id, buildBacktestPayload(form));
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }
@@ -119,7 +105,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <CardTitle>Backtest</CardTitle>
-            <CardDescription>Deterministic replay using stored, closed ProjectX candles</CardDescription>
+            <CardDescription>Deterministic replay of the configured contract&apos;s complete closed-candle history</CardDescription>
           </div>
           <div className="flex flex-wrap gap-2">
             <Badge variant="accent">Next-bar fills</Badge>
@@ -128,19 +114,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-5">
-        <form className="grid gap-3 md:grid-cols-2 xl:grid-cols-[1fr_1fr_1fr_1fr_1fr_auto] xl:items-end" onSubmit={handleSubmit}>
-          <BacktestInput
-            label="Start date"
-            type="date"
-            value={form.startDate}
-            onChange={(value) => setForm((current) => ({ ...current, startDate: value }))}
-          />
-          <BacktestInput
-            label="End date"
-            type="date"
-            value={form.endDate}
-            onChange={(value) => setForm((current) => ({ ...current, endDate: value }))}
-          />
+        <form className="grid gap-3 md:grid-cols-2 xl:grid-cols-[1fr_1fr_1fr_auto] xl:items-end" onSubmit={handleSubmit}>
           <BacktestInput
             label="Starting balance"
             type="number"
@@ -166,7 +140,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
             onChange={(value) => setForm((current) => ({ ...current, slippageTicks: value }))}
           />
           <Button type="submit" disabled={!bot || running} className="w-full xl:w-auto">
-            {running ? "Running…" : "Run Backtest"}
+            {running ? "Running Full History…" : "Run Full History Backtest"}
           </Button>
         </form>
 
@@ -183,7 +157,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         ) : result ? (
           <BacktestResults result={result} />
         ) : (
-          <BacktestEmptyState message="Choose a bounded date range and execution costs, then run the replay." />
+          <BacktestEmptyState message="Set the execution costs, then replay every fully closed candle available for this contract." />
         )}
       </CardContent>
     </Card>
@@ -222,7 +196,7 @@ function BacktestRunningState() {
   return (
     <div role="status" className="flex items-center gap-3 rounded-xl border border-app-accent/30 bg-app-accent/10 px-4 py-4 text-sm text-app-text-soft">
       <span className="h-4 w-4 animate-spin rounded-full border-2 border-app-accent/25 border-t-app-accent" aria-hidden="true" />
-      Replaying closed candles. No orders can be routed from this run.
+      Preparing and replaying the full closed-candle history. No orders can be routed from this run.
     </div>
   );
 }
@@ -236,7 +210,10 @@ export function BacktestResults({ result }: { result: BotBacktestResult }) {
         <div>
           <h4 className="text-sm font-semibold text-app-text md:text-base">Results</h4>
           <p className="mt-1 text-xs text-app-muted">
-            {formatDate(result.range.start)} – {formatDate(result.range.end)} · {integerFormatter.format(result.range.bar_count)} bars · generated {formatTimestamp(result.created_at)}
+            {formatContract(result.range.symbol, result.range.contract_id)} · {formatTimeframe(result.range.timeframe_unit, result.range.timeframe_unit_number)} · {integerFormatter.format(result.range.bar_count)} closed bars
+          </p>
+          <p className="mt-1 text-xs text-app-muted">
+            {formatTimestamp(result.range.start)} – {formatTimestamp(result.range.end)} · generated {formatTimestamp(result.created_at)}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -518,20 +495,11 @@ function TradeLedger({ result }: { result: BotBacktestResult }) {
 }
 
 function buildDefaultForm(): BotBacktestFormState {
-  const end = new Date();
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - 30);
   return {
-    startDate: toDateInput(start),
-    endDate: toDateInput(end),
     startingBalance: "50000",
     commissionPerContract: "1.20",
     slippageTicks: "1",
   };
-}
-
-function toDateInput(value: Date): string {
-  return value.toISOString().slice(0, 10);
 }
 
 function formatCurrency(value: number): string {
@@ -562,9 +530,12 @@ function formatTimestamp(value: string): string {
   return Number.isNaN(date.getTime()) ? value : timestampFormatter.format(date);
 }
 
-function formatDate(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : dateFormatter.format(date);
+function formatContract(symbol: string | null, contractId: string): string {
+  return symbol ? `${symbol} (${contractId})` : contractId;
+}
+
+function formatTimeframe(unit: string, unitNumber: number): string {
+  return `${integerFormatter.format(unitNumber)}-${unit}`;
 }
 
 function humanize(value: string): string {

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -87,14 +87,18 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     setRunning(true);
     setError(null);
     try {
-      const nextResult = await botsApi.runBacktest(bot.id, {
+      const payload = {
         start: `${form.startDate}T00:00:00.000Z`,
         end: `${form.endDate}T23:59:59.999Z`,
         starting_balance: Number(form.startingBalance),
         commission_per_contract: Number(form.commissionPerContract),
         slippage_ticks: Number(form.slippageTicks),
         force_close_at_end: true,
-      });
+      };
+      if (bot.strategy_type === "topbot_adaptive") {
+        await botsApi.prepareBacktest(bot.id, payload);
+      }
+      const nextResult = await botsApi.runBacktest(bot.id, payload);
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }

--- a/frontend/src/pages/bot/BotBacktestPanel.tsx
+++ b/frontend/src/pages/bot/BotBacktestPanel.tsx
@@ -64,9 +64,12 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestSequence = useRef(0);
+  const requestController = useRef<AbortController | null>(null);
 
   useEffect(() => () => {
     requestSequence.current += 1;
+    requestController.current?.abort();
+    requestController.current = null;
   }, []);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -84,6 +87,9 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
 
     const sequence = requestSequence.current + 1;
     requestSequence.current = sequence;
+    requestController.current?.abort();
+    const controller = new AbortController();
+    requestController.current = controller;
     setRunning(true);
     setError(null);
     try {
@@ -96,9 +102,9 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
         force_close_at_end: true,
       };
       if (bot.strategy_type === "topbot_adaptive") {
-        await botsApi.prepareBacktest(bot.id, payload);
+        await botsApi.prepareBacktest(bot.id, payload, { signal: controller.signal });
       }
-      const nextResult = await botsApi.runBacktest(bot.id, payload);
+      const nextResult = await botsApi.runBacktest(bot.id, payload, { signal: controller.signal });
       if (requestSequence.current === sequence) {
         setResult(nextResult);
       }
@@ -109,6 +115,7 @@ export function BotBacktestPanel({ bot }: BotBacktestPanelProps) {
     } finally {
       if (requestSequence.current === sequence) {
         setRunning(false);
+        requestController.current = null;
       }
     }
   }
@@ -324,6 +331,9 @@ function EquityDrawdownChart({ equity, drawdown }: { equity: BotBacktestEquityPo
   const paths = useMemo(() => buildBacktestChartPaths(equity, drawdown), [drawdown, equity]);
   const firstTimestamp = equity[0]?.timestamp ?? drawdown[0]?.timestamp ?? null;
   const lastTimestamp = equity[equity.length - 1]?.timestamp ?? drawdown[drawdown.length - 1]?.timestamp ?? null;
+  const chartWasSampled =
+    paths.equityRenderedPointCount < paths.equitySourcePointCount ||
+    paths.drawdownRenderedPointCount < paths.drawdownSourcePointCount;
 
   return (
     <div className="min-w-0 rounded-xl border border-app-border bg-app-bg/30 p-4">
@@ -338,22 +348,29 @@ function EquityDrawdownChart({ equity, drawdown }: { equity: BotBacktestEquityPo
         </div>
       </div>
       {paths.equity || paths.drawdown ? (
-        <svg viewBox={`0 0 ${BACKTEST_CHART_WIDTH} 270`} className="h-auto w-full" role="img" aria-labelledby="backtest-chart-title backtest-chart-description">
-          <title id="backtest-chart-title">Backtest equity and drawdown chart</title>
-          <desc id="backtest-chart-description">Equity ranges from {formatCurrency(paths.equityMin)} to {formatCurrency(paths.equityMax)}. Maximum drawdown is {formatPercent(paths.drawdownMax)}.</desc>
-          {[BACKTEST_EQUITY_TOP, BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT / 2, BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT, BACKTEST_DRAWDOWN_TOP, BACKTEST_DRAWDOWN_TOP + BACKTEST_DRAWDOWN_HEIGHT].map((y) => (
-            <line key={y} x1="0" x2={BACKTEST_CHART_WIDTH} y1={y} y2={y} stroke="rgb(var(--theme-chart-grid) / 0.5)" strokeWidth="1" />
-          ))}
-          {paths.equityFill ? <path d={paths.equityFill} fill="rgb(var(--theme-accent) / 0.09)" /> : null}
-          {paths.equity ? <path d={paths.equity} fill="none" stroke="rgb(var(--theme-accent))" strokeWidth="2.25" vectorEffect="non-scaling-stroke" /> : null}
-          {paths.drawdown ? <path d={paths.drawdown} fill="none" stroke="rgb(var(--theme-negative))" strokeWidth="1.75" vectorEffect="non-scaling-stroke" /> : null}
-          <text x="4" y="10" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatCompactCurrency(paths.equityMax)}</text>
-          <text x="4" y={BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT - 4} fill="rgb(var(--theme-chart-label))" fontSize="11">{formatCompactCurrency(paths.equityMin)}</text>
-          <text x="4" y={BACKTEST_DRAWDOWN_TOP - 7} fill="rgb(var(--theme-chart-label))" fontSize="11">Drawdown</text>
-          <text x="4" y={BACKTEST_DRAWDOWN_TOP + BACKTEST_DRAWDOWN_HEIGHT - 4} fill="rgb(var(--theme-chart-label))" fontSize="11">{formatPercent(paths.drawdownMax)}</text>
-          {firstTimestamp ? <text x="0" y="266" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatTimestamp(firstTimestamp)}</text> : null}
-          {lastTimestamp ? <text x={BACKTEST_CHART_WIDTH} y="266" textAnchor="end" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatTimestamp(lastTimestamp)}</text> : null}
-        </svg>
+        <>
+          <svg viewBox={`0 0 ${BACKTEST_CHART_WIDTH} 270`} className="h-auto w-full" role="img" aria-labelledby="backtest-chart-title backtest-chart-description">
+            <title id="backtest-chart-title">Backtest equity and drawdown chart</title>
+            <desc id="backtest-chart-description">Equity ranges from {formatCurrency(paths.equityMin)} to {formatCurrency(paths.equityMax)}. Maximum drawdown is {formatPercent(paths.drawdownMax)}.</desc>
+            {[BACKTEST_EQUITY_TOP, BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT / 2, BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT, BACKTEST_DRAWDOWN_TOP, BACKTEST_DRAWDOWN_TOP + BACKTEST_DRAWDOWN_HEIGHT].map((y) => (
+              <line key={y} x1="0" x2={BACKTEST_CHART_WIDTH} y1={y} y2={y} stroke="rgb(var(--theme-chart-grid) / 0.5)" strokeWidth="1" />
+            ))}
+            {paths.equityFill ? <path d={paths.equityFill} fill="rgb(var(--theme-accent) / 0.09)" /> : null}
+            {paths.equity ? <path d={paths.equity} fill="none" stroke="rgb(var(--theme-accent))" strokeWidth="2.25" vectorEffect="non-scaling-stroke" /> : null}
+            {paths.drawdown ? <path d={paths.drawdown} fill="none" stroke="rgb(var(--theme-negative))" strokeWidth="1.75" vectorEffect="non-scaling-stroke" /> : null}
+            <text x="4" y="10" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatCompactCurrency(paths.equityMax)}</text>
+            <text x="4" y={BACKTEST_EQUITY_TOP + BACKTEST_EQUITY_HEIGHT - 4} fill="rgb(var(--theme-chart-label))" fontSize="11">{formatCompactCurrency(paths.equityMin)}</text>
+            <text x="4" y={BACKTEST_DRAWDOWN_TOP - 7} fill="rgb(var(--theme-chart-label))" fontSize="11">Drawdown</text>
+            <text x="4" y={BACKTEST_DRAWDOWN_TOP + BACKTEST_DRAWDOWN_HEIGHT - 4} fill="rgb(var(--theme-chart-label))" fontSize="11">{formatPercent(paths.drawdownMax)}</text>
+            {firstTimestamp ? <text x="0" y="266" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatTimestamp(firstTimestamp)}</text> : null}
+            {lastTimestamp ? <text x={BACKTEST_CHART_WIDTH} y="266" textAnchor="end" fill="rgb(var(--theme-chart-label))" fontSize="11">{formatTimestamp(lastTimestamp)}</text> : null}
+          </svg>
+          {chartWasSampled ? (
+            <p className="mt-2 text-[11px] text-app-muted">
+              Chart rendering is deterministically sampled to {integerFormatter.format(paths.equityRenderedPointCount)} of {integerFormatter.format(paths.equitySourcePointCount)} equity points for display; all returned points remain included in backtest results and metrics.
+            </p>
+          ) : null}
+        </>
       ) : (
         <div className="grid h-56 place-items-center text-sm text-app-muted">No equity points returned.</div>
       )}

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
-import { useSearchParams } from "react-router-dom";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useOutletContext, useSearchParams } from "react-router-dom";
 
+import type { AppShellOutletContext } from "../../app/AppShell";
 import { Badge } from "../../components/ui/Badge";
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/Card";
@@ -9,9 +10,8 @@ import { Select } from "../../components/ui/Select";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/Table";
 import { ACCOUNT_QUERY_PARAM, parseAccountId } from "../../lib/accountSelection";
-import { accountsApi, botsApi } from "../../lib/api";
+import { botsApi, readSelectedBotConfigId, rememberSelectedBotConfigId } from "../../lib/api";
 import type {
-  AccountInfo,
   BotActivity,
   BotConfig,
   BotEvaluation,
@@ -25,10 +25,15 @@ import type {
   ProjectXContract,
   ProjectXMarketCandle,
 } from "../../lib/types";
-import { BotAnalysisPanel } from "./BotAnalysisPanel";
-import { BotBacktestPanel } from "./BotBacktestPanel";
 import { BotSignalChart } from "./BotSignalChart";
 import type { BotMarketSnapshot } from "./botMarketContext";
+
+const BotAnalysisPanel = lazy(() =>
+  import("./BotAnalysisPanel").then((module) => ({ default: module.BotAnalysisPanel })),
+);
+const BotBacktestPanel = lazy(() =>
+  import("./BotBacktestPanel").then((module) => ({ default: module.BotBacktestPanel })),
+);
 
 const timeframeUnits: BotTimeframeUnit[] = ["second", "minute", "hour", "day", "week", "month"];
 const strategyOptions: Array<{ value: BotStrategyType; label: string }> = [
@@ -1170,9 +1175,9 @@ function Sparkline({ candles }: { candles: ProjectXMarketCandle[] }) {
 export function BotPage() {
   const [searchParams] = useSearchParams();
   const accountFromQuery = parseAccountId(searchParams.get(ACCOUNT_QUERY_PARAM));
-  const [accounts, setAccounts] = useState<AccountInfo[]>([]);
+  const { accounts } = useOutletContext<AppShellOutletContext>();
   const [configs, setConfigs] = useState<BotConfig[]>([]);
-  const [selectedBotId, setSelectedBotId] = useState<number | null>(null);
+  const [selectedBotId, setSelectedBotId] = useState<number | null>(() => readSelectedBotConfigId());
   const [activity, setActivity] = useState<BotActivity | null>(null);
   const [lastEvaluation, setLastEvaluation] = useState<BotEvaluation | null>(null);
   const [contracts, setContracts] = useState<ProjectXContract[]>([]);
@@ -1212,24 +1217,16 @@ export function BotPage() {
     }
     setError(null);
     try {
-      const [accountRows, botRows] = await Promise.all([
-        accountsApi.getSelectableAccounts(),
-        botsApi.listConfigs(),
-      ]);
-      setAccounts(accountRows);
+      const botRows = await botsApi.listConfigs();
       setConfigs(botRows.items);
       setConfigWarnings(botRows.warnings ?? []);
       setSelectedBotId((current) => {
         if (current && botRows.items.some((item) => item.id === current)) {
           return current;
         }
-        return botRows.items[0]?.id ?? null;
+        const remembered = readSelectedBotConfigId();
+        return botRows.items.find((item) => item.id === remembered)?.id ?? botRows.items[0]?.id ?? null;
       });
-      if (accountRows.length > 0) {
-        setForm((current) =>
-          current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accountRows[0].id) },
-        );
-      }
     } catch (err) {
       setConfigWarnings([]);
       setError(err instanceof Error ? err.message : "Failed to load bot data");
@@ -1238,7 +1235,7 @@ export function BotPage() {
         setLoading(false);
       }
     }
-  }, [accountFromQuery]);
+  }, []);
 
   const loadActivity = useCallback(async (botId: number | null) => {
     if (!botId) {
@@ -1261,7 +1258,20 @@ export function BotPage() {
   }, [loadConfigs]);
 
   useEffect(() => {
-    void loadActivity(selectedBot?.id ?? null);
+    const botId = selectedBot?.id ?? null;
+    if (!botId) {
+      setActivity(null);
+      return undefined;
+    }
+
+    setActivity(null);
+    const run = () => void loadActivity(botId);
+    if (typeof window.requestIdleCallback === "function") {
+      const requestId = window.requestIdleCallback(run, { timeout: 1_500 });
+      return () => window.cancelIdleCallback(requestId);
+    }
+    const timeoutId = window.setTimeout(run, 100);
+    return () => window.clearTimeout(timeoutId);
   }, [
     loadActivity,
     selectedBot?.contract_id,
@@ -1276,11 +1286,21 @@ export function BotPage() {
       return;
     }
 
+    rememberSelectedBotConfigId(selectedBot.id);
     setEditingBotId(selectedBot.id);
     setForm(formFromBot(selectedBot));
     setContracts([]);
     setFormError(null);
   }, [selectedBot]);
+
+  useEffect(() => {
+    if (accounts.length === 0) {
+      return;
+    }
+    setForm((current) =>
+      current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accounts[0].id) },
+    );
+  }, [accountFromQuery, accounts]);
 
   async function handleSearchContracts() {
     if (!form.contractSearch.trim()) {
@@ -2454,6 +2474,24 @@ export function BotPage() {
       ))}
 
       <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_340px] xl:items-stretch">
+        <div className="order-1 min-w-0 space-y-5 xl:col-start-1 xl:row-start-1">
+          <BotSignalChart
+            bot={selectedBot}
+            activity={activity}
+            lastEvaluation={selectedBotEvaluation}
+            refreshToken={chartRefreshToken}
+            onMarketData={setMarketSnapshot}
+          />
+          <Suspense fallback={<Skeleton className="h-[360px]" />}>
+            <BotAnalysisPanel
+              bot={selectedBot}
+              evaluation={selectedBotEvaluation}
+              marketSnapshot={marketSnapshot}
+              loading={actionLoading === "start" || actionLoading === "evaluate"}
+              onEvaluate={selectedBot ? () => void runBotAction("evaluate") : undefined}
+            />
+          </Suspense>
+        </div>
         <Card className="order-3 min-w-0 xl:col-start-2 xl:row-start-1">
           <CardHeader>
             <CardTitle>Configuration</CardTitle>
@@ -3831,7 +3869,9 @@ export function BotPage() {
                   value={selectedBot?.id ? String(selectedBot.id) : ""}
                   onChange={(event) => {
                     const nextId = Number.parseInt(event.target.value, 10);
-                    setSelectedBotId(Number.isFinite(nextId) ? nextId : null);
+                    const selectedId = Number.isFinite(nextId) ? nextId : null;
+                    rememberSelectedBotConfigId(selectedId);
+                    setSelectedBotId(selectedId);
                   }}
                 >
                   {configs.length === 0 ? <option value="">No bots</option> : null}
@@ -4000,25 +4040,11 @@ export function BotPage() {
             </CardContent>
           </Card>
 
-          <div className="order-1 min-w-0 space-y-5 xl:col-start-1 xl:row-start-1">
-            <BotSignalChart
-              bot={selectedBot}
-              activity={activity}
-              lastEvaluation={selectedBotEvaluation}
-              refreshToken={chartRefreshToken}
-              onMarketData={setMarketSnapshot}
-            />
-            <BotAnalysisPanel
-              bot={selectedBot}
-              evaluation={selectedBotEvaluation}
-              marketSnapshot={marketSnapshot}
-              loading={actionLoading === "start" || actionLoading === "evaluate"}
-              onEvaluate={selectedBot ? () => void runBotAction("evaluate") : undefined}
-            />
-          </div>
         </div>
       </div>
-      <BotBacktestPanel key={selectedBot?.id ?? "no-bot"} bot={selectedBot} />
+      <Suspense fallback={<Skeleton className="h-[420px]" />}>
+        <BotBacktestPanel key={selectedBot?.id ?? "no-bot"} bot={selectedBot} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -42,7 +42,7 @@ const strategyOptions: Array<{ value: BotStrategyType; label: string }> = [
   { value: "supertrend_pivot", label: "Supertrend + Pivot Points" },
   { value: "opening_rvol_breakout", label: "Opening 5m RVOL Breakout" },
   { value: "atr_adjusted_relative_strength", label: "ATR-Adjusted Relative Strength" },
-  { value: "relative_strength_spy", label: "Relative Strength vs SPY" },
+  { value: "relative_strength_spy", label: "Relative Strength vs MES" },
   { value: "pullback_trap_reversal", label: "Pullback Trap Reversal" },
   { value: "bollinger_mean_reversion", label: "Bollinger Band Mean Reversion" },
   { value: "bollinger_rsi_reversal", label: "Bollinger RSI Reversal" },
@@ -203,7 +203,7 @@ const VWAP_GAP_RETRACE_DEFAULTS = {
   maxDataStalenessSeconds: "180",
 };
 const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   moveLookbackBars: "3",
   atrPeriod: "14",
   relativeVolumePeriod: "20",
@@ -218,7 +218,7 @@ const ATR_ADJUSTED_RELATIVE_STRENGTH_DEFAULTS = {
   maxDataStalenessSeconds: "600",
 };
 const RELATIVE_STRENGTH_SPY_DEFAULTS = {
-  benchmarkSymbol: "SPY",
+  benchmarkSymbol: "MES",
   comparisonBars: "12",
   pullbackLookbackBars: "3",
   relativeVolumePeriod: "20",
@@ -278,8 +278,8 @@ const STRATEGY_DEFAULT_NAMES: Partial<Record<BotStrategyType, string>> = {
   liquidity_sweep_retest: "MNQ Liquidity Sweep + Zone Retest",
   supertrend_pivot: "MNQ Supertrend + Pivot Points",
   opening_rvol_breakout: "MNQ Opening 5m RVOL Breakout",
-  atr_adjusted_relative_strength: "AAPL ATR-Adjusted Relative Strength",
-  relative_strength_spy: "AAPL Relative Strength vs SPY",
+  atr_adjusted_relative_strength: "MNQ ATR-Adjusted Relative Strength",
+  relative_strength_spy: "MNQ Relative Strength vs MES",
   pullback_trap_reversal: "MNQ Pullback Trap Reversal",
   bollinger_mean_reversion: "MNQ Bollinger Band Mean Reversion",
   bollinger_rsi_reversal: "MNQ Bollinger RSI Reversal",
@@ -935,7 +935,7 @@ function strategyLabel(strategyType: BotStrategyType) {
     return "ATR-Adjusted Relative Strength";
   }
   if (strategyType === "relative_strength_spy") {
-    return "Relative Strength vs SPY";
+    return "Relative Strength vs MES";
   }
   if (strategyType === "pullback_trap_reversal") {
     return "Pullback Trap Reversal";
@@ -1047,7 +1047,7 @@ function strategySummary(bot: BotConfig) {
     const window = bot.strategy_params?.comparison_bars ?? RELATIVE_STRENGTH_SPY_DEFAULTS.comparisonBars;
     const rvol = bot.strategy_params?.minimum_relative_volume ?? RELATIVE_STRENGTH_SPY_DEFAULTS.minimumRelativeVolume;
     return {
-      label: "RS/SPY",
+      label: "RS/MES",
       value: `${window} x 5m · RVOL ${rvol}x`,
     };
   }
@@ -1883,6 +1883,10 @@ export function BotPage() {
       setFormError("9/15 EMA scalping requires a 3-minute or 5-minute chart.");
       return;
     }
+    if (form.strategyType === "topbot_adaptive" && form.timeframeUnit === "month") {
+      setFormError("TopBot Adaptive does not support monthly candles.");
+      return;
+    }
     if (form.strategyType === "support_resistance" && levelTolerancePercent === null) {
       setFormError("Level tolerance must be a valid positive percent.");
       return;
@@ -2531,7 +2535,7 @@ export function BotPage() {
                         value={form.timeframeUnit}
                         onChange={(event) => setForm({ ...form, timeframeUnit: event.target.value as BotTimeframeUnit })}
                       >
-                        {timeframeUnits.map((unit) => (
+                        {timeframeUnits.filter((unit) => unit !== "month").map((unit) => (
                           <option key={unit} value={unit}>
                             {unit}
                           </option>

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { useSearchParams } from "react-router-dom";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useOutletContext, useSearchParams } from "react-router-dom";
 
+import type { AppShellOutletContext } from "../../app/AppShell";
 import { Badge } from "../../components/ui/Badge";
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/Card";
@@ -9,9 +10,8 @@ import { Select } from "../../components/ui/Select";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/Table";
 import { ACCOUNT_QUERY_PARAM, parseAccountId } from "../../lib/accountSelection";
-import { accountsApi, botsApi, getAuthenticatedCacheScope } from "../../lib/api";
+import { botsApi } from "../../lib/api";
 import type {
-  AccountInfo,
   BotActivity,
   BotConfig,
   BotEvaluation,
@@ -25,10 +25,15 @@ import type {
   ProjectXContract,
   ProjectXMarketCandle,
 } from "../../lib/types";
-import { BotAnalysisPanel } from "./BotAnalysisPanel";
-import { BotBacktestPanel } from "./BotBacktestPanel";
 import { BotSignalChart } from "./BotSignalChart";
 import type { BotMarketSnapshot } from "./botMarketContext";
+
+const BotAnalysisPanel = lazy(() =>
+  import("./BotAnalysisPanel").then((module) => ({ default: module.BotAnalysisPanel })),
+);
+const BotBacktestPanel = lazy(() =>
+  import("./BotBacktestPanel").then((module) => ({ default: module.BotBacktestPanel })),
+);
 
 const timeframeUnits: BotTimeframeUnit[] = ["second", "minute", "hour", "day", "week", "month"];
 const strategyOptions: Array<{ value: BotStrategyType; label: string }> = [
@@ -1170,7 +1175,7 @@ function Sparkline({ candles }: { candles: ProjectXMarketCandle[] }) {
 export function BotPage() {
   const [searchParams] = useSearchParams();
   const accountFromQuery = parseAccountId(searchParams.get(ACCOUNT_QUERY_PARAM));
-  const [accounts, setAccounts] = useState<AccountInfo[]>([]);
+  const { accounts } = useOutletContext<AppShellOutletContext>();
   const [configs, setConfigs] = useState<BotConfig[]>([]);
   const [selectedBotId, setSelectedBotId] = useState<number | null>(null);
   const [activity, setActivity] = useState<BotActivity | null>(null);
@@ -1189,7 +1194,6 @@ export function BotPage() {
   const [editingBotId, setEditingBotId] = useState<number | null>(null);
   const [marketSnapshot, setMarketSnapshot] = useState<BotMarketSnapshot | null>(null);
   const [authenticatedCacheScope, setAuthenticatedCacheScope] = useState<string | null>(null);
-  const accountsRequestSequence = useRef(0);
   const configsRequestSequence = useRef(0);
   const activityRequestSequence = useRef(0);
   const activityRequestController = useRef<AbortController | null>(null);
@@ -1224,27 +1228,6 @@ export function BotPage() {
   );
   const selectedBotStrategySummary = useMemo(() => (selectedBot ? strategySummary(selectedBot) : null), [selectedBot]);
 
-  const loadAccounts = useCallback(async () => {
-    const sequence = accountsRequestSequence.current + 1;
-    accountsRequestSequence.current = sequence;
-    try {
-      const accountRows = await accountsApi.getSelectableAccounts();
-      if (accountsRequestSequence.current !== sequence) {
-        return;
-      }
-      setAccounts(accountRows);
-      if (accountRows.length > 0) {
-        setForm((current) =>
-          current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accountRows[0].id) },
-        );
-      }
-    } catch (err) {
-      if (accountsRequestSequence.current === sequence) {
-        setError(err instanceof Error ? err.message : "Failed to load accounts");
-      }
-    }
-  }, [accountFromQuery]);
-
   const loadConfigs = useCallback(async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
     const sequence = configsRequestSequence.current + 1;
     configsRequestSequence.current = sequence;
@@ -1253,10 +1236,7 @@ export function BotPage() {
     }
     setError(null);
     try {
-      const [botRows, cacheScope] = await Promise.all([
-        botsApi.listConfigs(),
-        getAuthenticatedCacheScope(),
-      ]);
+      const { configs: botRows, cacheScope } = await botsApi.listConfigsWithCacheScope();
       if (configsRequestSequence.current !== sequence) {
         return;
       }
@@ -1320,12 +1300,10 @@ export function BotPage() {
   }, []);
 
   useEffect(() => {
-    void loadAccounts();
     void loadConfigs({ showLoading: true });
-  }, [loadAccounts, loadConfigs]);
+  }, [loadConfigs]);
 
   useEffect(() => () => {
-    accountsRequestSequence.current += 1;
     configsRequestSequence.current += 1;
     activityRequestSequence.current += 1;
     activityRequestController.current?.abort();
@@ -1333,7 +1311,32 @@ export function BotPage() {
   }, []);
 
   useEffect(() => {
-    void loadActivity(selectedBot?.id ?? null);
+    if (accounts.length === 0) {
+      return;
+    }
+    setForm((current) =>
+      current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accounts[0].id) },
+    );
+  }, [accountFromQuery, accounts]);
+
+  useEffect(() => {
+    activityRequestSequence.current += 1;
+    activityRequestController.current?.abort();
+    activityRequestController.current = null;
+    setActivity(null);
+    setActivityLoading(false);
+    const botId = selectedBot?.id ?? null;
+    if (!botId) {
+      return undefined;
+    }
+
+    const run = () => void loadActivity(botId);
+    if (typeof window.requestIdleCallback === "function") {
+      const requestId = window.requestIdleCallback(run, { timeout: 1_500 });
+      return () => window.cancelIdleCallback(requestId);
+    }
+    const timeoutId = window.setTimeout(run, 100);
+    return () => window.clearTimeout(timeoutId);
   }, [
     loadActivity,
     selectedBot?.contract_id,
@@ -4085,17 +4088,21 @@ export function BotPage() {
               refreshToken={chartRefreshToken}
               onMarketData={setMarketSnapshot}
             />
-            <BotAnalysisPanel
-              bot={selectedBot}
-              evaluation={selectedBotEvaluation}
-              marketSnapshot={marketSnapshot}
-              loading={actionLoading === "start" || actionLoading === "evaluate"}
-              onEvaluate={selectedBot ? () => void runBotAction("evaluate") : undefined}
-            />
+            <Suspense fallback={<Skeleton className="h-[360px]" />}>
+              <BotAnalysisPanel
+                bot={selectedBot}
+                evaluation={selectedBotEvaluation}
+                marketSnapshot={marketSnapshot}
+                loading={actionLoading === "start" || actionLoading === "evaluate"}
+                onEvaluate={selectedBot ? () => void runBotAction("evaluate") : undefined}
+              />
+            </Suspense>
           </div>
         </div>
       </div>
-      <BotBacktestPanel key={selectedBot?.id ?? "no-bot"} bot={selectedBot} />
+      <Suspense fallback={<Skeleton className="h-[420px]" />}>
+        <BotBacktestPanel key={selectedBot?.id ?? "no-bot"} bot={selectedBot} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/pages/bot/BotPage.tsx
+++ b/frontend/src/pages/bot/BotPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { Badge } from "../../components/ui/Badge";
@@ -9,7 +9,7 @@ import { Select } from "../../components/ui/Select";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/Table";
 import { ACCOUNT_QUERY_PARAM, parseAccountId } from "../../lib/accountSelection";
-import { accountsApi, botsApi } from "../../lib/api";
+import { accountsApi, botsApi, getAuthenticatedCacheScope } from "../../lib/api";
 import type {
   AccountInfo,
   BotActivity,
@@ -1188,6 +1188,12 @@ export function BotPage() {
   const [chartRefreshToken, setChartRefreshToken] = useState(0);
   const [editingBotId, setEditingBotId] = useState<number | null>(null);
   const [marketSnapshot, setMarketSnapshot] = useState<BotMarketSnapshot | null>(null);
+  const [authenticatedCacheScope, setAuthenticatedCacheScope] = useState<string | null>(null);
+  const accountsRequestSequence = useRef(0);
+  const configsRequestSequence = useRef(0);
+  const activityRequestSequence = useRef(0);
+  const activityRequestController = useRef<AbortController | null>(null);
+  const selectedBotIdRef = useRef<number | null>(null);
 
   const selectedBot = useMemo(
     () => configs.find((config) => config.id === selectedBotId) ?? configs[0] ?? null,
@@ -1204,19 +1210,57 @@ export function BotPage() {
         : null,
     [lastEvaluation, selectedBot],
   );
+  selectedBotIdRef.current = selectedBot?.id ?? null;
+  const selectedBotActivity = useMemo(
+    () =>
+      selectedBot &&
+      activity?.config.id === selectedBot.id &&
+      activity.config.contract_id === selectedBot.contract_id &&
+      activity.config.timeframe_unit === selectedBot.timeframe_unit &&
+      activity.config.timeframe_unit_number === selectedBot.timeframe_unit_number
+        ? activity
+        : null,
+    [activity, selectedBot],
+  );
   const selectedBotStrategySummary = useMemo(() => (selectedBot ? strategySummary(selectedBot) : null), [selectedBot]);
 
+  const loadAccounts = useCallback(async () => {
+    const sequence = accountsRequestSequence.current + 1;
+    accountsRequestSequence.current = sequence;
+    try {
+      const accountRows = await accountsApi.getSelectableAccounts();
+      if (accountsRequestSequence.current !== sequence) {
+        return;
+      }
+      setAccounts(accountRows);
+      if (accountRows.length > 0) {
+        setForm((current) =>
+          current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accountRows[0].id) },
+        );
+      }
+    } catch (err) {
+      if (accountsRequestSequence.current === sequence) {
+        setError(err instanceof Error ? err.message : "Failed to load accounts");
+      }
+    }
+  }, [accountFromQuery]);
+
   const loadConfigs = useCallback(async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
+    const sequence = configsRequestSequence.current + 1;
+    configsRequestSequence.current = sequence;
     if (showLoading) {
       setLoading(true);
     }
     setError(null);
     try {
-      const [accountRows, botRows] = await Promise.all([
-        accountsApi.getSelectableAccounts(),
+      const [botRows, cacheScope] = await Promise.all([
         botsApi.listConfigs(),
+        getAuthenticatedCacheScope(),
       ]);
-      setAccounts(accountRows);
+      if (configsRequestSequence.current !== sequence) {
+        return;
+      }
+      setAuthenticatedCacheScope(cacheScope);
       setConfigs(botRows.items);
       setConfigWarnings(botRows.warnings ?? []);
       setSelectedBotId((current) => {
@@ -1225,40 +1269,68 @@ export function BotPage() {
         }
         return botRows.items[0]?.id ?? null;
       });
-      if (accountRows.length > 0) {
-        setForm((current) =>
-          current.accountId ? current : { ...current, accountId: String(accountFromQuery ?? accountRows[0].id) },
-        );
-      }
     } catch (err) {
-      setConfigWarnings([]);
-      setError(err instanceof Error ? err.message : "Failed to load bot data");
+      if (configsRequestSequence.current === sequence) {
+        setConfigWarnings([]);
+        setError(err instanceof Error ? err.message : "Failed to load bot data");
+      }
     } finally {
-      if (showLoading) {
+      if (showLoading && configsRequestSequence.current === sequence) {
         setLoading(false);
       }
     }
-  }, [accountFromQuery]);
+  }, []);
 
   const loadActivity = useCallback(async (botId: number | null) => {
+    const sequence = activityRequestSequence.current + 1;
+    activityRequestSequence.current = sequence;
+    activityRequestController.current?.abort();
+    activityRequestController.current = null;
     if (!botId) {
       setActivity(null);
+      setActivityLoading(false);
       return;
     }
+    if (selectedBotIdRef.current !== botId) {
+      return;
+    }
+    const controller = new AbortController();
+    activityRequestController.current = controller;
+    setActivity(null);
     setActivityLoading(true);
     try {
-      const payload = await botsApi.getActivity(botId);
-      setActivity(payload);
+      const payload = await botsApi.getActivity(botId, 50, { signal: controller.signal });
+      if (activityRequestSequence.current === sequence && selectedBotIdRef.current === botId) {
+        setActivity(payload);
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load bot activity");
+      if (
+        activityRequestSequence.current === sequence &&
+        selectedBotIdRef.current === botId &&
+        !(err instanceof Error && err.name === "AbortError")
+      ) {
+        setError(err instanceof Error ? err.message : "Failed to load bot activity");
+      }
     } finally {
-      setActivityLoading(false);
+      if (activityRequestSequence.current === sequence) {
+        setActivityLoading(false);
+        activityRequestController.current = null;
+      }
     }
   }, []);
 
   useEffect(() => {
+    void loadAccounts();
     void loadConfigs({ showLoading: true });
-  }, [loadConfigs]);
+  }, [loadAccounts, loadConfigs]);
+
+  useEffect(() => () => {
+    accountsRequestSequence.current += 1;
+    configsRequestSequence.current += 1;
+    activityRequestSequence.current += 1;
+    activityRequestController.current?.abort();
+    activityRequestController.current = null;
+  }, []);
 
   useEffect(() => {
     void loadActivity(selectedBot?.id ?? null);
@@ -3953,11 +4025,11 @@ export function BotPage() {
                   </div>
                   {activityLoading ? (
                     <Skeleton className="h-64" />
-                  ) : activity ? (
+                  ) : selectedBotActivity ? (
                     <div className="grid gap-4 xl:grid-cols-2">
                       <ActivityTable
                         title="Decisions"
-                        rows={activity.decisions.slice(0, 8).map((decision) => ({
+                        rows={selectedBotActivity.decisions.slice(0, 8).map((decision) => ({
                           id: decision.id,
                           left: decision.action,
                           middle: decision.reason,
@@ -3967,7 +4039,7 @@ export function BotPage() {
                       />
                       <ActivityTable
                         title="Orders"
-                        rows={activity.order_attempts.slice(0, 8).map((attempt) => ({
+                        rows={selectedBotActivity.order_attempts.slice(0, 8).map((attempt) => ({
                           id: attempt.id,
                           left: attempt.status,
                           middle: `${attempt.side} ${attempt.size} ${attempt.contract_id}`,
@@ -3977,7 +4049,7 @@ export function BotPage() {
                       />
                       <ActivityTable
                         title="Risk"
-                        rows={activity.risk_events.slice(0, 8).map((risk) => ({
+                        rows={selectedBotActivity.risk_events.slice(0, 8).map((risk) => ({
                           id: risk.id,
                           left: risk.severity,
                           middle: `${risk.code}: ${risk.message}`,
@@ -3987,7 +4059,7 @@ export function BotPage() {
                       />
                       <ActivityTable
                         title="Runs"
-                        rows={activity.runs.slice(0, 8).map((run) => ({
+                        rows={selectedBotActivity.runs.slice(0, 8).map((run) => ({
                           id: run.id,
                           left: run.status,
                           middle: run.stop_reason ?? (run.dry_run ? "dry_run" : "live"),
@@ -4007,7 +4079,8 @@ export function BotPage() {
           <div className="order-1 min-w-0 space-y-5 xl:col-start-1 xl:row-start-1">
             <BotSignalChart
               bot={selectedBot}
-              activity={activity}
+              authenticatedCacheScope={authenticatedCacheScope}
+              activity={selectedBotActivity}
               lastEvaluation={selectedBotEvaluation}
               refreshToken={chartRefreshToken}
               onMarketData={setMarketSnapshot}

--- a/frontend/src/pages/bot/BotSignalChart.tsx
+++ b/frontend/src/pages/bot/BotSignalChart.tsx
@@ -25,7 +25,8 @@ import {
 
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/Card";
-import { botsApi, streamProjectXMarketPrice } from "../../lib/api";
+import { botsApi, buildProjectXCandleRequestKey, streamProjectXMarketPrice, type CandleQuery } from "../../lib/api";
+import { ENABLE_PERF_LOGS, logPerfInfo } from "../../lib/perf";
 import { APP_THEME_CHANGED_EVENT } from "../../lib/theme";
 import type { BotActivity, BotConfig, BotEvaluation, BotTimeframeUnit, ProjectXMarketCandle, ProjectXMarketPrice } from "../../lib/types";
 import {
@@ -35,12 +36,15 @@ import {
   readBotCandleCache,
   upsertMarketCandles,
   writeBotCandleCache,
+  type CandleQueryWindow,
 } from "./botCandleCache";
 import {
   buildGapRangeKey,
   buildGapRepairWindows,
   findCandleGaps,
   isGapCoveredByRepairWindows,
+  planBotCandleFetches,
+  type BotCandleFetchRequest,
   type CandleGap,
 } from "./botCandleGaps";
 import type { BotMarketSnapshot } from "./botMarketContext";
@@ -94,7 +98,9 @@ import {
 import { BotEvaluationOverlayStatus } from "./BotEvaluationOverlayStatus";
 import {
   BOT_CHART_MAX_BARS,
+  BOT_CHART_TIMEFRAMES,
   buildBotChartQuery,
+  buildInitialBotChartQuery,
   buildBotLivePriceQuery,
   buildCandlestickData,
   buildEmaData,
@@ -107,12 +113,17 @@ import {
   toUtcTimestamp,
   type LiquidityLevel,
   type LiquiditySide,
+  type BotChartTimeframe,
+  type BotChartTimeframeId,
 } from "./botChartData";
 import {
   LatestRequestCoordinator,
+  LogicalViewportMemory,
+  PrioritizedRequestScheduler,
   getViewportRestoreRange,
   invalidateChartRequestLanes,
   type ChartViewportMutation,
+  type RequestPriority,
 } from "./botChartLifecycle";
 import { readBotChartThemeColors } from "./botChartTheme";
 import { buildVolumeData } from "./botChartVolume";
@@ -146,21 +157,29 @@ const LIVE_PRICE_STREAM_STALE_MS = 5_000;
 const LIVE_PRICE_STALE_AFTER_MS = 2 * LIVE_PRICE_POLL_INTERVAL_MS + 5_000;
 const CANDLE_REQUEST_TIMEOUT_MS = 70_000;
 const LIVE_PRICE_REQUEST_TIMEOUT_MS = 12_000;
-const MIN_CACHED_CHART_HYDRATION_BARS = 25;
+const BACKGROUND_CANDLE_START_INTERVAL_MS = 300;
 const LIQUIDITY_LINE_DRAG_HIT_RADIUS_PX = 8;
-const CHART_TIMEFRAME_OPTIONS = [
-  { id: "1m", label: "1m", unit: "minute", unitNumber: 1 },
-  { id: "5m", label: "5m", unit: "minute", unitNumber: 5 },
-  { id: "15m", label: "15m", unit: "minute", unitNumber: 15 },
-  { id: "1h", label: "1H", unit: "hour", unitNumber: 1 },
-  { id: "4h", label: "4H", unit: "hour", unitNumber: 4 },
-  { id: "1d", label: "1D", unit: "day", unitNumber: 1 },
-] as const;
-type ChartTimeframeOption = (typeof CHART_TIMEFRAME_OPTIONS)[number];
-type ChartTimeframeId = ChartTimeframeOption["id"];
-const DEFAULT_CHART_TIMEFRAME_ID: ChartTimeframeId = "5m";
+const DEFAULT_CHART_TIMEFRAME_ID: BotChartTimeframeId = "5m";
 const EASTERN_TIME_ZONE = "America/New_York";
 const VWAP_SESSION_START_TIME = "18:00";
+
+const candleRequestScheduler = new PrioritizedRequestScheduler<string>({
+  maxConcurrency: 2,
+  maxBackgroundConcurrency: 1,
+  minBackgroundStartIntervalMs: BACKGROUND_CANDLE_START_INTERVAL_MS,
+});
+
+function requestProjectXCandles(
+  query: CandleQuery,
+  priority: RequestPriority,
+  signal?: AbortSignal,
+): Promise<ProjectXMarketCandle[]> {
+  return candleRequestScheduler.schedule(
+    buildProjectXCandleRequestKey(query),
+    (sharedSignal) => botsApi.getCandles(query, { signal: sharedSignal }),
+    { priority, signal },
+  );
+}
 
 const lastLoadedFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: EASTERN_TIME_ZONE,
@@ -246,7 +265,7 @@ interface LivePricePoint {
 
 interface ChartTimeframeSelection {
   key: string;
-  id: ChartTimeframeId;
+  id: BotChartTimeframeId;
 }
 
 type LiquidityPriceOverrides = Partial<Record<LiquiditySide, number>>;
@@ -265,6 +284,23 @@ interface AppliedSeriesState {
   fast: LineData<UTCTimestamp>[];
   slow: LineData<UTCTimestamp>[];
   vwap: LineData<UTCTimestamp>[];
+}
+
+type SignalChartLoadKind = "cold" | "warm" | "timeframe-switch";
+
+interface PendingSignalChartLoadTiming {
+  contextKey: string;
+  kind: SignalChartLoadKind;
+  startedAtMs: number;
+  requestCount: number;
+  cacheHit: boolean;
+  measured: boolean;
+}
+
+interface SignalChartPerfContext {
+  contextKey: string;
+  botId: number | null;
+  contractId: string;
 }
 
 interface LiquidityDragState {
@@ -296,12 +332,18 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const fittedViewportRef = useRef<FittedViewportState | null>(null);
   const autoHistoryHookRef = useRef<((range: LogicalRange | null) => void) | null>(null);
   const appliedSeriesStateRef = useRef<AppliedSeriesState | null>(null);
+  const signalChartPerfContextRef = useRef<SignalChartPerfContext | null>(null);
+  const pendingSignalChartLoadTimingRef = useRef<PendingSignalChartLoadTiming | null>(null);
+  const signalChartMeasureFrameRef = useRef<number | null>(null);
   const candleRequestsRef = useRef(new LatestRequestCoordinator());
   const liveRequestsRef = useRef(new LatestRequestCoordinator());
   const historyRequestsRef = useRef(new LatestRequestCoordinator());
   const repairRequestsRef = useRef(new LatestRequestCoordinator());
+  const chartBackgroundControllerRef = useRef<AbortController | null>(null);
+  const warmTimeframesControllerRef = useRef<AbortController | null>(null);
   const requestTimeoutIdsRef = useRef<Set<number>>(new Set());
   const pendingViewportRestoreRef = useRef<LogicalRange | null>(null);
+  const viewportMemoryRef = useRef(new LogicalViewportMemory<string>());
   const viewportRestoreFrameRef = useRef<number | null>(null);
   const lastLiveStreamEventAtRef = useRef(0);
   const pendingLiveStreamPriceRef = useRef<ProjectXMarketPrice | null>(null);
@@ -352,7 +394,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }));
   const selectedTimeframeId =
     timeframeSelection.key === botTimeframeSelectionKey ? timeframeSelection.id : defaultChartTimeframeIdForBot(bot);
-  const chartTimeframe = CHART_TIMEFRAME_OPTIONS.find((option) => option.id === selectedTimeframeId) ?? CHART_TIMEFRAME_OPTIONS[0];
+  const chartTimeframe = BOT_CHART_TIMEFRAMES.find((option) => option.id === selectedTimeframeId) ?? BOT_CHART_TIMEFRAMES[0];
   const chartConfig = useMemo<BotConfig | null>(() => {
     if (!bot) {
       return null;
@@ -364,6 +406,11 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     };
   }, [bot, chartTimeframe]);
   const chartViewportKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${selectedTimeframeId}`;
+  const chartBotId = bot?.id ?? null;
+  const chartContractId = bot?.contract_id ?? "";
+  const warmContractKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${bot?.symbol ?? ""}`;
+  const warmBotRef = useRef<BotConfig | null>(bot);
+  warmBotRef.current = bot;
   const [marketDataContextKey, setMarketDataContextKey] = useState(chartViewportKey);
   const marketDataMatchesContext = marketDataContextKey === chartViewportKey;
 
@@ -482,7 +529,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const latestClosedCandle = useMemo(
     () =>
       marketDataMatchesContext
-        ? [...candles].reverse().find((candle) => !candle.is_partial && isRenderableMarketCandle(candle)) ?? null
+        ? findLatestClosedMarketCandle(candles)
         : null,
     [candles, marketDataMatchesContext],
   );
@@ -536,6 +583,38 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const drawingStorageScopeKey = drawingStorageScope ? buildBotDrawingStorageKey(drawingStorageScope) : null;
   const chartViewportKeyRef = useRef(chartViewportKey);
   chartViewportKeyRef.current = chartViewportKey;
+
+  useEffect(() => {
+    if (!ENABLE_PERF_LOGS || chartBotId === null) {
+      pendingSignalChartLoadTimingRef.current = null;
+      signalChartPerfContextRef.current =
+        chartBotId === null
+          ? null
+          : { contextKey: chartViewportKey, botId: chartBotId, contractId: chartContractId };
+      return;
+    }
+
+    const previous = signalChartPerfContextRef.current;
+    const timeframeSwitch =
+      previous !== null &&
+      previous.contextKey !== chartViewportKey &&
+      previous.botId === chartBotId &&
+      previous.contractId === chartContractId;
+    pendingSignalChartLoadTimingRef.current = {
+      contextKey: chartViewportKey,
+      kind: timeframeSwitch ? "timeframe-switch" : "cold",
+      startedAtMs: performance.now(),
+      requestCount: 0,
+      cacheHit: false,
+      measured: false,
+    };
+    signalChartPerfContextRef.current = {
+      contextKey: chartViewportKey,
+      botId: chartBotId,
+      contractId: chartContractId,
+    };
+  }, [chartBotId, chartContractId, chartViewportKey]);
+
   const queueViewportRestore = useCallback(
     (mutation: ChartViewportMutation, previousRows: ProjectXMarketCandle[], nextRows: ProjectXMarketCandle[]) => {
       const handles = chartHandlesRef.current;
@@ -628,6 +707,8 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   // Reset per-market transient state when the chart context changes.
   useEffect(() => {
     setMarketDataContextKey(chartViewportKey);
+    chartBackgroundControllerRef.current?.abort();
+    chartBackgroundControllerRef.current = null;
     candlesRef.current = [];
     liveCandleRef.current = null;
     setCandles([]);
@@ -658,6 +739,21 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     }
     setHistoryLoading(false);
     setGapRepairing(false);
+  }, [chartViewportKey]);
+
+  useEffect(() => {
+    const viewportMemory = viewportMemoryRef.current;
+    const rememberedRange = viewportMemory.restore(chartViewportKey);
+    if (rememberedRange) {
+      pendingViewportRestoreRef.current = rememberedRange;
+    }
+
+    return () => {
+      viewportMemory.save(
+        chartViewportKey,
+        chartHandlesRef.current?.chart.timeScale().getVisibleLogicalRange() ?? null,
+      );
+    };
   }, [chartViewportKey]);
 
   // Periodic tick so freshness text ("Updated Xs ago", stale chip) re-renders.
@@ -776,10 +872,161 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     writeBotDrawings(drawingStorageScope, drawings);
   }, [drawingStorageScope, drawingStorageScopeKey, drawings, hydratedDrawingScopeKey]);
 
+  const commitCandleFetch = useCallback(
+    ({
+      cacheKey,
+      cacheLimit,
+      contextKey,
+      request,
+      rows,
+      replaceCache = false,
+      applyToChart = true,
+      mutation,
+    }: {
+      cacheKey: string;
+      cacheLimit: number;
+      contextKey: string;
+      request: BotCandleFetchRequest;
+      rows: ProjectXMarketCandle[];
+      replaceCache?: boolean;
+      applyToChart?: boolean;
+      mutation?: ChartViewportMutation;
+    }) => {
+      const fetchedAt = new Date();
+      const previousEntry = readBotCandleCache(cacheKey);
+      const cacheBase = replaceCache ? [] : previousEntry?.candles ?? [];
+      const mergedCache = mergeMarketCandles(
+        cacheBase,
+        rows,
+        Math.min(
+          BOT_CHART_MAX_BARS,
+          Math.max(cacheLimit, previousEntry?.candles.length ?? 0, rows.length),
+        ),
+      );
+      const coverage = replaceCache
+        ? request.window
+        : mergeCandleCacheCoverage(previousEntry?.coverage ?? null, request.window);
+      writeBotCandleCache(cacheKey, mergedCache, cacheLimitForRows(cacheLimit, mergedCache.length), {
+        savedAt: fetchedAt,
+        coverage,
+      });
+
+      if (!applyToChart || contextKey !== chartViewportKeyRef.current) {
+        return;
+      }
+
+      const previousRows = candlesRef.current;
+      const nextRows = upsertMarketCandles(previousRows, rows, MAX_LOADED_BARS);
+      if (nextRows !== previousRows) {
+        queueViewportRestore(
+          mutation ??
+            (request.reason === "missing-history" || request.reason === "interior-gap" ? "pagination" : "live"),
+          previousRows,
+          nextRows,
+        );
+        candlesRef.current = nextRows;
+        setCandles(nextRows);
+      }
+      setLastLoadedAt(fetchedAt);
+      setServedFromCacheOnly(false);
+
+      if (request.reason === "interior-gap") {
+        const config = chartConfigRef.current;
+        if (config) {
+          const remaining = findCandleGaps(
+            candlesRef.current,
+            config.timeframe_unit,
+            config.timeframe_unit_number,
+          );
+          for (const gap of remaining) {
+            if (gap.kind === "data" && isGapCoveredByRepairWindows(gap, [request.window])) {
+              repairedGapKeysRef.current.add(buildGapRangeKey(gap));
+            }
+          }
+          setRepairVersion((current) => current + 1);
+        }
+      }
+    },
+    [queueViewportRestore],
+  );
+
+  const scheduleBackgroundCandleFetches = useCallback(
+    ({
+      cacheKey,
+      cacheLimit,
+      config,
+      contextKey,
+      requests,
+    }: {
+      cacheKey: string;
+      cacheLimit: number;
+      config: BotConfig;
+      contextKey: string;
+      requests: BotCandleFetchRequest[];
+    }) => {
+      chartBackgroundControllerRef.current?.abort();
+      const runnableRequests = requests.filter((request) => {
+        if (request.reason !== "interior-gap") {
+          return true;
+        }
+        return findCandleGaps(
+          candlesRef.current,
+          config.timeframe_unit,
+          config.timeframe_unit_number,
+        ).some(
+          (gap) =>
+            gap.kind === "data" &&
+            isGapCoveredByRepairWindows(gap, [request.window]) &&
+            !repairedGapKeysRef.current.has(buildGapRangeKey(gap)),
+        );
+      });
+      if (runnableRequests.length === 0) {
+        chartBackgroundControllerRef.current = null;
+        return;
+      }
+
+      const controller = new AbortController();
+      chartBackgroundControllerRef.current = controller;
+      let pendingCount = runnableRequests.length;
+      for (const request of runnableRequests) {
+        const query = candleQueryForFetchRequest(config, request);
+        void requestProjectXCandles(query, "background", controller.signal)
+          .then((rows) => {
+            commitCandleFetch({
+              cacheKey,
+              cacheLimit,
+              contextKey,
+              request,
+              rows,
+              applyToChart: contextKey === chartViewportKeyRef.current,
+            });
+          })
+          .catch((error) => {
+            if (!isAbortError(error)) {
+              logPerfInfo("[perf][signal-chart] background-fetch-error", {
+                contextKey,
+                reason: request.reason,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          })
+          .finally(() => {
+            pendingCount -= 1;
+            if (pendingCount === 0 && chartBackgroundControllerRef.current === controller) {
+              chartBackgroundControllerRef.current = null;
+            }
+          });
+      }
+    },
+    [commitCandleFetch],
+  );
+
   const loadCandles = useCallback(
     async ({ silent = false, forceRefresh = false }: LoadCandlesOptions = {}) => {
       if (!chartConfig) {
         candleRequestsRef.current.invalidate();
+        chartBackgroundControllerRef.current?.abort();
+        chartBackgroundControllerRef.current = null;
         setCandles([]);
         setLiveCandle(null);
         setStreamPrice(null);
@@ -804,10 +1051,9 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         setGapRepairing(false);
       }
 
-      const request = candleRequestsRef.current.begin(chartViewportKey);
-      const timeoutId = window.setTimeout(() => request.controller.abort(), CANDLE_REQUEST_TIMEOUT_MS);
-      requestTimeoutIdsRef.current.add(timeoutId);
-      const queryWindow = buildBotChartQuery(chartConfig);
+      const now = new Date();
+      const queryWindow = buildBotChartQuery(chartConfig, now);
+      const initialQueryWindow = buildInitialBotChartQuery(chartConfig, now);
       const cacheKey = buildBotCandleCacheKey({
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol,
@@ -817,60 +1063,123 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       });
       const cachedEntry = forceRefresh ? null : readBotCandleCache(cacheKey);
       const cachedCandles = cachedEntry ? filterMarketCandlesForWindow(cachedEntry.candles, queryWindow) : [];
-      const hydrateFromCache = shouldHydrateChartFromCache(cachedCandles.length, queryWindow.limit);
+      const plan = forceRefresh
+        ? null
+        : planBotCandleFetches({
+            targetWindow: queryWindow,
+            initialWindow: initialQueryWindow,
+            cache:
+              cachedEntry && cachedCandles.length > 0
+                ? {
+                    candles: cachedCandles,
+                    savedAt: cachedEntry.savedAt,
+                    coverage: cachedEntry.coverage,
+                  }
+                : null,
+            unit: chartConfig.timeframe_unit,
+            unitNumber: chartConfig.timeframe_unit_number,
+            now,
+            maxRepairWindows: MAX_GAP_REPAIR_WINDOWS,
+          });
+      const foregroundRequests: BotCandleFetchRequest[] = forceRefresh
+        ? [
+            {
+              reason: "stale-tail",
+              priority: "foreground",
+              window: { start: queryWindow.start, end: queryWindow.end },
+              limit: queryWindow.limit,
+              repair: false,
+            },
+          ]
+        : plan?.foreground ?? [];
+      const backgroundRequests = plan?.background ?? [];
 
-      if (cachedEntry && hydrateFromCache) {
-        // Paint cached bars immediately on cold loads; when in-memory data already
-        // exists (background polls), leave it alone so paged-in history survives.
+      if (cachedEntry && cachedCandles.length > 0) {
+        // Paint every valid cached row immediately. In-memory rows already on
+        // screen may include deeper paged history, so preserve them on polls.
         if (candlesRef.current.length === 0) {
           setCandles(cachedCandles);
           candlesRef.current = cachedCandles;
           setLastLoadedAt(cachedEntry.savedAt);
         }
+        const pendingTiming = pendingSignalChartLoadTimingRef.current;
+        if (pendingTiming?.contextKey === chartViewportKey) {
+          pendingTiming.cacheHit = true;
+          if (pendingTiming.kind === "cold") {
+            pendingTiming.kind = "warm";
+          }
+        }
         setLoading(false);
-        if (!silent) {
+        if (!silent && foregroundRequests.length > 0) {
           setRefreshing(true);
         }
       } else if (forceRefresh) {
         setRefreshing(true);
-      } else if (cachedEntry && !silent) {
-        setLoading(true);
-      } else if (!silent) {
+      } else if (!silent && foregroundRequests.length > 0) {
         setLoading(true);
       }
       setError(null);
 
-      try {
-        const rows = await botsApi.getCandles({
-          contractId: chartConfig.contract_id,
-          symbol: chartConfig.symbol ?? undefined,
-          start: queryWindow.start,
-          end: queryWindow.end,
-          live: false,
-          unit: chartConfig.timeframe_unit,
-          unitNumber: chartConfig.timeframe_unit_number,
-          limit: queryWindow.limit,
-          includePartialBar: false,
-          refresh: forceRefresh,
-        }, { signal: request.signal });
-        if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
-          return;
+      if (foregroundRequests.length === 0) {
+        setLoading(false);
+        setRefreshing(false);
+        if (cachedCandles.length > 0) {
+          setServedFromCacheOnly(false);
         }
-        const mergedRows = forceRefresh ? rows : mergeMarketCandles(cachedCandles, rows, queryWindow.limit);
-        // Keep older history the user already paged in; the fetch window only covers the recent range.
-        // Rolled partials also remain until ProjectX returns their authoritative
-        // closed replacement; upsert precedence guarantees closed always wins.
-        const nextRows = upsertMarketCandles(candlesRef.current, mergedRows, MAX_LOADED_BARS);
-        queueViewportRestore(forceRefresh ? "refresh" : "live", candlesRef.current, nextRows);
-        setCandles(nextRows);
-        candlesRef.current = nextRows;
-        writeBotCandleCache(cacheKey, mergedRows, queryWindow.limit);
-        setLastLoadedAt(new Date());
-        setServedFromCacheOnly(false);
+        if (backgroundRequests.length > 0) {
+          scheduleBackgroundCandleFetches({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            config: chartConfig,
+            contextKey: chartViewportKey,
+            requests: backgroundRequests,
+          });
+        }
+        return;
+      }
+
+      const request = candleRequestsRef.current.begin(chartViewportKey);
+      const timeoutId = window.setTimeout(() => request.controller.abort(), CANDLE_REQUEST_TIMEOUT_MS);
+      requestTimeoutIdsRef.current.add(timeoutId);
+      try {
+        for (const fetchRequest of foregroundRequests) {
+          const pendingTiming = pendingSignalChartLoadTimingRef.current;
+          if (pendingTiming?.contextKey === chartViewportKey) {
+            pendingTiming.requestCount += 1;
+          }
+          const rows = await requestProjectXCandles(
+            {
+              ...candleQueryForFetchRequest(chartConfig, fetchRequest),
+              refresh: forceRefresh,
+            },
+            "foreground",
+            request.signal,
+          );
+          if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
+            return;
+          }
+          commitCandleFetch({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            contextKey: chartViewportKey,
+            request: fetchRequest,
+            rows,
+            replaceCache: forceRefresh,
+            mutation: forceRefresh ? "refresh" : undefined,
+          });
+        }
         if (forceRefresh) {
           // Retry previously confirmed-empty holes after an explicit provider refresh.
           repairedGapKeysRef.current = new Set();
           setRepairVersion((current) => current + 1);
+        } else if (backgroundRequests.length > 0) {
+          scheduleBackgroundCandleFetches({
+            cacheKey,
+            cacheLimit: queryWindow.limit,
+            config: chartConfig,
+            contextKey: chartViewportKey,
+            requests: backgroundRequests,
+          });
         }
       } catch (err) {
         if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
@@ -898,7 +1207,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         }
       }
     },
-    [chartConfig, chartViewportKey, queueViewportRestore],
+    [chartConfig, chartViewportKey, commitCandleFetch, scheduleBackgroundCandleFetches],
   );
 
   const loadLivePrice = useCallback(async ({ force = false }: LoadLivePriceOptions = {}) => {
@@ -920,7 +1229,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     const queryWindow = buildBotLivePriceQuery(chartConfig);
 
     try {
-      const rows = await botsApi.getCandles({
+      const rows = await requestProjectXCandles({
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol ?? undefined,
         start: queryWindow.start,
@@ -931,21 +1240,35 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         limit: queryWindow.limit,
         includePartialBar: true,
         refresh: true,
-      }, { signal: request.signal });
+      }, "foreground", request.signal);
       if (!liveRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
 
       // Promote closed candles from the live window into the chart immediately so a
       // just-finished bar does not vanish until the next slow poll.
-      const closedRows = rows
-        .filter((row) => !row.is_partial)
-        .filter((row) => !hasClosedCandleAtTimestamp(candlesRef.current, row));
+      const closedRows = rows.filter((row) => !row.is_partial);
       if (closedRows.length > 0) {
-        const merged = upsertMarketCandles(candlesRef.current, closedRows, MAX_LOADED_BARS);
-        queueViewportRestore("live", candlesRef.current, merged);
-        candlesRef.current = merged;
-        setCandles(merged);
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: chartConfig.contract_id,
+          symbol: chartConfig.symbol,
+          live: false,
+          unit: chartConfig.timeframe_unit,
+          unitNumber: chartConfig.timeframe_unit_number,
+        });
+        commitCandleFetch({
+          cacheKey,
+          cacheLimit: BOT_CHART_MAX_BARS,
+          contextKey: chartViewportKey,
+          request: {
+            reason: "stale-tail",
+            priority: "foreground",
+            window: { start: queryWindow.start, end: queryWindow.end },
+            limit: queryWindow.limit,
+            repair: false,
+          },
+          rows: closedRows,
+        });
       }
 
       const latest = getLatestMarketCandle(rows);
@@ -995,7 +1318,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       requestTimeoutIdsRef.current.delete(timeoutId);
       liveRequestsRef.current.finish(request);
     }
-  }, [chartConfig, chartViewportKey, queueViewportRestore]);
+  }, [chartConfig, chartViewportKey, commitCandleFetch]);
 
   const loadOlderCandles = useCallback(async () => {
     const config = chartConfigRef.current;
@@ -1022,7 +1345,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     requestTimeoutIdsRef.current.add(timeoutId);
     setHistoryLoading(true);
     try {
-      const rows = await botsApi.getCandles({
+      const rows = await requestProjectXCandles({
         contractId: config.contract_id,
         symbol: config.symbol ?? undefined,
         start: queryWindow.start,
@@ -1032,7 +1355,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         unitNumber: config.timeframe_unit_number,
         limit: queryWindow.limit,
         includePartialBar: false,
-      }, { signal: request.signal });
+      }, "foreground", request.signal);
       if (!historyRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
@@ -1048,11 +1371,27 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         return;
       }
 
-      const merged = upsertMarketCandles(candlesRef.current, olderRows, MAX_LOADED_BARS);
-      queueViewportRestore("pagination", candlesRef.current, merged);
-      candlesRef.current = merged;
-      setCandles(merged);
-      if (merged.length >= MAX_LOADED_BARS) {
+      const cacheKey = buildBotCandleCacheKey({
+        contractId: config.contract_id,
+        symbol: config.symbol,
+        live: false,
+        unit: config.timeframe_unit,
+        unitNumber: config.timeframe_unit_number,
+      });
+      commitCandleFetch({
+        cacheKey,
+        cacheLimit: BOT_CHART_MAX_BARS,
+        contextKey,
+        request: {
+          reason: "missing-history",
+          priority: "foreground",
+          window: { start: queryWindow.start, end: queryWindow.end },
+          limit: queryWindow.limit,
+          repair: false,
+        },
+        rows: olderRows,
+      });
+      if (candlesRef.current.length >= MAX_LOADED_BARS) {
         hasMoreHistoryRef.current = false;
         setHasMoreHistory(false);
       }
@@ -1067,7 +1406,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         setHistoryLoading(false);
       }
     }
-  }, [queueViewportRestore]);
+  }, [commitCandleFetch]);
 
   const repairDataGaps = useCallback(async () => {
     const config = chartConfigRef.current;
@@ -1095,7 +1434,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     try {
       const repairedRows: ProjectXMarketCandle[] = [];
       for (const window_ of windows) {
-        const rows = await botsApi.getCandles({
+        const rows = await requestProjectXCandles({
           contractId: config.contract_id,
           symbol: config.symbol ?? undefined,
           start: window_.start,
@@ -1106,7 +1445,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
           limit: BOT_CHART_MAX_BARS,
           includePartialBar: false,
           repair: true,
-        }, { signal: request.signal });
+        }, "foreground", request.signal);
         if (!repairRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
           return;
         }
@@ -1115,13 +1454,31 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         }
       }
       if (repairedRows.length > 0) {
-        const additiveRepairRows = repairedRows.filter(
-          (row) => row.is_partial || !hasClosedCandleAtTimestamp(candlesRef.current, row),
+        const previousRows = candlesRef.current;
+        const merged = upsertMarketCandles(previousRows, repairedRows, MAX_LOADED_BARS);
+        if (merged !== previousRows) {
+          queueViewportRestore("pagination", previousRows, merged);
+          candlesRef.current = merged;
+          setCandles(merged);
+        }
+
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: config.contract_id,
+          symbol: config.symbol,
+          live: false,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+        });
+        const previousEntry = readBotCandleCache(cacheKey);
+        const cacheRows = mergeMarketCandles(previousEntry?.candles ?? [], repairedRows, BOT_CHART_MAX_BARS);
+        const coverage = windows.reduce<CandleQueryWindow | null>(
+          (current, window_) => mergeCandleCacheCoverage(current, window_),
+          previousEntry?.coverage ?? null,
         );
-        const merged = upsertMarketCandles(candlesRef.current, additiveRepairRows, MAX_LOADED_BARS);
-        queueViewportRestore("pagination", candlesRef.current, merged);
-        candlesRef.current = merged;
-        setCandles(merged);
+        writeBotCandleCache(cacheKey, cacheRows, cacheLimitForRows(BOT_CHART_MAX_BARS, cacheRows.length), {
+          savedAt: new Date(),
+          coverage,
+        });
       }
 
       // Only gaps covered by this bounded pass can be confirmed empty. Remaining
@@ -2074,8 +2431,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     applySeriesData(handles.slowSeries, incremental ? previousState.slow : null, nextState.slow);
     applySeriesData(handles.vwapSeries, incremental ? previousState.vwap : null, nextState.vwap);
     appliedSeriesStateRef.current = nextState;
-    const restoreRange = pendingViewportRestoreRef.current;
-    pendingViewportRestoreRef.current = null;
+    const restoreRange = chartCandles.length > 0 ? pendingViewportRestoreRef.current : null;
+    if (chartCandles.length > 0) {
+      pendingViewportRestoreRef.current = null;
+    }
     if (viewportRestoreFrameRef.current !== null) {
       window.cancelAnimationFrame(viewportRestoreFrameRef.current);
       viewportRestoreFrameRef.current = null;
@@ -2086,6 +2445,54 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         if (chartHandlesRef.current === handles) {
           handles.chart.timeScale().setVisibleLogicalRange(restoreRange);
         }
+      });
+    }
+    const pendingTiming = pendingSignalChartLoadTimingRef.current;
+    if (
+      ENABLE_PERF_LOGS &&
+      chartCandles.length > 0 &&
+      pendingTiming &&
+      !pendingTiming.measured &&
+      pendingTiming.contextKey === timeframeKey
+    ) {
+      pendingTiming.measured = true;
+      if (signalChartMeasureFrameRef.current !== null) {
+        window.cancelAnimationFrame(signalChartMeasureFrameRef.current);
+      }
+      signalChartMeasureFrameRef.current = window.requestAnimationFrame(() => {
+        signalChartMeasureFrameRef.current = null;
+        if (pendingSignalChartLoadTimingRef.current !== pendingTiming) {
+          return;
+        }
+        const endedAtMs = performance.now();
+        const metricName = `topsignal:signal-chart:${pendingTiming.kind}-first-paint`;
+        const detail = {
+          contextKey: timeframeKey,
+          cacheHit: pendingTiming.cacheHit,
+          requestCount: pendingTiming.requestCount,
+          barCount: chartCandles.length,
+        };
+        try {
+          performance.measure(metricName, {
+            start: pendingTiming.startedAtMs,
+            end: endedAtMs,
+            detail,
+          });
+        } catch {
+          // Older browsers can omit PerformanceMeasureOptions.detail.
+          performance.measure(metricName, {
+            start: pendingTiming.startedAtMs,
+            end: endedAtMs,
+          });
+        }
+        logPerfInfo(
+          "[perf][signal-chart] first-paint",
+          JSON.stringify({
+            metricName,
+            durationMs: Math.round((endedAtMs - pendingTiming.startedAtMs) * 10) / 10,
+            ...detail,
+          }),
+        );
       });
     }
     setDrawingOverlayRevision((current) => current + 1);
@@ -2234,17 +2641,103 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }, [livePrice, livePriceIsStale, livePricePoint?.isPartial]);
 
   useEffect(() => {
-    let active = true;
-    void loadCandles().finally(() => {
-      if (active) {
-        void loadLivePrice({ force: true });
+    void loadCandles();
+    void loadLivePrice({ force: true });
+  }, [loadCandles, loadLivePrice, refreshToken]);
+
+  useEffect(() => {
+    warmTimeframesControllerRef.current?.abort();
+    const selectedBot = warmBotRef.current;
+    if (!selectedBot) {
+      warmTimeframesControllerRef.current = null;
+      return;
+    }
+
+    const controller = new AbortController();
+    warmTimeframesControllerRef.current = controller;
+    window.queueMicrotask(() => {
+      if (controller.signal.aborted || warmTimeframesControllerRef.current !== controller) {
+        return;
       }
+      const now = new Date();
+      let queuedCount = 0;
+      for (const timeframe of BOT_CHART_TIMEFRAMES) {
+        const config: BotConfig = {
+          ...selectedBot,
+          timeframe_unit: timeframe.unit,
+          timeframe_unit_number: timeframe.unitNumber,
+        };
+        const initialWindow = buildInitialBotChartQuery(config, now);
+        const cacheKey = buildBotCandleCacheKey({
+          contractId: config.contract_id,
+          symbol: config.symbol,
+          live: false,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+        });
+        const cacheEntry = readBotCandleCache(cacheKey);
+        const cachedCandles = cacheEntry
+          ? filterMarketCandlesForWindow(cacheEntry.candles, initialWindow)
+          : [];
+        const plan = planBotCandleFetches({
+          targetWindow: initialWindow,
+          initialWindow,
+          cache:
+            cacheEntry && cachedCandles.length > 0
+              ? {
+                  candles: cachedCandles,
+                  savedAt: cacheEntry.savedAt,
+                  coverage: cacheEntry.coverage,
+                }
+              : null,
+          unit: config.timeframe_unit,
+          unitNumber: config.timeframe_unit_number,
+          now,
+          maxRepairWindows: 1,
+        });
+
+        for (const fetchRequest of plan.requests) {
+          queuedCount += 1;
+          const query = candleQueryForFetchRequest(config, fetchRequest);
+          void requestProjectXCandles(query, "background", controller.signal)
+            .then((rows) => {
+              commitCandleFetch({
+                cacheKey,
+                cacheLimit: initialWindow.limit,
+                contextKey: `warm:${warmContractKey}:${timeframe.id}`,
+                request: fetchRequest,
+                rows,
+                applyToChart: false,
+              });
+            })
+            .catch((error) => {
+              if (!isAbortError(error)) {
+                logPerfInfo("[perf][signal-chart] warm-error", {
+                  contractKey: warmContractKey,
+                  timeframe: timeframe.id,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            });
+        }
+      }
+      logPerfInfo(
+        "[perf][signal-chart] warm-queued",
+        JSON.stringify({
+          contractKey: warmContractKey,
+          queuedCount,
+          timeframes: BOT_CHART_TIMEFRAMES.map((timeframe) => timeframe.id),
+        }),
+      );
     });
 
     return () => {
-      active = false;
+      controller.abort();
+      if (warmTimeframesControllerRef.current === controller) {
+        warmTimeframesControllerRef.current = null;
+      }
     };
-  }, [loadCandles, loadLivePrice, refreshToken]);
+  }, [commitCandleFetch, warmContractKey]);
 
   useEffect(() => {
     const candleRequests = candleRequestsRef.current;
@@ -2257,6 +2750,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       liveRequests.dispose();
       historyRequests.dispose();
       repairRequests.dispose();
+      chartBackgroundControllerRef.current?.abort();
+      chartBackgroundControllerRef.current = null;
+      warmTimeframesControllerRef.current?.abort();
+      warmTimeframesControllerRef.current = null;
       for (const timeoutId of requestTimeoutIds) {
         window.clearTimeout(timeoutId);
       }
@@ -2264,6 +2761,10 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       if (viewportRestoreFrameRef.current !== null) {
         window.cancelAnimationFrame(viewportRestoreFrameRef.current);
         viewportRestoreFrameRef.current = null;
+      }
+      if (signalChartMeasureFrameRef.current !== null) {
+        window.cancelAnimationFrame(signalChartMeasureFrameRef.current);
+        signalChartMeasureFrameRef.current = null;
       }
       if (liveStreamRenderTimeoutRef.current !== null) {
         window.clearTimeout(liveStreamRenderTimeoutRef.current);
@@ -2567,7 +3068,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         <div className="mt-3 flex flex-col gap-2 rounded-lg border border-app-border/80 bg-app-bg/40 p-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             <div className="inline-flex h-8 overflow-hidden rounded-md border border-app-border-strong/70 bg-app-surface/95 shadow-[0_10px_24px_-22px_rgb(var(--theme-shadow-color)/0.55)]" aria-label="Chart timeframe">
-              {CHART_TIMEFRAME_OPTIONS.map((option) => {
+              {BOT_CHART_TIMEFRAMES.map((option) => {
                 const active = option.id === selectedTimeframeId;
                 return (
                   <button
@@ -2775,14 +3276,53 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   );
 }
 
-function findMatchingTimeframeId(unit: BotTimeframeUnit, unitNumber: number): ChartTimeframeId | null {
+function candleQueryForFetchRequest(config: BotConfig, request: BotCandleFetchRequest): CandleQuery {
+  return {
+    contractId: config.contract_id,
+    symbol: config.symbol ?? undefined,
+    start: request.window.start,
+    end: request.window.end,
+    live: false,
+    unit: config.timeframe_unit,
+    unitNumber: config.timeframe_unit_number,
+    limit: request.limit,
+    includePartialBar: false,
+    repair: request.repair,
+  };
+}
+
+function mergeCandleCacheCoverage(
+  existing: CandleQueryWindow | null,
+  incoming: CandleQueryWindow,
+): CandleQueryWindow {
+  if (!existing) {
+    return incoming;
+  }
+  const existingStartMs = Date.parse(existing.start);
+  const existingEndMs = Date.parse(existing.end);
+  const incomingStartMs = Date.parse(incoming.start);
+  const incomingEndMs = Date.parse(incoming.end);
+  if (![existingStartMs, existingEndMs, incomingStartMs, incomingEndMs].every(Number.isFinite)) {
+    return incoming;
+  }
+  return {
+    start: new Date(Math.min(existingStartMs, incomingStartMs)).toISOString(),
+    end: new Date(Math.max(existingEndMs, incomingEndMs)).toISOString(),
+  };
+}
+
+function cacheLimitForRows(requestedLimit: number, rowCount: number): number {
+  return Math.min(BOT_CHART_MAX_BARS, Math.max(1, Math.trunc(requestedLimit), Math.trunc(rowCount)));
+}
+
+function findMatchingTimeframeId(unit: BotTimeframeUnit, unitNumber: number): BotChartTimeframeId | null {
   const normalizedNumber = Math.max(1, Math.trunc(unitNumber));
   return (
-    CHART_TIMEFRAME_OPTIONS.find((option) => option.unit === unit && option.unitNumber === normalizedNumber)?.id ?? null
+    BOT_CHART_TIMEFRAMES.find((option) => option.unit === unit && option.unitNumber === normalizedNumber)?.id ?? null
   );
 }
 
-function defaultChartTimeframeIdForBot(bot: BotConfig | null): ChartTimeframeId {
+function defaultChartTimeframeIdForBot(bot: BotConfig | null): BotChartTimeframeId {
   if (!bot) {
     return DEFAULT_CHART_TIMEFRAME_ID;
   }
@@ -2794,10 +3334,6 @@ function buildBotTimeframeSelectionKey(bot: BotConfig | null): string {
     return "none";
   }
   return `${bot.id}:${bot.timeframe_unit}:${Math.max(1, Math.trunc(bot.timeframe_unit_number))}`;
-}
-
-function shouldHydrateChartFromCache(candleCount: number, requestedLimit: number): boolean {
-  return candleCount >= Math.min(MIN_CACHED_CHART_HYDRATION_BARS, Math.max(1, Math.trunc(requestedLimit)));
 }
 
 const MAX_INCREMENTAL_APPEND_BARS = 8;
@@ -2966,7 +3502,7 @@ function compactMeridiem(value: string): string {
   return value.replace(/\s(AM|PM)$/, "$1");
 }
 
-function buildChartSubtitle(bot: BotConfig, chartTimeframe: ChartTimeframeOption): string {
+function buildChartSubtitle(bot: BotConfig, chartTimeframe: BotChartTimeframe): string {
   const market = bot.symbol ?? bot.contract_id;
   const botTimeframeLabel = formatTimeframeLabel(bot.timeframe_unit, bot.timeframe_unit_number);
   if (botTimeframeLabel === chartTimeframe.label) {
@@ -2977,7 +3513,7 @@ function buildChartSubtitle(bot: BotConfig, chartTimeframe: ChartTimeframeOption
 
 function formatTimeframeLabel(unit: BotTimeframeUnit, unitNumber: number): string {
   const normalizedNumber = Math.max(1, Math.trunc(unitNumber));
-  const preset = CHART_TIMEFRAME_OPTIONS.find((option) => option.unit === unit && option.unitNumber === normalizedNumber);
+  const preset = BOT_CHART_TIMEFRAMES.find((option) => option.unit === unit && option.unitNumber === normalizedNumber);
   if (preset) {
     return preset.label;
   }
@@ -3061,19 +3597,35 @@ function marketCandlesShareTimestamp(left: ProjectXMarketCandle, right: ProjectX
   return Number.isFinite(leftMs) && leftMs === rightMs;
 }
 
-function hasClosedCandleAtTimestamp(candles: readonly ProjectXMarketCandle[], candidate: ProjectXMarketCandle): boolean {
-  return candles.some((candle) => !candle.is_partial && marketCandlesShareTimestamp(candle, candidate));
-}
-
 function marketCandleFetchedAtMs(candle: ProjectXMarketCandle): number {
   const fetchedAtMs = candle.fetched_at ? Date.parse(candle.fetched_at) : Number.NaN;
   return Number.isFinite(fetchedAtMs) ? fetchedAtMs : 0;
 }
 
 function getLatestMarketCandle(candles: ProjectXMarketCandle[]): ProjectXMarketCandle | null {
-  return candles
-    .filter(isRenderableMarketCandle)
-    .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp))[0] ?? null;
+  let latest: ProjectXMarketCandle | null = null;
+  let latestTimestampMs = Number.NEGATIVE_INFINITY;
+  for (const candle of candles) {
+    if (!isRenderableMarketCandle(candle)) {
+      continue;
+    }
+    const timestampMs = Date.parse(candle.timestamp);
+    if (timestampMs >= latestTimestampMs) {
+      latest = candle;
+      latestTimestampMs = timestampMs;
+    }
+  }
+  return latest;
+}
+
+function findLatestClosedMarketCandle(candles: readonly ProjectXMarketCandle[]): ProjectXMarketCandle | null {
+  for (let index = candles.length - 1; index >= 0; index -= 1) {
+    const candle = candles[index];
+    if (!candle.is_partial && isRenderableMarketCandle(candle)) {
+      return candle;
+    }
+  }
+  return null;
 }
 
 function isRenderableMarketCandle(candle: ProjectXMarketCandle): boolean {

--- a/frontend/src/pages/bot/BotSignalChart.tsx
+++ b/frontend/src/pages/bot/BotSignalChart.tsx
@@ -25,7 +25,7 @@ import {
 
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/Card";
-import { botsApi, buildProjectXCandleRequestKey, streamProjectXMarketPrice, type CandleQuery } from "../../lib/api";
+import { botsApi, buildUserScopedProjectXCandleRequestKey, streamProjectXMarketPrice, type CandleQuery } from "../../lib/api";
 import { ENABLE_PERF_LOGS, logPerfInfo } from "../../lib/perf";
 import { APP_THEME_CHANGED_EVENT } from "../../lib/theme";
 import type { BotActivity, BotConfig, BotEvaluation, BotTimeframeUnit, ProjectXMarketCandle, ProjectXMarketPrice } from "../../lib/types";
@@ -178,7 +178,7 @@ function requestProjectXCandles(
   signal?: AbortSignal,
 ): Promise<ProjectXMarketCandle[]> {
   return candleRequestScheduler.schedule(
-    `${authenticatedCacheScope}|${buildProjectXCandleRequestKey(query)}`,
+    buildUserScopedProjectXCandleRequestKey(authenticatedCacheScope, query),
     (sharedSignal) => botsApi.getCandles(query, { signal: sharedSignal }),
     { priority, signal },
   );
@@ -2854,7 +2854,7 @@ export function BotSignalChart({ bot, authenticatedCacheScope, activity, lastEva
     }, POLL_INTERVAL_MS);
 
     return () => window.clearInterval(intervalId);
-  }, [bot, loadCandles]);
+  }, [authenticatedCacheScope, bot, loadCandles]);
 
   useEffect(() => {
     if (!bot) {

--- a/frontend/src/pages/bot/BotSignalChart.tsx
+++ b/frontend/src/pages/bot/BotSignalChart.tsx
@@ -2234,16 +2234,8 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }, [livePrice, livePriceIsStale, livePricePoint?.isPartial]);
 
   useEffect(() => {
-    let active = true;
-    void loadCandles().finally(() => {
-      if (active) {
-        void loadLivePrice({ force: true });
-      }
-    });
-
-    return () => {
-      active = false;
-    };
+    void loadCandles();
+    void loadLivePrice({ force: true });
   }, [loadCandles, loadLivePrice, refreshToken]);
 
   useEffect(() => {

--- a/frontend/src/pages/bot/BotSignalChart.tsx
+++ b/frontend/src/pages/bot/BotSignalChart.tsx
@@ -31,6 +31,7 @@ import type { BotActivity, BotConfig, BotEvaluation, BotTimeframeUnit, ProjectXM
 import {
   buildBotCandleCacheKey,
   filterMarketCandlesForWindow,
+  invalidateLegacyBotCandleCache,
   mergeMarketCandles,
   readBotCandleCache,
   upsertMarketCandles,
@@ -112,6 +113,7 @@ import {
   LatestRequestCoordinator,
   getViewportRestoreRange,
   invalidateChartRequestLanes,
+  runChartContextLoadsInParallel,
   type ChartViewportMutation,
 } from "./botChartLifecycle";
 import { readBotChartThemeColors } from "./botChartTheme";
@@ -221,6 +223,8 @@ interface ChartHandles {
 
 interface BotSignalChartProps {
   bot: BotConfig | null;
+  /** Stable non-secret namespace for persisted per-user chart state. */
+  authenticatedCacheScope: string | null;
   activity: BotActivity | null;
   lastEvaluation: BotEvaluation | null;
   refreshToken: number;
@@ -272,7 +276,7 @@ interface LiquidityDragState {
   pointerId: number;
 }
 
-export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, onMarketData }: BotSignalChartProps) {
+export function BotSignalChart({ bot, authenticatedCacheScope, activity, lastEvaluation, refreshToken, onMarketData }: BotSignalChartProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartHandlesRef = useRef<ChartHandles | null>(null);
   const livePriceLineRef = useRef<IPriceLine | null>(null);
@@ -309,6 +313,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const candlesRef = useRef<ProjectXMarketCandle[]>([]);
   const liveCandleRef = useRef<ProjectXMarketCandle | null>(null);
   const repairedGapKeysRef = useRef<Set<string>>(new Set());
+  const automaticRepairLoadVersionRef = useRef(-1);
   const actionableEvaluationsRef = useRef<Map<number, BotEvaluation>>(new Map());
   const hasMoreHistoryRef = useRef(true);
   const marketSnapshotTimeoutRef = useRef<number | null>(null);
@@ -363,7 +368,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       timeframe_unit_number: chartTimeframe.unitNumber,
     };
   }, [bot, chartTimeframe]);
-  const chartViewportKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${selectedTimeframeId}`;
+  const chartViewportKey = `${authenticatedCacheScope ?? "scope-pending"}:${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${bot?.symbol ?? ""}:${selectedTimeframeId}`;
   const [marketDataContextKey, setMarketDataContextKey] = useState(chartViewportKey);
   const marketDataMatchesContext = marketDataContextKey === chartViewportKey;
 
@@ -521,17 +526,18 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   const livePriceIsStale =
     livePricePoint !== null &&
     (!Number.isFinite(livePriceObservedAtMs) || Date.now() - livePriceObservedAtMs > LIVE_PRICE_STALE_AFTER_MS);
-  const liquidityDragContextKey = `${bot?.id ?? "none"}:${bot?.contract_id ?? ""}:${selectedTimeframeId}`;
+  const liquidityDragContextKey = chartViewportKey;
   const drawingStorageScope = useMemo<BotDrawingStorageScope | null>(
     () =>
-      bot
+      bot && authenticatedCacheScope
         ? {
+            userScope: authenticatedCacheScope,
             botId: bot.id,
             contractId: bot.contract_id,
             timeframe: selectedTimeframeId,
           }
         : null,
-    [bot, selectedTimeframeId],
+    [authenticatedCacheScope, bot, selectedTimeframeId],
   );
   const drawingStorageScopeKey = drawingStorageScope ? buildBotDrawingStorageKey(drawingStorageScope) : null;
   const chartViewportKeyRef = useRef(chartViewportKey);
@@ -552,6 +558,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     [],
   );
   const [repairVersion, setRepairVersion] = useState(0);
+  const [canonicalLoadVersion, setCanonicalLoadVersion] = useState(0);
   const candleGaps = useMemo<CandleGap[]>(
     () => (chartConfig ? findCandleGaps(candles, chartConfig.timeframe_unit, chartConfig.timeframe_unit_number) : []),
     [candles, chartConfig],
@@ -637,10 +644,12 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     setLivePriceError(null);
     setLastLoadedAt(null);
     repairedGapKeysRef.current = new Set();
+    automaticRepairLoadVersionRef.current = -1;
     hasMoreHistoryRef.current = true;
     setHasMoreHistory(true);
     setServedFromCacheOnly(false);
     setRepairVersion(0);
+    setCanonicalLoadVersion(0);
     invalidateChartRequestLanes([
       candleRequestsRef.current,
       liveRequestsRef.current,
@@ -778,7 +787,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
 
   const loadCandles = useCallback(
     async ({ silent = false, forceRefresh = false }: LoadCandlesOptions = {}) => {
-      if (!chartConfig) {
+      if (!chartConfig || !authenticatedCacheScope) {
         candleRequestsRef.current.invalidate();
         setCandles([]);
         setLiveCandle(null);
@@ -808,15 +817,20 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       const timeoutId = window.setTimeout(() => request.controller.abort(), CANDLE_REQUEST_TIMEOUT_MS);
       requestTimeoutIdsRef.current.add(timeoutId);
       const queryWindow = buildBotChartQuery(chartConfig);
-      const cacheKey = buildBotCandleCacheKey({
+      const cacheKeyInput = {
+        userScope: authenticatedCacheScope,
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol,
         live: false,
         unit: chartConfig.timeframe_unit,
         unitNumber: chartConfig.timeframe_unit_number,
-      });
+      } as const;
+      invalidateLegacyBotCandleCache(cacheKeyInput);
+      const cacheKey = buildBotCandleCacheKey(cacheKeyInput);
       const cachedEntry = forceRefresh ? null : readBotCandleCache(cacheKey);
-      const cachedCandles = cachedEntry ? filterMarketCandlesForWindow(cachedEntry.candles, queryWindow) : [];
+      const cachedCandles = cachedEntry
+        ? filterCandlesForChartContext(filterMarketCandlesForWindow(cachedEntry.candles, queryWindow), chartConfig)
+        : [];
       const hydrateFromCache = shouldHydrateChartFromCache(cachedCandles.length, queryWindow.limit);
 
       if (cachedEntry && hydrateFromCache) {
@@ -841,7 +855,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       setError(null);
 
       try {
-        const rows = await botsApi.getCandles({
+        const fetchedRows = await botsApi.getCandles({
           contractId: chartConfig.contract_id,
           symbol: chartConfig.symbol ?? undefined,
           start: queryWindow.start,
@@ -856,6 +870,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         if (!candleRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
           return;
         }
+        const rows = filterCandlesForChartContext(fetchedRows, chartConfig);
         const mergedRows = forceRefresh ? rows : mergeMarketCandles(cachedCandles, rows, queryWindow.limit);
         // Keep older history the user already paged in; the fetch window only covers the recent range.
         // Rolled partials also remain until ProjectX returns their authoritative
@@ -864,6 +879,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         queueViewportRestore(forceRefresh ? "refresh" : "live", candlesRef.current, nextRows);
         setCandles(nextRows);
         candlesRef.current = nextRows;
+        setCanonicalLoadVersion((current) => current + 1);
         writeBotCandleCache(cacheKey, mergedRows, queryWindow.limit);
         setLastLoadedAt(new Date());
         setServedFromCacheOnly(false);
@@ -898,11 +914,11 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         }
       }
     },
-    [chartConfig, chartViewportKey, queueViewportRestore],
+    [authenticatedCacheScope, chartConfig, chartViewportKey, queueViewportRestore],
   );
 
   const loadLivePrice = useCallback(async ({ force = false }: LoadLivePriceOptions = {}) => {
-    if (!chartConfig) {
+    if (!chartConfig || !authenticatedCacheScope) {
       liveRequestsRef.current.invalidate();
       setLiveCandle(null);
       setStreamPrice(null);
@@ -920,7 +936,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     const queryWindow = buildBotLivePriceQuery(chartConfig);
 
     try {
-      const rows = await botsApi.getCandles({
+      const fetchedRows = await botsApi.getCandles({
         contractId: chartConfig.contract_id,
         symbol: chartConfig.symbol ?? undefined,
         start: queryWindow.start,
@@ -935,6 +951,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       if (!liveRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
+      const rows = filterCandlesForChartContext(fetchedRows, chartConfig);
 
       // Promote closed candles from the live window into the chart immediately so a
       // just-finished bar does not vanish until the next slow poll.
@@ -995,7 +1012,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       requestTimeoutIdsRef.current.delete(timeoutId);
       liveRequestsRef.current.finish(request);
     }
-  }, [chartConfig, chartViewportKey, queueViewportRestore]);
+  }, [authenticatedCacheScope, chartConfig, chartViewportKey, queueViewportRestore]);
 
   const loadOlderCandles = useCallback(async () => {
     const config = chartConfigRef.current;
@@ -1022,7 +1039,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     requestTimeoutIdsRef.current.add(timeoutId);
     setHistoryLoading(true);
     try {
-      const rows = await botsApi.getCandles({
+      const fetchedRows = await botsApi.getCandles({
         contractId: config.contract_id,
         symbol: config.symbol ?? undefined,
         start: queryWindow.start,
@@ -1036,6 +1053,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
       if (!historyRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
         return;
       }
+      const rows = filterCandlesForChartContext(fetchedRows, config);
 
       const earliestMs = Date.parse(earliest.timestamp);
       const olderRows = rows.filter((row) => {
@@ -1095,7 +1113,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
     try {
       const repairedRows: ProjectXMarketCandle[] = [];
       for (const window_ of windows) {
-        const rows = await botsApi.getCandles({
+        const fetchedRows = await botsApi.getCandles({
           contractId: config.contract_id,
           symbol: config.symbol ?? undefined,
           start: window_.start,
@@ -1110,6 +1128,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         if (!repairRequestsRef.current.accepts(request, chartViewportKeyRef.current)) {
           return;
         }
+        const rows = filterCandlesForChartContext(fetchedRows, config);
         if (rows.length > 0) {
           repairedRows.push(...rows);
         }
@@ -2234,17 +2253,33 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   }, [livePrice, livePriceIsStale, livePricePoint?.isPartial]);
 
   useEffect(() => {
-    let active = true;
-    void loadCandles().finally(() => {
-      if (active) {
-        void loadLivePrice({ force: true });
-      }
-    });
-
-    return () => {
-      active = false;
-    };
+    // These requests use independent latest-wins lanes and merge with
+    // closed-over-partial precedence, so starting them together gives a cached
+    // chart its live quote immediately instead of waiting for history refresh.
+    void runChartContextLoadsInParallel(
+      () => loadCandles(),
+      () => loadLivePrice({ force: true }),
+    );
   }, [loadCandles, loadLivePrice, refreshToken]);
+
+  useEffect(() => {
+    if (
+      canonicalLoadVersion <= 0 ||
+      automaticRepairLoadVersionRef.current === canonicalLoadVersion ||
+      unrepairedDataGaps.length === 0 ||
+      loading ||
+      refreshing ||
+      historyLoading ||
+      gapRepairing
+    ) {
+      return;
+    }
+
+    // One bounded automatic pass per canonical load. Further holes remain
+    // eligible on the next poll or through the explicit Backfill control.
+    automaticRepairLoadVersionRef.current = canonicalLoadVersion;
+    void repairDataGaps();
+  }, [canonicalLoadVersion, gapRepairing, historyLoading, loading, refreshing, repairDataGaps, unrepairedDataGaps.length]);
 
   useEffect(() => {
     const candleRequests = candleRequestsRef.current;
@@ -2287,7 +2322,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
   // Poll closed candles for any selected bot. Review of a stopped bot still
   // needs a fresh chart; the backend serves cached rows cheaply when fresh.
   useEffect(() => {
-    if (!bot) {
+    if (!bot || !authenticatedCacheScope) {
       return;
     }
 
@@ -2344,7 +2379,7 @@ export function BotSignalChart({ bot, activity, lastEvaluation, refreshToken, on
         liveStreamRenderTimeoutRef.current = null;
       }
     };
-  }, [bot, scheduleLiveStreamPrice]);
+  }, [authenticatedCacheScope, bot, scheduleLiveStreamPrice]);
 
   useEffect(() => {
     if (!bot) {
@@ -3059,6 +3094,27 @@ function marketCandlesShareTimestamp(left: ProjectXMarketCandle, right: ProjectX
   const leftMs = Date.parse(left.timestamp);
   const rightMs = Date.parse(right.timestamp);
   return Number.isFinite(leftMs) && leftMs === rightMs;
+}
+
+function filterCandlesForChartContext(
+  candles: readonly ProjectXMarketCandle[],
+  config: BotConfig,
+): ProjectXMarketCandle[] {
+  const contractId = config.contract_id.trim().toUpperCase();
+  const symbol = config.symbol?.trim().toUpperCase() ?? null;
+  return candles.filter((candle) => {
+    if (
+      candle.live ||
+      candle.unit !== config.timeframe_unit ||
+      candle.unit_number !== config.timeframe_unit_number
+    ) {
+      return false;
+    }
+    const candleSymbol = candle.symbol?.trim().toUpperCase() ?? null;
+    return symbol && candleSymbol
+      ? candleSymbol === symbol
+      : candle.contract_id.trim().toUpperCase() === contractId;
+  });
 }
 
 function hasClosedCandleAtTimestamp(candles: readonly ProjectXMarketCandle[], candidate: ProjectXMarketCandle): boolean {

--- a/frontend/src/pages/bot/botBacktest.test.ts
+++ b/frontend/src/pages/bot/botBacktest.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint } from "../../lib/types";
-import { buildBacktestChartPaths, validateBacktestForm, type BotBacktestFormState } from "./botBacktest";
+import {
+  BACKTEST_MAX_RENDERED_CHART_POINTS,
+  buildBacktestChartPaths,
+  validateBacktestForm,
+  type BotBacktestFormState,
+} from "./botBacktest";
 
 const validForm: BotBacktestFormState = {
   startDate: "2026-01-01",
@@ -52,5 +57,30 @@ describe("buildBacktestChartPaths", () => {
     expect(first.equityMin).toBe(50_000);
     expect(first.equityMax).toBe(50_100);
     expect(first.drawdownMax).toBe(2);
+  });
+
+  it("bounds SVG work for full-history results without discarding source counts or extrema", () => {
+    const pointCount = 100_000;
+    const equity = Array.from({ length: pointCount }, (_, index): BotBacktestEquityPoint => ({
+      timestamp: new Date(Date.UTC(2020, 0, 1, 0, index)).toISOString(),
+      equity: index === 54_321 ? 90_000 : 50_000 + (index % 100),
+      realized_pnl: 0,
+      unrealized_pnl: 0,
+    }));
+    const drawdown = equity.map((point, index): BotBacktestDrawdownPoint => ({
+      timestamp: point.timestamp,
+      equity: point.equity,
+      drawdown_dollars: index === 12_345 ? 5_000 : index % 50,
+      drawdown_percent: index === 12_345 ? 10 : (index % 50) / 10,
+    }));
+
+    const paths = buildBacktestChartPaths(equity, drawdown);
+
+    expect(paths.equitySourcePointCount).toBe(pointCount);
+    expect(paths.drawdownSourcePointCount).toBe(pointCount);
+    expect(paths.equityRenderedPointCount).toBeLessThanOrEqual(BACKTEST_MAX_RENDERED_CHART_POINTS);
+    expect(paths.drawdownRenderedPointCount).toBeLessThanOrEqual(BACKTEST_MAX_RENDERED_CHART_POINTS);
+    expect(paths.equityMax).toBe(90_000);
+    expect(paths.drawdownMax).toBe(10);
   });
 });

--- a/frontend/src/pages/bot/botBacktest.test.ts
+++ b/frontend/src/pages/bot/botBacktest.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from "vitest";
 
 import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint } from "../../lib/types";
-import { buildBacktestChartPaths, validateBacktestForm, type BotBacktestFormState } from "./botBacktest";
+import {
+  buildBacktestChartPaths,
+  buildBacktestPayload,
+  validateBacktestForm,
+  type BotBacktestFormState,
+} from "./botBacktest";
 
 const validForm: BotBacktestFormState = {
-  startDate: "2026-01-01",
-  endDate: "2026-01-31",
   startingBalance: "50000",
   commissionPerContract: "1.20",
   slippageTicks: "1",
 };
 
 describe("validateBacktestForm", () => {
-  it("accepts a bounded range and non-negative execution costs", () => {
+  it("accepts full-history execution settings", () => {
     expect(validateBacktestForm(validForm)).toBeNull();
   });
 
-  it("rejects reversed ranges and malformed numeric settings", () => {
-    expect(validateBacktestForm({ ...validForm, startDate: "2026-02-01" })).toBe(
-      "Start date must be on or before the end date.",
-    );
+  it("rejects malformed numeric settings", () => {
     expect(validateBacktestForm({ ...validForm, startingBalance: "0" })).toBe(
       "Starting balance must be greater than zero.",
     );
@@ -29,6 +29,21 @@ describe("validateBacktestForm", () => {
     expect(validateBacktestForm({ ...validForm, slippageTicks: "0.5" })).toBe(
       "Slippage must be a whole number of ticks, zero or greater.",
     );
+  });
+});
+
+describe("buildBacktestPayload", () => {
+  it("omits date bounds from the normal full-history request", () => {
+    const payload = buildBacktestPayload(validForm);
+
+    expect(payload).toEqual({
+      starting_balance: 50_000,
+      commission_per_contract: 1.2,
+      slippage_ticks: 1,
+      force_close_at_end: true,
+    });
+    expect(payload).not.toHaveProperty("start");
+    expect(payload).not.toHaveProperty("end");
   });
 });
 

--- a/frontend/src/pages/bot/botBacktest.ts
+++ b/frontend/src/pages/bot/botBacktest.ts
@@ -5,6 +5,7 @@ export const BACKTEST_EQUITY_TOP = 14;
 export const BACKTEST_EQUITY_HEIGHT = 132;
 export const BACKTEST_DRAWDOWN_TOP = 184;
 export const BACKTEST_DRAWDOWN_HEIGHT = 58;
+export const BACKTEST_MAX_RENDERED_CHART_POINTS = 2_000;
 
 export interface BotBacktestFormState {
   startDate: string;
@@ -21,6 +22,10 @@ export interface BotBacktestChartPaths {
   equityMin: number;
   equityMax: number;
   drawdownMax: number;
+  equitySourcePointCount: number;
+  equityRenderedPointCount: number;
+  drawdownSourcePointCount: number;
+  drawdownRenderedPointCount: number;
 }
 
 export function validateBacktestForm(form: BotBacktestFormState): string | null {
@@ -55,13 +60,17 @@ export function buildBacktestChartPaths(
   equity: BotBacktestEquityPoint[],
   drawdown: BotBacktestDrawdownPoint[],
 ): BotBacktestChartPaths {
-  const equityValues = equity.map((point) => point.equity).filter(Number.isFinite);
-  const drawdownValues = drawdown.map((point) => Math.abs(point.drawdown_percent)).filter(Number.isFinite);
-  const equityMin = equityValues.length > 0 ? Math.min(...equityValues) : 0;
-  const equityMax = equityValues.length > 0 ? Math.max(...equityValues) : 0;
-  const drawdownMax = drawdownValues.length > 0 ? Math.max(...drawdownValues) : 0;
-  const equityPath = linePath(equityValues, BACKTEST_EQUITY_TOP, BACKTEST_EQUITY_HEIGHT, equityMin, equityMax);
-  const drawdownPath = linePath(drawdownValues, BACKTEST_DRAWDOWN_TOP, BACKTEST_DRAWDOWN_HEIGHT, 0, drawdownMax, false);
+  const equityValues = toIndexedValues(equity.map((point) => point.equity));
+  const drawdownValues = toIndexedValues(drawdown.map((point) => Math.abs(point.drawdown_percent)));
+  const equityBounds = findBounds(equityValues);
+  const drawdownBounds = findBounds(drawdownValues);
+  const sampledEquity = sampleChartValues(equityValues, BACKTEST_MAX_RENDERED_CHART_POINTS);
+  const sampledDrawdown = sampleChartValues(drawdownValues, BACKTEST_MAX_RENDERED_CHART_POINTS);
+  const equityMin = equityBounds.min;
+  const equityMax = equityBounds.max;
+  const drawdownMax = drawdownBounds.max;
+  const equityPath = linePath(sampledEquity, equity.length, BACKTEST_EQUITY_TOP, BACKTEST_EQUITY_HEIGHT, equityMin, equityMax);
+  const drawdownPath = linePath(sampledDrawdown, drawdown.length, BACKTEST_DRAWDOWN_TOP, BACKTEST_DRAWDOWN_HEIGHT, 0, drawdownMax, false);
   return {
     equity: equityPath,
     equityFill: equityPath
@@ -71,18 +80,89 @@ export function buildBacktestChartPaths(
     equityMin,
     equityMax,
     drawdownMax,
+    equitySourcePointCount: equity.length,
+    equityRenderedPointCount: sampledEquity.length,
+    drawdownSourcePointCount: drawdown.length,
+    drawdownRenderedPointCount: sampledDrawdown.length,
   };
 }
 
-function linePath(values: number[], top: number, height: number, min: number, max: number, invert = true): string {
+interface IndexedChartValue {
+  index: number;
+  value: number;
+}
+
+function linePath(
+  values: IndexedChartValue[],
+  sourceLength: number,
+  top: number,
+  height: number,
+  min: number,
+  max: number,
+  invert = true,
+): string {
   if (values.length === 0) {
     return "";
   }
   const span = max - min || 1;
-  return values.map((value, index) => {
-    const x = values.length === 1 ? BACKTEST_CHART_WIDTH / 2 : (index / (values.length - 1)) * BACKTEST_CHART_WIDTH;
+  return values.map(({ index, value }) => {
+    const x = sourceLength <= 1 ? BACKTEST_CHART_WIDTH / 2 : (index / (sourceLength - 1)) * BACKTEST_CHART_WIDTH;
     const ratio = (value - min) / span;
     const y = top + (invert ? 1 - ratio : ratio) * height;
-    return `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    return `${index === values[0].index ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
   }).join(" ");
+}
+
+function toIndexedValues(values: number[]): IndexedChartValue[] {
+  const indexed: IndexedChartValue[] = [];
+  values.forEach((value, index) => {
+    if (Number.isFinite(value)) {
+      indexed.push({ index, value });
+    }
+  });
+  return indexed;
+}
+
+function findBounds(values: IndexedChartValue[]): { min: number; max: number } {
+  if (values.length === 0) {
+    return { min: 0, max: 0 };
+  }
+  let min = values[0].value;
+  let max = values[0].value;
+  for (let index = 1; index < values.length; index += 1) {
+    min = Math.min(min, values[index].value);
+    max = Math.max(max, values[index].value);
+  }
+  return { min, max };
+}
+
+/** Deterministic min/max bucket sampling keeps spikes while bounding SVG work. */
+function sampleChartValues(values: IndexedChartValue[], maxPoints: number): IndexedChartValue[] {
+  if (values.length <= maxPoints) {
+    return values;
+  }
+  const bucketCount = Math.max(1, Math.floor((maxPoints - 2) / 2));
+  const sampled: IndexedChartValue[] = [values[0]];
+  const interiorLength = values.length - 2;
+  for (let bucket = 0; bucket < bucketCount; bucket += 1) {
+    const start = 1 + Math.floor((bucket * interiorLength) / bucketCount);
+    const end = 1 + Math.floor(((bucket + 1) * interiorLength) / bucketCount);
+    if (start >= end) {
+      continue;
+    }
+    let min = values[start];
+    let max = values[start];
+    for (let index = start + 1; index < end; index += 1) {
+      if (values[index].value < min.value) min = values[index];
+      if (values[index].value > max.value) max = values[index];
+    }
+    if (min.index <= max.index) {
+      sampled.push(min);
+      if (max.index !== min.index) sampled.push(max);
+    } else {
+      sampled.push(max, min);
+    }
+  }
+  sampled.push(values[values.length - 1]);
+  return sampled;
 }

--- a/frontend/src/pages/bot/botBacktest.ts
+++ b/frontend/src/pages/bot/botBacktest.ts
@@ -1,4 +1,4 @@
-import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint } from "../../lib/types";
+import type { BotBacktestDrawdownPoint, BotBacktestEquityPoint, BotBacktestInput } from "../../lib/types";
 
 export const BACKTEST_CHART_WIDTH = 720;
 export const BACKTEST_EQUITY_TOP = 14;
@@ -7,8 +7,6 @@ export const BACKTEST_DRAWDOWN_TOP = 184;
 export const BACKTEST_DRAWDOWN_HEIGHT = 58;
 
 export interface BotBacktestFormState {
-  startDate: string;
-  endDate: string;
   startingBalance: string;
   commissionPerContract: string;
   slippageTicks: string;
@@ -24,18 +22,6 @@ export interface BotBacktestChartPaths {
 }
 
 export function validateBacktestForm(form: BotBacktestFormState): string | null {
-  if (!form.startDate || !form.endDate) {
-    return "Start and end dates are required.";
-  }
-  const start = Date.parse(`${form.startDate}T00:00:00.000Z`);
-  const end = Date.parse(`${form.endDate}T23:59:59.999Z`);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
-    return "Enter a valid date range.";
-  }
-  if (start > end) {
-    return "Start date must be on or before the end date.";
-  }
-
   const startingBalance = Number(form.startingBalance);
   if (!Number.isFinite(startingBalance) || startingBalance <= 0) {
     return "Starting balance must be greater than zero.";
@@ -49,6 +35,15 @@ export function validateBacktestForm(form: BotBacktestFormState): string | null 
     return "Slippage must be a whole number of ticks, zero or greater.";
   }
   return null;
+}
+
+export function buildBacktestPayload(form: BotBacktestFormState): BotBacktestInput {
+  return {
+    starting_balance: Number(form.startingBalance),
+    commission_per_contract: Number(form.commissionPerContract),
+    slippage_ticks: Number(form.slippageTicks),
+    force_close_at_end: true,
+  };
 }
 
 export function buildBacktestChartPaths(

--- a/frontend/src/pages/bot/botCandleCache.test.ts
+++ b/frontend/src/pages/bot/botCandleCache.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildBotCandleCacheKey, filterMarketCandlesForWindow, mergeMarketCandles, upsertMarketCandles } from "./botCandleCache";
+import {
+  buildBotCandleCacheKey,
+  filterMarketCandlesForWindow,
+  mergeMarketCandles,
+  readBotCandleCache,
+  resetBotCandleMemoryCacheForTests,
+  upsertMarketCandles,
+  writeBotCandleCache,
+} from "./botCandleCache";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
 function candle(timestamp: string, close: number, overrides: Partial<ProjectXMarketCandle> = {}): ProjectXMarketCandle {
@@ -23,6 +31,43 @@ function candle(timestamp: string, close: number, overrides: Partial<ProjectXMar
   };
 }
 
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+beforeEach(() => {
+  resetBotCandleMemoryCacheForTests();
+});
+
+afterEach(() => {
+  resetBotCandleMemoryCacheForTests();
+  vi.unstubAllGlobals();
+});
+
 describe("buildBotCandleCacheKey", () => {
   it("normalizes equivalent bot market inputs to the same key", () => {
     expect(
@@ -42,6 +87,93 @@ describe("buildBotCandleCacheKey", () => {
         unitNumber: 5,
       }),
     );
+  });
+
+  it("isolates timeframe/cache-key switching", () => {
+    const minuteKey = buildBotCandleCacheKey({
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 1,
+    });
+    const fiveMinuteKey = buildBotCandleCacheKey({
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 5,
+    });
+
+    writeBotCandleCache(minuteKey, [candle("2026-06-25T14:00:00Z", 101)], 300);
+    writeBotCandleCache(fiveMinuteKey, [candle("2026-06-25T14:05:00Z", 105)], 300);
+
+    expect(minuteKey).not.toBe(fiveMinuteKey);
+    expect(readBotCandleCache(minuteKey)?.candles[0].close).toBe(101);
+    expect(readBotCandleCache(fiveMinuteKey)?.candles[0].close).toBe(105);
+  });
+});
+
+describe("cache persistence", () => {
+  it("uses even a single valid cached candle and persists coverage metadata", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:test";
+    const savedAt = new Date("2026-06-25T14:06:00Z");
+
+    writeBotCandleCache(
+      key,
+      [
+        candle("2026-06-25T14:00:00Z", 101),
+        candle("2026-06-25T14:05:00Z", 102, { is_partial: true }),
+      ],
+      300,
+      {
+        savedAt,
+        coverage: {
+          start: "2026-06-25T13:00:00Z",
+          end: "2026-06-25T14:06:00Z",
+        },
+      },
+    );
+
+    resetBotCandleMemoryCacheForTests();
+    const entry = readBotCandleCache(key);
+    expect(entry?.candles).toHaveLength(1);
+    expect(entry?.candles[0].is_partial).toBe(false);
+    expect(entry?.savedAt?.toISOString()).toBe(savedAt.toISOString());
+    expect(entry?.coverage).toEqual({
+      start: "2026-06-25T13:00:00.000Z",
+      end: "2026-06-25T14:06:00.000Z",
+    });
+  });
+
+  it("reads legacy v1 payloads without coverage", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:legacy";
+    storage.setItem(
+      key,
+      JSON.stringify({
+        savedAt: "2026-06-25T14:06:00Z",
+        candles: [candle("2026-06-25T14:00:00Z", 101)],
+      }),
+    );
+
+    expect(readBotCandleCache(key)).toMatchObject({
+      coverage: null,
+      candles: [{ close: 101 }],
+    });
+  });
+
+  it("serves repeated reads from memory before localStorage", () => {
+    const storage = new MemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    const key = "topsignal:bot-candles:v1:memory";
+    writeBotCandleCache(key, [candle("2026-06-25T14:00:00Z", 101)], 300);
+    storage.setItem(key, "not-json");
+
+    expect(readBotCandleCache(key)?.candles[0].close).toBe(101);
   });
 });
 
@@ -84,6 +216,20 @@ describe("mergeMarketCandles", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toBe(closed);
+  });
+
+  it("returns the existing array identity for a semantic no-op merge", () => {
+    const existing = [
+      candle("2026-04-26T13:35:00Z", 100),
+      candle("2026-04-26T13:40:00Z", 101),
+    ];
+    const equivalentTail = candle("2026-04-26T13:40:00.000Z", 101, {
+      id: 42,
+      fetched_at: "2026-04-26T13:45:02Z",
+    });
+
+    expect(mergeMarketCandles(existing, [equivalentTail], 300)).toBe(existing);
+    expect(upsertMarketCandles(existing, [equivalentTail], 300)).toBe(existing);
   });
 });
 

--- a/frontend/src/pages/bot/botCandleCache.test.ts
+++ b/frontend/src/pages/bot/botCandleCache.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildBotCandleCacheKey, filterMarketCandlesForWindow, mergeMarketCandles, upsertMarketCandles } from "./botCandleCache";
+import {
+  buildBotCandleCacheKey,
+  filterMarketCandlesForWindow,
+  invalidateLegacyBotCandleCache,
+  mergeMarketCandles,
+  upsertMarketCandles,
+  type BotCandleCacheKeyInput,
+} from "./botCandleCache";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
 function candle(timestamp: string, close: number, overrides: Partial<ProjectXMarketCandle> = {}): ProjectXMarketCandle {
@@ -24,9 +31,12 @@ function candle(timestamp: string, close: number, overrides: Partial<ProjectXMar
 }
 
 describe("buildBotCandleCacheKey", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("normalizes equivalent bot market inputs to the same key", () => {
     expect(
       buildBotCandleCacheKey({
+        userScope: "user:one",
         contractId: " con.f.us.mnq.m26 ",
         symbol: " mnq ",
         live: false,
@@ -35,6 +45,7 @@ describe("buildBotCandleCacheKey", () => {
       }),
     ).toBe(
       buildBotCandleCacheKey({
+        userScope: "user:one",
         contractId: "CON.F.US.MNQ.M26",
         symbol: "MNQ",
         live: false,
@@ -42,6 +53,40 @@ describe("buildBotCandleCacheKey", () => {
         unitNumber: 5,
       }),
     );
+  });
+
+  it("isolates persisted candles by authenticated user", () => {
+    const input: BotCandleCacheKeyInput = {
+      userScope: "user:one",
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 5,
+    };
+
+    expect(buildBotCandleCacheKey({ ...input, userScope: "user:two" })).not.toBe(buildBotCandleCacheKey(input));
+    expect(buildBotCandleCacheKey(input)).toContain("topsignal:bot-candles:v2:");
+  });
+
+  it("deletes the unscoped v1 entry instead of assigning it to the current user", () => {
+    const removed: string[] = [];
+    vi.stubGlobal("window", {
+      localStorage: {
+        removeItem: (key: string) => removed.push(key),
+      },
+    });
+
+    invalidateLegacyBotCandleCache({
+      userScope: "user:one",
+      contractId: "CON.F.US.MNQ.M26",
+      symbol: "MNQ",
+      live: false,
+      unit: "minute",
+      unitNumber: 5,
+    });
+
+    expect(removed).toEqual(["topsignal:bot-candles:v1:practice%7CCON.F.US.MNQ.M26%7CMNQ%7Cminute%7C5"]);
   });
 });
 

--- a/frontend/src/pages/bot/botCandleCache.ts
+++ b/frontend/src/pages/bot/botCandleCache.ts
@@ -13,9 +13,13 @@ interface BotCandleCacheKeyInput {
 interface BotCandleCachePayload {
   savedAt: string;
   candles: ProjectXMarketCandle[];
+  /** Optional v1 extension. Old payloads without coverage remain readable. */
+  coverageStart?: string;
+  /** Optional v1 extension. Old payloads without coverage remain readable. */
+  coverageEnd?: string;
 }
 
-interface CandleQueryWindow {
+export interface CandleQueryWindow {
   start: string;
   end: string;
 }
@@ -23,7 +27,26 @@ interface CandleQueryWindow {
 export interface BotCandleCacheEntry {
   savedAt: Date | null;
   candles: ProjectXMarketCandle[];
+  /** The query range known to have been checked, including session-empty ranges. */
+  coverage: CandleQueryWindow | null;
 }
+
+export interface BotCandleCacheWriteMetadata {
+  /** Defaults to the current time. Supplying it keeps tests and warmers deterministic. */
+  savedAt?: Date;
+  /** Request coverage is more accurate than deriving coverage from the first/last row. */
+  coverage?: CandleQueryWindow | null;
+}
+
+/**
+ * The hot read path stays entirely in memory after the first localStorage read.
+ * Entries are scoped by the already contract+environment+timeframe-specific key.
+ */
+const memoryCache = new Map<string, BotCandleCacheEntry>();
+const canonicalMetadataByArray = new WeakMap<
+  ProjectXMarketCandle[],
+  { timestamps: number[]; hasPartial: boolean }
+>();
 
 export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
   const parts = [
@@ -37,6 +60,11 @@ export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
 }
 
 export function readBotCandleCache(cacheKey: string): BotCandleCacheEntry | null {
+  const inMemory = memoryCache.get(cacheKey);
+  if (inMemory) {
+    return inMemory;
+  }
+
   const storage = getLocalStorage();
   if (!storage) {
     return null;
@@ -51,52 +79,78 @@ export function readBotCandleCache(cacheKey: string): BotCandleCacheEntry | null
     if (!Array.isArray(parsed.candles)) {
       return null;
     }
-    const candles = selectMarketCandles(parsed.candles, false);
+    const candles = canonicalizeMarketCandles(parsed.candles, false).rows;
     if (candles.length === 0) {
       return null;
     }
-    const savedAtMs = typeof parsed.savedAt === "string" ? Date.parse(parsed.savedAt) : Number.NaN;
-    return {
-      savedAt: Number.isFinite(savedAtMs) ? new Date(savedAtMs) : null,
+    const savedAt = parseDate(parsed.savedAt);
+    const entry: BotCandleCacheEntry = {
+      savedAt,
       candles,
+      coverage: parseCoverage(parsed.coverageStart, parsed.coverageEnd),
     };
+    memoryCache.set(cacheKey, entry);
+    return entry;
   } catch {
     storage.removeItem(cacheKey);
     return null;
   }
 }
 
-export function writeBotCandleCache(cacheKey: string, candles: ProjectXMarketCandle[], limit: number): void {
+export function writeBotCandleCache(
+  cacheKey: string,
+  candles: ProjectXMarketCandle[],
+  limit: number,
+  metadata: BotCandleCacheWriteMetadata = {},
+): void {
+  const rows = trimCandlesForCache(candles, limit);
   const storage = getLocalStorage();
+  if (rows.length === 0) {
+    memoryCache.delete(cacheKey);
+    storage?.removeItem(cacheKey);
+    return;
+  }
+
+  const savedAt = validDateOrNow(metadata.savedAt);
+  const coverage = normalizeCoverage(metadata.coverage);
+  const entry: BotCandleCacheEntry = { savedAt, candles: rows, coverage };
+  memoryCache.set(cacheKey, entry);
+
   if (!storage) {
     return;
   }
 
-  const rows = trimCandlesForCache(candles, limit);
-  if (rows.length === 0) {
-    storage.removeItem(cacheKey);
-    return;
-  }
-
+  const payload: BotCandleCachePayload = {
+    savedAt: savedAt.toISOString(),
+    candles: rows,
+    ...(coverage ? { coverageStart: coverage.start, coverageEnd: coverage.end } : {}),
+  };
   try {
-    storage.setItem(
-      cacheKey,
-      JSON.stringify({
-        savedAt: new Date().toISOString(),
-        candles: rows,
-      } satisfies BotCandleCachePayload),
-    );
+    storage.setItem(cacheKey, JSON.stringify(payload));
   } catch {
-    // localStorage may be full or disabled; the network path still works.
+    // localStorage may be full or disabled; the memory/network paths still work.
   }
 }
 
+/**
+ * Clear only the process-local layer. Exported so tests can verify persisted-v1
+ * fallback without coupling production code to a browser storage event.
+ */
+export function resetBotCandleMemoryCacheForTests(): void {
+  memoryCache.clear();
+}
+
+/**
+ * Merge closed candles for persistence. Canonical inputs use a tail-aware
+ * linear merge and retain existing row references. Partial rows are never
+ * persisted, and a no-op returns `existingCandles` itself when it is canonical.
+ */
 export function mergeMarketCandles(
   existingCandles: ProjectXMarketCandle[],
   incomingCandles: ProjectXMarketCandle[],
   limit: number,
 ): ProjectXMarketCandle[] {
-  return trimCandlesForCache([...existingCandles, ...incomingCandles], limit);
+  return mergeCanonicalMarketCandles(existingCandles, incomingCandles, false, Math.max(1, Math.trunc(limit)));
 }
 
 export function filterMarketCandlesForWindow(
@@ -109,11 +163,13 @@ export function filterMarketCandlesForWindow(
     return [];
   }
 
-  return selectMarketCandles(candles, true)
-    .filter((candle) => {
-      const timestampMs = Date.parse(candle.timestamp);
-      return timestampMs >= startMs && timestampMs <= endMs;
-    });
+  const canonical = canonicalizeMarketCandles(candles, true);
+  const fromIndex = lowerBound(canonical.timestamps, startMs);
+  const toIndex = upperBound(canonical.timestamps, endMs);
+  if (canonical.reusedInput && fromIndex === 0 && toIndex === candles.length) {
+    return candles;
+  }
+  return canonical.rows.slice(fromIndex, toIndex);
 }
 
 /**
@@ -127,30 +183,74 @@ export function upsertMarketCandles(
   incomingCandles: ProjectXMarketCandle[],
   limit?: number,
 ): ProjectXMarketCandle[] {
-  const sorted = selectMarketCandles([...existingCandles, ...incomingCandles], true);
-  if (limit === undefined) {
-    return sorted;
-  }
-  return sorted.slice(-Math.max(1, Math.trunc(limit)));
+  const boundedLimit = limit === undefined ? Number.POSITIVE_INFINITY : Math.max(1, Math.trunc(limit));
+  return mergeCanonicalMarketCandles(existingCandles, incomingCandles, true, boundedLimit);
 }
 
 function trimCandlesForCache(candles: ProjectXMarketCandle[], limit: number): ProjectXMarketCandle[] {
   const boundedLimit = Math.max(1, Math.trunc(limit));
-  return selectMarketCandles(candles, false).slice(-boundedLimit);
+  const canonical = canonicalizeMarketCandles(candles, false);
+  if (canonical.rows.length <= boundedLimit) {
+    return canonical.rows;
+  }
+  return canonical.rows.slice(-boundedLimit);
+}
+
+interface CanonicalCandles {
+  rows: ProjectXMarketCandle[];
+  timestamps: number[];
+  reusedInput: boolean;
 }
 
 /**
- * Select one canonical row per instant without altering its provider OHLC.
- * Closed rows always outrank partial rows, regardless of array order or ISO
- * timestamp spelling; rows with equal completion state retain last-write-wins.
+ * Validate and canonicalize only when necessary. The overwhelmingly common
+ * API/cache arrays are already sorted and unique, so they skip Map allocation
+ * and sorting entirely.
  */
-function selectMarketCandles(candles: unknown[], includePartial: boolean): ProjectXMarketCandle[] {
+function canonicalizeMarketCandles(candles: unknown[], includePartial: boolean): CanonicalCandles {
+  const knownMetadata = canonicalMetadataByArray.get(candles as ProjectXMarketCandle[]);
+  if (knownMetadata && (includePartial || !knownMetadata.hasPartial)) {
+    return {
+      rows: candles as ProjectXMarketCandle[],
+      timestamps: knownMetadata.timestamps,
+      reusedInput: true,
+    };
+  }
+
+  const timestamps: number[] = [];
+  let previousTimestamp = Number.NEGATIVE_INFINITY;
+  let alreadyCanonical = true;
+  let hasPartial = false;
+
+  for (const value of candles) {
+    if (!isCachedMarketCandle(value) || (!includePartial && value.is_partial)) {
+      alreadyCanonical = false;
+      break;
+    }
+    hasPartial ||= value.is_partial;
+    const timestampMs = Date.parse(value.timestamp);
+    if (timestampMs <= previousTimestamp) {
+      alreadyCanonical = false;
+      break;
+    }
+    timestamps.push(timestampMs);
+    previousTimestamp = timestampMs;
+  }
+
+  if (alreadyCanonical) {
+    canonicalMetadataByArray.set(candles as ProjectXMarketCandle[], { timestamps, hasPartial });
+    return {
+      rows: candles as ProjectXMarketCandle[],
+      timestamps,
+      reusedInput: true,
+    };
+  }
+
   const byTimestamp = new Map<number, ProjectXMarketCandle>();
   for (const value of candles) {
     if (!isCachedMarketCandle(value) || (!includePartial && value.is_partial)) {
       continue;
     }
-
     const timestampMs = Date.parse(value.timestamp);
     const existing = byTimestamp.get(timestampMs);
     if (existing && !existing.is_partial && value.is_partial) {
@@ -159,9 +259,179 @@ function selectMarketCandles(candles: unknown[], includePartial: boolean): Proje
     byTimestamp.set(timestampMs, value);
   }
 
-  return Array.from(byTimestamp.entries())
-    .sort(([leftTimestamp], [rightTimestamp]) => leftTimestamp - rightTimestamp)
-    .map(([, candle]) => candle);
+  const entries = Array.from(byTimestamp.entries()).sort(
+    ([leftTimestamp], [rightTimestamp]) => leftTimestamp - rightTimestamp,
+  );
+  const rows = entries.map(([, candle]) => candle);
+  const sortedTimestamps = entries.map(([timestamp]) => timestamp);
+  canonicalMetadataByArray.set(rows, {
+    timestamps: sortedTimestamps,
+    hasPartial: rows.some((candle) => candle.is_partial),
+  });
+  return {
+    rows,
+    timestamps: sortedTimestamps,
+    reusedInput: false,
+  };
+}
+
+function mergeCanonicalMarketCandles(
+  existingInput: ProjectXMarketCandle[],
+  incomingInput: ProjectXMarketCandle[],
+  includePartial: boolean,
+  limit: number,
+): ProjectXMarketCandle[] {
+  const existing = canonicalizeMarketCandles(existingInput, includePartial);
+  const incoming = canonicalizeMarketCandles(incomingInput, includePartial);
+
+  if (existingInput === incomingInput && existing.reusedInput && existing.rows.length <= limit) {
+    return existingInput;
+  }
+
+  if (incoming.rows.length === 0) {
+    if (existing.rows.length <= limit) {
+      return existing.reusedInput ? existingInput : existing.rows;
+    }
+    return existing.rows.slice(-limit);
+  }
+  if (existing.rows.length === 0) {
+    if (incoming.rows.length <= limit) {
+      return incoming.rows;
+    }
+    return incoming.rows.slice(-limit);
+  }
+
+  const incomingFirstTimestamp = incoming.timestamps[0];
+  const existingLastIndex = existing.rows.length - 1;
+  const existingLastTimestamp = existing.timestamps[existingLastIndex];
+  if (incoming.rows.length === 1 && incomingFirstTimestamp === existingLastTimestamp) {
+    const existingLast = existing.rows[existingLastIndex];
+    const incomingLast = incoming.rows[0];
+    if (
+      (!existingLast.is_partial && incomingLast.is_partial) ||
+      marketCandlesSemanticallyEqual(existingLast, incomingLast)
+    ) {
+      return existing.rows.length <= limit && existing.reusedInput
+        ? existingInput
+        : existing.rows.slice(-limit);
+    }
+  }
+  if (incomingFirstTimestamp > existingLastTimestamp) {
+    const appended = [...existing.rows, ...incoming.rows];
+    const bounded = appended.length <= limit ? appended : appended.slice(-limit);
+    canonicalMetadataByArray.set(bounded, {
+      timestamps:
+        appended.length <= limit
+          ? [...existing.timestamps, ...incoming.timestamps]
+          : [...existing.timestamps, ...incoming.timestamps].slice(-limit),
+      hasPartial: bounded.some((candle) => candle.is_partial),
+    });
+    return bounded;
+  }
+
+  // Incoming polling data normally overlaps only the tail. Keep the older
+  // prefix without walking it, then linearly merge just the overlapping suffix.
+  const mergeFrom = lowerBound(existing.timestamps, incoming.timestamps[0]);
+  const merged = existing.rows.slice(0, mergeFrom);
+  let existingIndex = mergeFrom;
+  let incomingIndex = 0;
+  let changed = false;
+
+  while (existingIndex < existing.rows.length && incomingIndex < incoming.rows.length) {
+    const existingTimestamp = existing.timestamps[existingIndex];
+    const incomingTimestamp = incoming.timestamps[incomingIndex];
+    if (existingTimestamp < incomingTimestamp) {
+      merged.push(existing.rows[existingIndex]);
+      existingIndex += 1;
+      continue;
+    }
+    if (incomingTimestamp < existingTimestamp) {
+      merged.push(incoming.rows[incomingIndex]);
+      changed = true;
+      incomingIndex += 1;
+      continue;
+    }
+
+    const existingRow = existing.rows[existingIndex];
+    const incomingRow = incoming.rows[incomingIndex];
+    if (!existingRow.is_partial && incomingRow.is_partial) {
+      merged.push(existingRow);
+    } else if (marketCandlesSemanticallyEqual(existingRow, incomingRow)) {
+      // Retaining the existing object makes a semantically unchanged poll a
+      // complete array identity no-op after the comparison below.
+      merged.push(existingRow);
+    } else {
+      merged.push(incomingRow);
+      changed = true;
+    }
+    existingIndex += 1;
+    incomingIndex += 1;
+  }
+
+  while (existingIndex < existing.rows.length) {
+    merged.push(existing.rows[existingIndex]);
+    existingIndex += 1;
+  }
+  while (incomingIndex < incoming.rows.length) {
+    merged.push(incoming.rows[incomingIndex]);
+    changed = true;
+    incomingIndex += 1;
+  }
+
+  const bounded = merged.length <= limit ? merged : merged.slice(-limit);
+  if (existing.reusedInput && !changed && existing.rows.length <= limit) {
+    return existingInput;
+  }
+  canonicalMetadataByArray.set(bounded, {
+    timestamps: bounded.map((candle) => Date.parse(candle.timestamp)),
+    hasPartial: bounded.some((candle) => candle.is_partial),
+  });
+  return bounded;
+}
+
+function marketCandlesSemanticallyEqual(left: ProjectXMarketCandle, right: ProjectXMarketCandle): boolean {
+  return (
+    Date.parse(left.timestamp) === Date.parse(right.timestamp) &&
+    left.contract_id === right.contract_id &&
+    left.symbol === right.symbol &&
+    left.live === right.live &&
+    left.unit === right.unit &&
+    left.unit_number === right.unit_number &&
+    left.open === right.open &&
+    left.high === right.high &&
+    left.low === right.low &&
+    left.close === right.close &&
+    left.volume === right.volume &&
+    left.is_partial === right.is_partial
+  );
+}
+
+function lowerBound(values: readonly number[], target: number): number {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const midpoint = (low + high) >>> 1;
+    if (values[midpoint] < target) {
+      low = midpoint + 1;
+    } else {
+      high = midpoint;
+    }
+  }
+  return low;
+}
+
+function upperBound(values: readonly number[], target: number): number {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const midpoint = (low + high) >>> 1;
+    if (values[midpoint] <= target) {
+      low = midpoint + 1;
+    } else {
+      high = midpoint;
+    }
+  }
+  return low;
 }
 
 function isCachedMarketCandle(value: unknown): value is ProjectXMarketCandle {
@@ -180,6 +450,40 @@ function isCachedMarketCandle(value: unknown): value is ProjectXMarketCandle {
     typeof candle.volume === "number" && Number.isFinite(candle.volume) &&
     typeof candle.is_partial === "boolean"
   );
+}
+
+function parseCoverage(start: unknown, end: unknown): CandleQueryWindow | null {
+  if (typeof start !== "string" || typeof end !== "string") {
+    return null;
+  }
+  return normalizeCoverage({ start, end });
+}
+
+function normalizeCoverage(coverage: CandleQueryWindow | null | undefined): CandleQueryWindow | null {
+  if (!coverage) {
+    return null;
+  }
+  const startMs = Date.parse(coverage.start);
+  const endMs = Date.parse(coverage.end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs > endMs) {
+    return null;
+  }
+  return {
+    start: new Date(startMs).toISOString(),
+    end: new Date(endMs).toISOString(),
+  };
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs) : null;
+}
+
+function validDateOrNow(value: Date | undefined): Date {
+  return value && Number.isFinite(value.getTime()) ? new Date(value.getTime()) : new Date();
 }
 
 function getLocalStorage(): Storage | null {

--- a/frontend/src/pages/bot/botCandleCache.ts
+++ b/frontend/src/pages/bot/botCandleCache.ts
@@ -1,8 +1,11 @@
 import type { BotTimeframeUnit, ProjectXMarketCandle } from "../../lib/types";
 
-const STORAGE_KEY_PREFIX = "topsignal:bot-candles:v1:";
+const STORAGE_KEY_PREFIX = "topsignal:bot-candles:v2:";
+const LEGACY_STORAGE_KEY_PREFIX = "topsignal:bot-candles:v1:";
 
-interface BotCandleCacheKeyInput {
+export interface BotCandleCacheKeyInput {
+  /** Stable non-secret authenticated-user namespace. */
+  userScope: string;
   contractId: string;
   symbol?: string | null;
   live: boolean;
@@ -27,6 +30,7 @@ export interface BotCandleCacheEntry {
 
 export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
   const parts = [
+    input.userScope.trim(),
     input.live ? "live" : "practice",
     input.contractId.trim().toUpperCase(),
     (input.symbol ?? "").trim().toUpperCase(),
@@ -34,6 +38,19 @@ export function buildBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
     String(Math.max(1, Math.trunc(input.unitNumber))),
   ];
   return `${STORAGE_KEY_PREFIX}${encodeURIComponent(parts.join("|"))}`;
+}
+
+/** Remove v1 entries rather than assigning their unknown owner to this user. */
+export function invalidateLegacyBotCandleCache(input: BotCandleCacheKeyInput): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(buildLegacyBotCandleCacheKey(input));
+  } catch {
+    // localStorage may be blocked; the scoped network path still works.
+  }
 }
 
 export function readBotCandleCache(cacheKey: string): BotCandleCacheEntry | null {
@@ -191,4 +208,15 @@ function getLocalStorage(): Storage | null {
   } catch {
     return null;
   }
+}
+
+function buildLegacyBotCandleCacheKey(input: BotCandleCacheKeyInput): string {
+  const parts = [
+    input.live ? "live" : "practice",
+    input.contractId.trim().toUpperCase(),
+    (input.symbol ?? "").trim().toUpperCase(),
+    input.unit,
+    String(Math.max(1, Math.trunc(input.unitNumber))),
+  ];
+  return `${LEGACY_STORAGE_KEY_PREFIX}${encodeURIComponent(parts.join("|"))}`;
 }

--- a/frontend/src/pages/bot/botCandleGaps.test.ts
+++ b/frontend/src/pages/bot/botCandleGaps.test.ts
@@ -6,6 +6,7 @@ import {
   findCandleGaps,
   isGapCoveredByRepairWindows,
   isFuturesSessionOpen,
+  type CandleGap,
 } from "./botCandleGaps";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
@@ -197,6 +198,25 @@ describe("findCandleGaps", () => {
 });
 
 describe("buildGapRepairWindows", () => {
+  it("plans zero closure repairs and exactly one request per bounded data-gap window", () => {
+    const base = Date.parse("2026-06-09T13:00:00Z");
+    const gap = (index: number, kind: CandleGap["kind"]): CandleGap => ({
+      kind,
+      fromMs: base + index * 2 * 60 * 60_000,
+      toMs: base + index * 2 * 60 * 60_000 + 10 * 60_000,
+      missingBars: 2,
+      missingSessionBars: kind === "data" ? 2 : 0,
+      beforeTimestamp: new Date(base + index * 2 * 60 * 60_000 - 5 * 60_000).toISOString(),
+      afterTimestamp: new Date(base + index * 2 * 60 * 60_000 + 10 * 60_000).toISOString(),
+    });
+
+    expect(buildGapRepairWindows([gap(0, "session"), gap(1, "session")], "minute", 5, 3)).toHaveLength(0);
+    expect(
+      buildGapRepairWindows([gap(0, "data"), gap(1, "data"), gap(2, "data"), gap(3, "data")], "minute", 5, 3),
+    ).toHaveLength(3);
+    expect(buildGapRepairWindows([gap(0, "data")], "minute", 5, 0)).toHaveLength(0);
+  });
+
   it("builds padded windows for data gaps only and merges overlapping ranges", () => {
     const gaps = findCandleGaps(
       [

--- a/frontend/src/pages/bot/botCandleGaps.test.ts
+++ b/frontend/src/pages/bot/botCandleGaps.test.ts
@@ -51,6 +51,21 @@ describe("isFuturesSessionOpen", () => {
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T21:55:00Z"))).toBe(false); // Sun 17:55 ET
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T22:00:00Z"))).toBe(true); // Sun 18:00 ET
   });
+
+  it("applies the equity-index daily halt only to recognized equity products", () => {
+    const halt = Date.parse("2026-07-06T20:15:00Z"); // Mon 16:15 ET
+    expect(isFuturesSessionOpen(halt, "CON.F.US.MNQ.U26")).toBe(false);
+    expect(isFuturesSessionOpen(halt, "UNKNOWN")).toBe(true);
+    expect(isFuturesSessionOpen(Date.parse("2026-07-06T20:30:00Z"), "MNQ")).toBe(true);
+  });
+
+  it("applies recurring equity-index holiday closes", () => {
+    expect(isFuturesSessionOpen(Date.parse("2026-04-03T13:14:00Z"), "MNQ")).toBe(true);
+    expect(isFuturesSessionOpen(Date.parse("2026-04-03T13:15:00Z"), "MNQ")).toBe(false);
+    expect(isFuturesSessionOpen(Date.parse("2026-07-03T16:55:00Z"), "MNQ")).toBe(true);
+    expect(isFuturesSessionOpen(Date.parse("2026-07-03T17:00:00Z"), "MNQ")).toBe(false);
+    expect(isFuturesSessionOpen(Date.parse("2026-07-03T17:00:00Z"), "UNKNOWN")).toBe(true);
+  });
 });
 
 describe("planBotCandleFetches", () => {
@@ -278,6 +293,18 @@ describe("findCandleGaps", () => {
     expect(gaps[0].missingSessionBars).toBe(0);
   });
 
+  it("classifies an equity holiday early close through the weekend as a session gap", () => {
+    const gaps = findCandleGaps(
+      [candle("2026-07-03T16:55:00Z"), candle("2026-07-05T22:00:00Z")],
+      "minute",
+      5,
+    );
+
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].kind).toBe("session");
+    expect(gaps[0].missingSessionBars).toBe(0);
+  });
+
   it("classifies a gap spanning closure plus trading hours as a data gap", () => {
     // Fri 16:50 ET -> Mon 10:00 ET: the Sunday evening + Monday morning buckets are in session.
     const gaps = findCandleGaps(
@@ -314,6 +341,21 @@ describe("findCandleGaps", () => {
     );
     expect(midweek).toHaveLength(1);
     expect(midweek[0].kind).toBe("data");
+  });
+
+  it("treats a full equity holiday plus its weekend as a daily session gap", () => {
+    const gaps = findCandleGaps(
+      [
+        candle("2026-12-24T00:00:00Z", { unit: "day", unit_number: 1 }),
+        candle("2026-12-28T00:00:00Z", { unit: "day", unit_number: 1 }),
+      ],
+      "day",
+      1,
+    );
+
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].kind).toBe("session");
+    expect(gaps[0].missingSessionBars).toBe(0);
   });
 
   it("skips week and month units", () => {

--- a/frontend/src/pages/bot/botCandleGaps.test.ts
+++ b/frontend/src/pages/bot/botCandleGaps.test.ts
@@ -6,6 +6,7 @@ import {
   findCandleGaps,
   isGapCoveredByRepairWindows,
   isFuturesSessionOpen,
+  planBotCandleFetches,
 } from "./botCandleGaps";
 import type { ProjectXMarketCandle } from "../../lib/types";
 
@@ -48,6 +49,179 @@ describe("isFuturesSessionOpen", () => {
     expect(isFuturesSessionOpen(Date.parse("2026-06-06T15:00:00Z"))).toBe(false); // Saturday
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T21:55:00Z"))).toBe(false); // Sun 17:55 ET
     expect(isFuturesSessionOpen(Date.parse("2026-06-07T22:00:00Z"))).toBe(true); // Sun 18:00 ET
+  });
+});
+
+describe("planBotCandleFetches", () => {
+  const targetWindow = {
+    start: "2026-06-09T11:00:00Z",
+    end: "2026-06-09T14:30:00Z",
+    limit: 600,
+  };
+  const initialWindow = {
+    start: "2026-06-09T13:00:00Z",
+    end: "2026-06-09T14:30:00Z",
+    limit: 300,
+  };
+
+  it("plans a cold load as a 300-bar foreground fetch before older history", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: null,
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("cold");
+    expect(plan.cacheUsable).toBe(false);
+    expect(plan.foreground).toEqual([
+      {
+        reason: "cold",
+        priority: "foreground",
+        window: {
+          start: "2026-06-09T13:00:00.000Z",
+          end: "2026-06-09T14:30:00.000Z",
+        },
+        limit: 300,
+        repair: false,
+      },
+    ]);
+    expect(plan.background[0]).toMatchObject({
+      reason: "missing-history",
+      priority: "background",
+      repair: false,
+    });
+    expect(plan.requests.map((request) => request.priority)).toEqual(["foreground", "background"]);
+  });
+
+  it("plans a warm load with fresh covered cache without a full foreground fetch", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        // Fewer than 25 rows is still a valid immediate SWR hydration.
+        candles: [candle("2026-06-09T14:25:00Z")],
+        savedAt: new Date("2026-06-09T14:29:55Z"),
+        coverage: targetWindow,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("warm-fresh");
+    expect(plan.cacheUsable).toBe(true);
+    expect(plan.requests).toEqual([]);
+  });
+
+  it("plans missing-history work in the background without repair mode", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        candles: [candle("2026-06-09T13:00:00Z"), candle("2026-06-09T13:05:00Z")],
+        savedAt: "2026-06-09T14:29:55Z",
+        coverage: {
+          start: "2026-06-09T13:00:00Z",
+          end: "2026-06-09T14:30:00Z",
+        },
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.foreground).toEqual([]);
+    expect(plan.background).toHaveLength(1);
+    expect(plan.background[0]).toMatchObject({
+      reason: "missing-history",
+      priority: "background",
+      repair: false,
+      window: {
+        start: "2026-06-09T11:00:00.000Z",
+        end: "2026-06-09T13:00:00.000Z",
+      },
+    });
+  });
+
+  it("plans stale tail revalidation as a small overlapping foreground fetch", () => {
+    const plan = planBotCandleFetches({
+      targetWindow,
+      initialWindow,
+      cache: {
+        candles: [candle("2026-06-09T14:20:00Z"), candle("2026-06-09T14:25:00Z")],
+        savedAt: "2026-06-09T14:20:00Z",
+        coverage: targetWindow,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:30:00Z"),
+    });
+
+    expect(plan.cacheState).toBe("warm-stale");
+    expect(plan.foreground).toHaveLength(1);
+    expect(plan.foreground[0]).toMatchObject({
+      reason: "stale-tail",
+      priority: "foreground",
+      limit: 8,
+      repair: false,
+    });
+    expect(Date.parse(plan.foreground[0].window.start)).toBeGreaterThan(Date.parse(targetWindow.start));
+  });
+
+  it("suppresses stale tail revalidation during a known closed futures session", () => {
+    const weekendTarget = {
+      start: "2026-06-05T14:00:00Z",
+      end: "2026-06-06T15:00:00Z",
+      limit: 300,
+    };
+    const plan = planBotCandleFetches({
+      targetWindow: weekendTarget,
+      initialWindow: weekendTarget,
+      cache: {
+        candles: [candle("2026-06-05T20:55:00Z")],
+        savedAt: "2026-06-05T21:00:00Z",
+        coverage: weekendTarget,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-06T15:00:00Z"),
+    });
+
+    expect(plan.isStale).toBe(true);
+    expect(plan.foreground).toEqual([]);
+  });
+
+  it("plans bounded interior data-gap repair in the background with repair mode", () => {
+    const gapTarget = {
+      start: "2026-06-09T13:55:00Z",
+      end: "2026-06-09T14:25:00Z",
+      limit: 300,
+    };
+    const plan = planBotCandleFetches({
+      targetWindow: gapTarget,
+      initialWindow: gapTarget,
+      cache: {
+        candles: [candle("2026-06-09T14:00:00Z"), candle("2026-06-09T14:20:00Z")],
+        savedAt: "2026-06-09T14:24:55Z",
+        coverage: gapTarget,
+      },
+      unit: "minute",
+      unitNumber: 5,
+      now: new Date("2026-06-09T14:25:00Z"),
+      maxRepairBars: 10,
+    });
+
+    expect(plan.foreground).toEqual([]);
+    expect(plan.background).toHaveLength(1);
+    expect(plan.background[0]).toMatchObject({
+      reason: "interior-gap",
+      priority: "background",
+      repair: true,
+    });
+    expect(plan.background[0].limit).toBeLessThanOrEqual(10);
   });
 });
 

--- a/frontend/src/pages/bot/botCandleGaps.ts
+++ b/frontend/src/pages/bot/botCandleGaps.ts
@@ -243,11 +243,14 @@ export function buildGapRepairWindows(
   unitNumber: number,
   maxWindows = 3,
 ): GapRepairWindow[] {
+  if (maxWindows <= 0) {
+    return [];
+  }
   const intervalMs = intervalSecondsFor(unit, unitNumber) * 1000;
   const dataGaps = gaps
     .filter((gap) => gap.kind === "data")
     .sort((left, right) => right.missingSessionBars - left.missingSessionBars)
-    .slice(0, Math.max(1, maxWindows));
+    .slice(0, Math.max(1, Math.trunc(maxWindows)));
 
   const ranges = dataGaps
     .map((gap) => ({

--- a/frontend/src/pages/bot/botCandleGaps.ts
+++ b/frontend/src/pages/bot/botCandleGaps.ts
@@ -6,16 +6,10 @@ import type { BotTimeframeUnit, ProjectXMarketCandle } from "../../lib/types";
  * A "gap" is a run of expected candle buckets with no data between two loaded
  * candles. Gaps are classified as:
  * - "session": every missing bucket falls inside a scheduled market closure
- *   (CME Globex futures hours: nightly 5-6pm ET maintenance break and the
- *   Fri 5pm -> Sun 6pm ET weekend closure). These are normal and not a data
- *   quality problem.
+ *   (CME Globex maintenance/weekend hours plus known equity-index halts and
+ *   recurring holidays). These are normal and not a data quality problem.
  * - "data": at least one missing bucket falls inside regular trading hours.
- *   These are either provider holes (repairable by refetching) or genuine
- *   no-trade/holiday periods the session model does not know about.
- *
- * Exchange holidays are intentionally not modeled; a holiday shows up as a
- * "data" gap that a repair fetch cannot fill. Callers should treat a gap that
- * survives a repair attempt as "confirmed empty" rather than retrying forever.
+ *   These are provider holes that can be repaired by a bounded refetch.
  */
 
 export type CandleGapKind = "session" | "data";
@@ -122,6 +116,12 @@ const EASTERN_TIME_ZONE = "America/New_York";
 /** Globex maintenance break: 17:00-17:59 ET Monday-Thursday (and Friday close). */
 const SESSION_BREAK_START_MINUTES = 17 * 60;
 const SESSION_BREAK_END_MINUTES = 18 * 60;
+const EQUITY_HALT_START_MINUTES = 16 * 60 + 15;
+const EQUITY_HALT_END_MINUTES = 16 * 60 + 30;
+const EARLY_CLOSE_MINUTES = 13 * 60;
+const LATE_EARLY_CLOSE_MINUTES = 13 * 60 + 15;
+const GOOD_FRIDAY_CLOSE_MINUTES = 9 * 60 + 15;
+const CME_EQUITY_ROOTS = new Set(["ES", "MES", "NQ", "MNQ", "YM", "MYM", "RTY", "M2K", "EMD", "MME", "NKD", "NIY"]);
 /** Cap per-gap bucket scans; beyond this a gap is sampled instead of walked. */
 const MAX_GAP_BUCKET_SCAN = 5_000;
 const DEFAULT_TAIL_REVALIDATION_BARS = 8;
@@ -131,6 +131,9 @@ const DEFAULT_MAX_REPAIR_BARS = 500;
 const easternHourFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: EASTERN_TIME_ZONE,
   weekday: "short",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
   hour: "2-digit",
   hourCycle: "h23",
 });
@@ -138,6 +141,9 @@ const easternHourFormatter = new Intl.DateTimeFormat("en-US", {
 interface EasternHourInfo {
   /** 0 = Sunday ... 6 = Saturday */
   weekday: number;
+  year: number;
+  month: number;
+  day: number;
   hour: number;
 }
 
@@ -161,16 +167,25 @@ function easternHourInfo(timestampMs: number): EasternHourInfo {
   }
 
   let weekday = 1;
+  let year = 1970;
+  let month = 1;
+  let day = 1;
   let hour = 0;
   for (const part of easternHourFormatter.formatToParts(new Date(hourKey * 3_600_000))) {
     if (part.type === "weekday") {
       weekday = WEEKDAY_INDEX[part.value] ?? 1;
+    } else if (part.type === "year") {
+      year = Number(part.value);
+    } else if (part.type === "month") {
+      month = Number(part.value);
+    } else if (part.type === "day") {
+      day = Number(part.value);
     } else if (part.type === "hour") {
       hour = Number(part.value);
     }
   }
 
-  const info = { weekday, hour };
+  const info = { weekday, year, month, day, hour };
   if (easternHourInfoCache.size > 20_000) {
     easternHourInfoCache.clear();
   }
@@ -178,29 +193,171 @@ function easternHourInfo(timestampMs: number): EasternHourInfo {
   return info;
 }
 
+interface CalendarDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+interface EquityHolidaySchedule {
+  fullClose: boolean;
+  earlyCloseMinutes?: number;
+}
+
+function calendarDateValue(value: CalendarDate): number {
+  return Date.UTC(value.year, value.month - 1, value.day);
+}
+
+function calendarDateFromValue(value: number): CalendarDate {
+  const parsed = new Date(value);
+  return { year: parsed.getUTCFullYear(), month: parsed.getUTCMonth() + 1, day: parsed.getUTCDate() };
+}
+
+function addCalendarDays(value: CalendarDate, days: number): CalendarDate {
+  return calendarDateFromValue(calendarDateValue(value) + days * 86_400_000);
+}
+
+function sameCalendarDate(left: CalendarDate, right: CalendarDate): boolean {
+  return left.year === right.year && left.month === right.month && left.day === right.day;
+}
+
+function calendarWeekday(value: CalendarDate): number {
+  return new Date(calendarDateValue(value)).getUTCDay();
+}
+
+function nthWeekday(year: number, month: number, weekday: number, occurrence: number): CalendarDate {
+  const first = { year, month, day: 1 };
+  const offset = (weekday - calendarWeekday(first) + 7) % 7;
+  return addCalendarDays(first, offset + 7 * (occurrence - 1));
+}
+
+function lastWeekday(year: number, month: number, weekday: number): CalendarDate {
+  const nextMonth = month === 12 ? { year: year + 1, month: 1, day: 1 } : { year, month: month + 1, day: 1 };
+  const last = addCalendarDays(nextMonth, -1);
+  return addCalendarDays(last, -((calendarWeekday(last) - weekday + 7) % 7));
+}
+
+function nearestWeekday(value: CalendarDate): CalendarDate {
+  const weekday = calendarWeekday(value);
+  if (weekday === 6) {
+    return addCalendarDays(value, -1);
+  }
+  if (weekday === 0) {
+    return addCalendarDays(value, 1);
+  }
+  return value;
+}
+
+function easterSunday(year: number): CalendarDate {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return { year, month, day };
+}
+
+function usesCmeEquitySchedule(symbol: string | null | undefined): boolean {
+  if (!symbol?.trim()) {
+    return false;
+  }
+  return symbol
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .some((token) => CME_EQUITY_ROOTS.has(token));
+}
+
+function equityHolidaySchedule(value: CalendarDate): EquityHolidaySchedule | null {
+  const year = value.year;
+  const newYear = { year, month: 1, day: 1 };
+  const observedNewYear = calendarWeekday(newYear) === 0 ? addCalendarDays(newYear, 1) : newYear;
+  if (sameCalendarDate(value, observedNewYear)) {
+    return { fullClose: true };
+  }
+  if (sameCalendarDate(value, nearestWeekday({ year, month: 12, day: 25 }))) {
+    return { fullClose: true };
+  }
+  if (sameCalendarDate(value, addCalendarDays(easterSunday(year), -2))) {
+    return { fullClose: false, earlyCloseMinutes: GOOD_FRIDAY_CLOSE_MINUTES };
+  }
+
+  const thanksgiving = nthWeekday(year, 11, 4, 4);
+  if (
+    sameCalendarDate(value, nthWeekday(year, 1, 1, 3)) ||
+    sameCalendarDate(value, nthWeekday(year, 2, 1, 3)) ||
+    sameCalendarDate(value, lastWeekday(year, 5, 1)) ||
+    (year >= 2022 && sameCalendarDate(value, nearestWeekday({ year, month: 6, day: 19 }))) ||
+    sameCalendarDate(value, nearestWeekday({ year, month: 7, day: 4 })) ||
+    sameCalendarDate(value, nthWeekday(year, 9, 1, 1)) ||
+    sameCalendarDate(value, thanksgiving)
+  ) {
+    return { fullClose: false, earlyCloseMinutes: EARLY_CLOSE_MINUTES };
+  }
+  if (sameCalendarDate(value, addCalendarDays(thanksgiving, 1))) {
+    return { fullClose: false, earlyCloseMinutes: LATE_EARLY_CLOSE_MINUTES };
+  }
+  if (value.month === 12 && value.day === 24 && calendarWeekday(value) >= 1 && calendarWeekday(value) <= 5) {
+    return { fullClose: false, earlyCloseMinutes: LATE_EARLY_CLOSE_MINUTES };
+  }
+  return null;
+}
+
 /**
  * Whether a candle bucket starting at `timestampMs` falls inside CME Globex
  * futures trading hours (Sun 18:00 ET through Fri 17:00 ET, with a daily
- * 17:00-18:00 ET maintenance break).
+ * 17:00-18:00 ET maintenance break). Known equity-index symbols additionally
+ * honor the 16:15-16:30 halt and recurring holiday schedules.
  *
  * The ET offset is always a whole number of hours, so the UTC minute is the
  * ET minute; only weekday+hour need the timezone conversion (memoized per hour).
  */
-export function isFuturesSessionOpen(timestampMs: number): boolean {
-  const { weekday, hour } = easternHourInfo(timestampMs);
+export function isFuturesSessionOpen(timestampMs: number, symbol?: string | null): boolean {
+  const local = easternHourInfo(timestampMs);
+  const { weekday, hour } = local;
   const minute = new Date(timestampMs).getUTCMinutes();
   const minutesOfDay = hour * 60 + minute;
 
   if (weekday === 6) {
     return false; // Saturday
   }
-  if (weekday === 0) {
-    return minutesOfDay >= SESSION_BREAK_END_MINUTES; // Sunday opens 18:00 ET
+  if (weekday === 0 && minutesOfDay < SESSION_BREAK_END_MINUTES) {
+    return false; // Sunday opens 18:00 ET
   }
-  if (weekday === 5) {
-    return minutesOfDay < SESSION_BREAK_START_MINUTES; // Friday closes 17:00 ET
+  if (weekday === 5 && minutesOfDay >= SESSION_BREAK_START_MINUTES) {
+    return false; // Friday closes 17:00 ET
   }
-  return minutesOfDay < SESSION_BREAK_START_MINUTES || minutesOfDay >= SESSION_BREAK_END_MINUTES;
+  if (minutesOfDay >= SESSION_BREAK_START_MINUTES && minutesOfDay < SESSION_BREAK_END_MINUTES) {
+    return false;
+  }
+  if (!usesCmeEquitySchedule(symbol)) {
+    return true;
+  }
+
+  const localDate = { year: local.year, month: local.month, day: local.day };
+  const tradingDate = minutesOfDay >= SESSION_BREAK_END_MINUTES ? addCalendarDays(localDate, 1) : localDate;
+  const holiday = equityHolidaySchedule(tradingDate);
+  if (holiday?.fullClose) {
+    return false;
+  }
+  if (sameCalendarDate(localDate, tradingDate)) {
+    const closeMinutes = holiday?.earlyCloseMinutes ?? SESSION_BREAK_START_MINUTES;
+    if (minutesOfDay >= closeMinutes) {
+      return false;
+    }
+    if (minutesOfDay >= EQUITY_HALT_START_MINUTES && minutesOfDay < EQUITY_HALT_END_MINUTES) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -208,9 +365,32 @@ export function isFuturesSessionOpen(timestampMs: number): boolean {
  * the UTC weekday is used; converting to ET would shift a midnight-stamped bar
  * into the previous evening and misclassify weekends.
  */
-function isUtcWeekday(timestampMs: number): boolean {
-  const weekday = new Date(timestampMs).getUTCDay();
-  return weekday >= 1 && weekday <= 5;
+function isUtcTradingDay(timestampMs: number, symbol?: string | null): boolean {
+  const timestamp = new Date(timestampMs);
+  const weekday = timestamp.getUTCDay();
+  if (weekday < 1 || weekday > 5) {
+    return false;
+  }
+  if (!usesCmeEquitySchedule(symbol)) {
+    return true;
+  }
+  return !equityHolidaySchedule({
+    year: timestamp.getUTCFullYear(),
+    month: timestamp.getUTCMonth() + 1,
+    day: timestamp.getUTCDate(),
+  })?.fullClose;
+}
+
+function inferCandleSessionSymbol(candles: readonly ProjectXMarketCandle[]): string | null {
+  for (const candle of candles) {
+    if (candle.symbol?.trim()) {
+      return candle.symbol;
+    }
+    if (candle.contract_id?.trim()) {
+      return candle.contract_id;
+    }
+  }
+  return null;
 }
 
 export function intervalSecondsFor(unit: BotTimeframeUnit, unitNumber: number): number {
@@ -258,7 +438,8 @@ export function planBotCandleFetches(input: PlanBotCandleFetchesInput): BotCandl
 
   const foreground: BotCandleFetchRequest[] = [];
   const background = buildMissingHistoryRequests(target, coverage.startMs, target.limit);
-  const sessionOpen = Number.isFinite(nowMs) && isFuturesSessionOpen(nowMs);
+  const sessionOpen =
+    Number.isFinite(nowMs) && isFuturesSessionOpen(nowMs, inferCandleSessionSymbol(input.cache.candles));
   const uncoveredTailMs = target.endMs - coverage.endMs;
   const normalizedTailBars = Math.max(2, Math.trunc(input.tailBars ?? DEFAULT_TAIL_REVALIDATION_BARS));
 
@@ -348,6 +529,7 @@ export function findCandleGaps(
   }
 
   const gaps: CandleGap[] = [];
+  const sessionSymbol = inferCandleSessionSymbol(candles);
   for (let index = 1; index < sortedTimestamps.length; index += 1) {
     const previous = sortedTimestamps[index - 1];
     const current = sortedTimestamps[index];
@@ -358,7 +540,7 @@ export function findCandleGaps(
 
     const fromMs = previous.ms + intervalMs;
     const toMs = current.ms;
-    const { missingBars, missingSessionBars } = countMissingBuckets(fromMs, toMs, intervalMs, unit);
+    const { missingBars, missingSessionBars } = countMissingBuckets(fromMs, toMs, intervalMs, unit, sessionSymbol);
     if (missingBars <= 0) {
       continue;
     }
@@ -382,13 +564,17 @@ function countMissingBuckets(
   toMs: number,
   intervalMs: number,
   unit: BotTimeframeUnit,
+  symbol: string | null,
 ): { missingBars: number; missingSessionBars: number } {
   const missingBars = Math.max(0, Math.round((toMs - fromMs) / intervalMs));
   if (missingBars === 0) {
     return { missingBars: 0, missingSessionBars: 0 };
   }
 
-  const isInSession = unit === "day" ? isUtcWeekday : isFuturesSessionOpen;
+  const isInSession =
+    unit === "day"
+      ? (timestampMs: number) => isUtcTradingDay(timestampMs, symbol)
+      : (timestampMs: number) => isFuturesSessionOpen(timestampMs, symbol);
   const step = missingBars > MAX_GAP_BUCKET_SCAN ? Math.ceil(missingBars / MAX_GAP_BUCKET_SCAN) : 1;
   let missingSessionBars = 0;
   for (let bucket = 0; bucket < missingBars; bucket += step) {

--- a/frontend/src/pages/bot/botCandleGaps.ts
+++ b/frontend/src/pages/bot/botCandleGaps.ts
@@ -41,6 +41,65 @@ export interface GapRepairWindow {
   end: string;
 }
 
+export interface BotCandleFetchQueryWindow extends GapRepairWindow {
+  limit: number;
+}
+
+export type BotCandleFetchPriority = "foreground" | "background";
+export type BotCandleFetchReason =
+  | "cold"
+  | "missing-tail"
+  | "stale-tail"
+  | "missing-history"
+  | "interior-gap";
+
+export interface BotCandleFetchRequest {
+  reason: BotCandleFetchReason;
+  priority: BotCandleFetchPriority;
+  window: GapRepairWindow;
+  limit: number;
+  /** Only interior-hole requests trigger the backend automatic-repair path. */
+  repair: boolean;
+}
+
+export interface BotCandleFetchCacheSnapshot {
+  candles: ProjectXMarketCandle[];
+  savedAt: Date | string | null;
+  /** Query coverage can extend beyond the first/last returned trading bar. */
+  coverage?: GapRepairWindow | null;
+}
+
+export interface PlanBotCandleFetchesInput {
+  /** Full chart range ultimately desired (for example the bot lookback). */
+  targetWindow: BotCandleFetchQueryWindow;
+  /** Fast first-paint range, normally the 300-bar initial query. */
+  initialWindow: BotCandleFetchQueryWindow;
+  cache: BotCandleFetchCacheSnapshot | null;
+  unit: BotTimeframeUnit;
+  unitNumber: number;
+  now: Date;
+  /** Optional deterministic override; the default scales with the timeframe. */
+  staleAfterMs?: number;
+  /** Number of bars in a small overlapping tail revalidation. Defaults to 8. */
+  tailBars?: number;
+  /** Maximum independently repaired interior gaps. Defaults to 3. */
+  maxRepairWindows?: number;
+  /** Provider-result cap for any one interior repair. Defaults to 500. */
+  maxRepairBars?: number;
+}
+
+export type BotCandleFetchCacheState = "cold" | "warm-fresh" | "warm-stale";
+
+export interface BotCandleFetchPlan {
+  cacheState: BotCandleFetchCacheState;
+  cacheUsable: boolean;
+  isStale: boolean;
+  /** Ordered with every foreground request before all background work. */
+  requests: BotCandleFetchRequest[];
+  foreground: BotCandleFetchRequest[];
+  background: BotCandleFetchRequest[];
+}
+
 /** Whether a gap was actually included in one of the bounded repair requests. */
 export function isGapCoveredByRepairWindows(gap: CandleGap, windows: readonly GapRepairWindow[]): boolean {
   return windows.some((window_) => {
@@ -65,6 +124,9 @@ const SESSION_BREAK_START_MINUTES = 17 * 60;
 const SESSION_BREAK_END_MINUTES = 18 * 60;
 /** Cap per-gap bucket scans; beyond this a gap is sampled instead of walked. */
 const MAX_GAP_BUCKET_SCAN = 5_000;
+const DEFAULT_TAIL_REVALIDATION_BARS = 8;
+const DEFAULT_MAX_REPAIR_WINDOWS = 3;
+const DEFAULT_MAX_REPAIR_BARS = 500;
 
 const easternHourFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: EASTERN_TIME_ZONE,
@@ -153,6 +215,112 @@ function isUtcWeekday(timestampMs: number): boolean {
 
 export function intervalSecondsFor(unit: BotTimeframeUnit, unitNumber: number): number {
   return UNIT_SECONDS_BY_NAME[unit] * Math.max(1, Math.trunc(unitNumber));
+}
+
+/**
+ * Build a stale-while-revalidate request plan without reading clocks, storage,
+ * or network state. Any valid cached row is immediately usable; request
+ * priority determines scheduling, not whether cache hydration is allowed.
+ *
+ * Cold loads fetch only the small initial window in the foreground. Warm loads
+ * fetch a missing/stale overlapping tail only when the futures session is open.
+ * Older target coverage and bounded interior-hole repairs are background work.
+ */
+export function planBotCandleFetches(input: PlanBotCandleFetchesInput): BotCandleFetchPlan {
+  const target = parseQueryWindow(input.targetWindow);
+  const initial = parseQueryWindow(input.initialWindow);
+  const intervalMs = intervalSecondsFor(input.unit, input.unitNumber) * 1000;
+  if (!target || !initial || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return finishFetchPlan("cold", false, true, [], []);
+  }
+
+  const cacheBounds = findCandleBounds(input.cache?.candles ?? []);
+  const cacheUsable = cacheBounds !== null;
+  if (!input.cache || !cacheUsable) {
+    const foreground: BotCandleFetchRequest[] = [
+      fetchRequest("cold", "foreground", initial, initial.limit, false),
+    ];
+    const background = buildMissingHistoryRequests(target, initial.startMs, Math.max(1, target.limit - initial.limit));
+    return finishFetchPlan("cold", false, true, foreground, background);
+  }
+
+  const nowMs = input.now.getTime();
+  const savedAtMs = parseTimestamp(input.cache.savedAt);
+  const staleAfterMs = Number.isFinite(input.staleAfterMs)
+    ? Math.max(0, Number(input.staleAfterMs))
+    : defaultStaleAfterMs(intervalMs);
+  const ageMs = Number.isFinite(nowMs) && savedAtMs !== null ? Math.max(0, nowMs - savedAtMs) : Number.POSITIVE_INFINITY;
+  const isStale = ageMs > staleAfterMs;
+  const coverage = parseCoverageWindow(input.cache.coverage) ?? {
+    startMs: cacheBounds.firstMs,
+    endMs: cacheBounds.lastMs,
+  };
+
+  const foreground: BotCandleFetchRequest[] = [];
+  const background = buildMissingHistoryRequests(target, coverage.startMs, target.limit);
+  const sessionOpen = Number.isFinite(nowMs) && isFuturesSessionOpen(nowMs);
+  const uncoveredTailMs = target.endMs - coverage.endMs;
+  const normalizedTailBars = Math.max(2, Math.trunc(input.tailBars ?? DEFAULT_TAIL_REVALIDATION_BARS));
+
+  if (sessionOpen && uncoveredTailMs > intervalMs) {
+    const startMs = Math.max(target.startMs, coverage.endMs - intervalMs);
+    foreground.push(
+      fetchRequest(
+        "missing-tail",
+        "foreground",
+        { startMs, endMs: target.endMs },
+        estimateWindowLimit(startMs, target.endMs, intervalMs, target.limit),
+        false,
+      ),
+    );
+  } else if (sessionOpen && isStale) {
+    const startMs = Math.max(target.startMs, target.endMs - intervalMs * (normalizedTailBars - 1));
+    foreground.push(
+      fetchRequest(
+        "stale-tail",
+        "foreground",
+        { startMs, endMs: target.endMs },
+        Math.min(target.limit, normalizedTailBars),
+        false,
+      ),
+    );
+  }
+
+  const maxRepairWindows = Math.max(0, Math.trunc(input.maxRepairWindows ?? DEFAULT_MAX_REPAIR_WINDOWS));
+  if (maxRepairWindows > 0) {
+    const interiorGaps = findCandleGaps(input.cache.candles, input.unit, input.unitNumber).filter(
+      (gap) => gap.kind === "data" && gap.fromMs >= target.startMs && gap.toMs <= target.endMs,
+    );
+    const repairWindows = buildGapRepairWindows(
+      interiorGaps,
+      input.unit,
+      input.unitNumber,
+      maxRepairWindows,
+    );
+    const maxRepairBars = Math.max(1, Math.trunc(input.maxRepairBars ?? DEFAULT_MAX_REPAIR_BARS));
+    for (const repairWindow of repairWindows) {
+      const parsedRepair = parseCoverageWindow(repairWindow);
+      if (!parsedRepair) {
+        continue;
+      }
+      const startMs = Math.max(target.startMs, parsedRepair.startMs);
+      const endMs = Math.min(target.endMs, parsedRepair.endMs);
+      if (startMs >= endMs) {
+        continue;
+      }
+      background.push(
+        fetchRequest(
+          "interior-gap",
+          "background",
+          { startMs, endMs },
+          estimateWindowLimit(startMs, endMs, intervalMs, maxRepairBars),
+          true,
+        ),
+      );
+    }
+  }
+
+  return finishFetchPlan(isStale ? "warm-stale" : "warm-fresh", true, isStale, foreground, background);
 }
 
 /**
@@ -275,6 +443,133 @@ export function buildGapRepairWindows(
 
 export function buildGapRangeKey(gap: CandleGap): string {
   return `${gap.fromMs}:${gap.toMs}`;
+}
+
+interface ParsedQueryWindow {
+  startMs: number;
+  endMs: number;
+  limit: number;
+}
+
+interface ParsedWindow {
+  startMs: number;
+  endMs: number;
+}
+
+function parseQueryWindow(window_: BotCandleFetchQueryWindow): ParsedQueryWindow | null {
+  const parsed = parseCoverageWindow(window_);
+  if (!parsed || !Number.isFinite(window_.limit) || window_.limit <= 0) {
+    return null;
+  }
+  return {
+    ...parsed,
+    limit: Math.max(1, Math.trunc(window_.limit)),
+  };
+}
+
+function parseCoverageWindow(window_: GapRepairWindow | null | undefined): ParsedWindow | null {
+  if (!window_) {
+    return null;
+  }
+  const startMs = Date.parse(window_.start);
+  const endMs = Date.parse(window_.end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs > endMs) {
+    return null;
+  }
+  return { startMs, endMs };
+}
+
+function findCandleBounds(candles: readonly ProjectXMarketCandle[]): { firstMs: number; lastMs: number } | null {
+  let firstMs = Number.POSITIVE_INFINITY;
+  let lastMs = Number.NEGATIVE_INFINITY;
+  for (const candle of candles) {
+    const timestampMs = Date.parse(candle.timestamp);
+    if (!Number.isFinite(timestampMs)) {
+      continue;
+    }
+    firstMs = Math.min(firstMs, timestampMs);
+    lastMs = Math.max(lastMs, timestampMs);
+  }
+  return Number.isFinite(firstMs) && Number.isFinite(lastMs) ? { firstMs, lastMs } : null;
+}
+
+function parseTimestamp(value: Date | string | null): number | null {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function defaultStaleAfterMs(intervalMs: number): number {
+  return Math.max(15_000, Math.min(60_000, Math.trunc(intervalMs / 2)));
+}
+
+function buildMissingHistoryRequests(
+  target: ParsedQueryWindow,
+  coveredFromMs: number,
+  requestedLimit: number,
+): BotCandleFetchRequest[] {
+  if (!Number.isFinite(coveredFromMs) || target.startMs >= coveredFromMs) {
+    return [];
+  }
+  const endMs = Math.min(target.endMs, coveredFromMs);
+  if (target.startMs >= endMs) {
+    return [];
+  }
+  return [
+    fetchRequest(
+      "missing-history",
+      "background",
+      { startMs: target.startMs, endMs },
+      Math.min(target.limit, Math.max(1, Math.trunc(requestedLimit))),
+      false,
+    ),
+  ];
+}
+
+function estimateWindowLimit(startMs: number, endMs: number, intervalMs: number, cap: number): number {
+  const estimatedBars = Math.ceil(Math.max(0, endMs - startMs) / intervalMs) + 1;
+  return Math.min(Math.max(1, Math.trunc(cap)), Math.max(1, estimatedBars));
+}
+
+function fetchRequest(
+  reason: BotCandleFetchReason,
+  priority: BotCandleFetchPriority,
+  window_: ParsedWindow,
+  limit: number,
+  repair: boolean,
+): BotCandleFetchRequest {
+  return {
+    reason,
+    priority,
+    window: {
+      start: new Date(window_.startMs).toISOString(),
+      end: new Date(window_.endMs).toISOString(),
+    },
+    limit: Math.max(1, Math.trunc(limit)),
+    repair,
+  };
+}
+
+function finishFetchPlan(
+  cacheState: BotCandleFetchCacheState,
+  cacheUsable: boolean,
+  isStale: boolean,
+  foreground: BotCandleFetchRequest[],
+  background: BotCandleFetchRequest[],
+): BotCandleFetchPlan {
+  return {
+    cacheState,
+    cacheUsable,
+    isStale,
+    requests: [...foreground, ...background],
+    foreground,
+    background,
+  };
 }
 
 function dedupeSortedTimestamps(candles: ProjectXMarketCandle[]): { ms: number; iso: string }[] {

--- a/frontend/src/pages/bot/botChartData.test.ts
+++ b/frontend/src/pages/bot/botChartData.test.ts
@@ -4,6 +4,7 @@ import {
   BOT_CHART_INITIAL_BARS,
   BOT_CHART_MAX_BARS,
   BOT_CHART_MIN_BARS,
+  BOT_CHART_TIMEFRAMES,
   buildBotChartQuery,
   buildInitialBotChartQuery,
   buildBotLivePriceQuery,
@@ -318,6 +319,17 @@ describe("buildLiquidityLevels", () => {
 });
 
 describe("buildBotChartQuery", () => {
+  it("defines the six contract timeframes warmed by the signal chart", () => {
+    expect(BOT_CHART_TIMEFRAMES.map((timeframe) => timeframe.id)).toEqual([
+      "1m",
+      "5m",
+      "15m",
+      "1h",
+      "4h",
+      "1d",
+    ]);
+  });
+
   it("uses a practical capped history window based on the bot timeframe", () => {
     const window = buildBotChartQuery(
       botConfig({

--- a/frontend/src/pages/bot/botChartData.ts
+++ b/frontend/src/pages/bot/botChartData.ts
@@ -5,6 +5,21 @@ import type { BotConfig, BotDecision, BotEvaluation, BotTimeframeUnit, ProjectXM
 export const BOT_CHART_MAX_BARS = 2_000;
 export const BOT_CHART_MIN_BARS = 300;
 export const BOT_CHART_INITIAL_BARS = BOT_CHART_MIN_BARS;
+export const BOT_CHART_TIMEFRAMES = [
+  { id: "1m", label: "1m", unit: "minute", unitNumber: 1 },
+  { id: "5m", label: "5m", unit: "minute", unitNumber: 5 },
+  { id: "15m", label: "15m", unit: "minute", unitNumber: 15 },
+  { id: "1h", label: "1H", unit: "hour", unitNumber: 1 },
+  { id: "4h", label: "4H", unit: "hour", unitNumber: 4 },
+  { id: "1d", label: "1D", unit: "day", unitNumber: 1 },
+] as const satisfies readonly {
+  id: string;
+  label: string;
+  unit: BotTimeframeUnit;
+  unitNumber: number;
+}[];
+export type BotChartTimeframe = (typeof BOT_CHART_TIMEFRAMES)[number];
+export type BotChartTimeframeId = BotChartTimeframe["id"];
 const CHART_LOOKBACK_MULTIPLIER = 3;
 
 const UNIT_SECONDS_BY_NAME: Record<BotTimeframeUnit, number> = {

--- a/frontend/src/pages/bot/botChartLifecycle.test.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.test.ts
@@ -1,13 +1,35 @@
 import type { Logical, LogicalRange, UTCTimestamp } from "lightweight-charts";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   LatestRequestCoordinator,
+  LogicalViewportMemory,
+  PrioritizedRequestScheduler,
   getViewportRestoreRange,
   invalidateChartRequestLanes,
   isViewportAtLiveEdge,
   preserveLogicalViewport,
 } from "./botChartLifecycle";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function logicalRange(from: number, to: number): LogicalRange {
   return { from: from as Logical, to: to as Logical };
@@ -113,6 +135,279 @@ describe("LatestRequestCoordinator", () => {
     expect(live.accepts(liveRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(history.accepts(historyRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(repair.accepts(repairRequest, "bot-a:MNQ:5m")).toBe(false);
+  });
+});
+
+describe("PrioritizedRequestScheduler", () => {
+  it("deduplicates exact keys across queued and active subscribers", async () => {
+    const scheduler = new PrioritizedRequestScheduler({ maxConcurrency: 1 });
+    const blocker = deferred<string>();
+    const sharedWork = deferred<string>();
+    const sharedTask = vi.fn(() => sharedWork.promise);
+
+    const blockingRequest = scheduler.schedule("blocker", () => blocker.promise);
+    const first = scheduler.schedule("shared", sharedTask);
+    const secondTask = vi.fn(() => Promise.resolve("wrong task"));
+    const second = scheduler.schedule("shared", secondTask);
+
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+    expect(sharedTask).not.toHaveBeenCalled();
+    expect(secondTask).not.toHaveBeenCalled();
+
+    blocker.resolve("unblocked");
+    await expect(blockingRequest).resolves.toBe("unblocked");
+    expect(sharedTask).toHaveBeenCalledOnce();
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(0);
+    const activeDuplicateTask = vi.fn(() => Promise.resolve("wrong active task"));
+    const third = scheduler.schedule("shared", activeDuplicateTask);
+
+    sharedWork.resolve("shared result");
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      "shared result",
+      "shared result",
+      "shared result",
+    ]);
+    expect(sharedTask).toHaveBeenCalledOnce();
+    expect(secondTask).not.toHaveBeenCalled();
+    expect(activeDuplicateTask).not.toHaveBeenCalled();
+  });
+
+  it("always selects queued foreground work before background work", async () => {
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 1,
+      maxBackgroundConcurrency: 1,
+    });
+    const blocker = deferred<void>();
+    const foreground = deferred<string>();
+    const background = deferred<string>();
+    const starts: string[] = [];
+
+    const blockingRequest = scheduler.schedule("active", () => blocker.promise);
+    const backgroundRequest = scheduler.schedule(
+      "background",
+      () => {
+        starts.push("background");
+        return background.promise;
+      },
+      { priority: "background" },
+    );
+    const foregroundRequest = scheduler.schedule("foreground", () => {
+      starts.push("foreground");
+      return foreground.promise;
+    });
+
+    blocker.resolve();
+    await blockingRequest;
+    expect(starts).toEqual(["foreground"]);
+    expect(scheduler.queuedBackgroundCount).toBe(1);
+
+    foreground.resolve("visible");
+    await expect(foregroundRequest).resolves.toBe("visible");
+    expect(starts).toEqual(["foreground", "background"]);
+    background.resolve("warm");
+    await expect(backgroundRequest).resolves.toBe("warm");
+  });
+
+  it("upgrades a queued background task when a foreground subscriber joins", async () => {
+    const scheduler = new PrioritizedRequestScheduler({ maxConcurrency: 1 });
+    const blocker = deferred<void>();
+    const starts: string[] = [];
+
+    const blockingRequest = scheduler.schedule("active", () => blocker.promise);
+    const olderBackground = scheduler.schedule(
+      "older-background",
+      () => {
+        starts.push("older-background");
+        return "older";
+      },
+      { priority: "background" },
+    );
+    const upgradedTask = vi.fn(() => {
+      starts.push("upgraded");
+      return "upgraded";
+    });
+    const backgroundSubscriber = scheduler.schedule("upgrade-me", upgradedTask, {
+      priority: "background",
+    });
+    const ignoredDuplicateTask = vi.fn(() => "duplicate");
+    const foregroundSubscriber = scheduler.schedule(
+      "upgrade-me",
+      ignoredDuplicateTask,
+      { priority: "foreground" },
+    );
+
+    expect(scheduler.queuedForegroundCount).toBe(1);
+    expect(scheduler.queuedBackgroundCount).toBe(1);
+    blocker.resolve();
+    await blockingRequest;
+    await expect(Promise.all([backgroundSubscriber, foregroundSubscriber])).resolves.toEqual([
+      "upgraded",
+      "upgraded",
+    ]);
+    await expect(olderBackground).resolves.toBe("older");
+
+    expect(starts).toEqual(["upgraded", "older-background"]);
+    expect(upgradedTask).toHaveBeenCalledOnce();
+    expect(ignoredDuplicateTask).not.toHaveBeenCalled();
+  });
+
+  it("limits background concurrency while leaving capacity for foreground work", async () => {
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 2,
+      maxBackgroundConcurrency: 1,
+    });
+    const firstBackground = deferred<void>();
+    const secondBackground = deferred<void>();
+    const foreground = deferred<void>();
+    const starts: string[] = [];
+
+    const first = scheduler.schedule(
+      "background-1",
+      () => {
+        starts.push("background-1");
+        return firstBackground.promise;
+      },
+      { priority: "background" },
+    );
+    const second = scheduler.schedule(
+      "background-2",
+      () => {
+        starts.push("background-2");
+        return secondBackground.promise;
+      },
+      { priority: "background" },
+    );
+    const visible = scheduler.schedule("foreground", () => {
+      starts.push("foreground");
+      return foreground.promise;
+    });
+
+    expect(starts).toEqual(["background-1", "foreground"]);
+    expect(scheduler.activeCount).toBe(2);
+    expect(scheduler.activeBackgroundCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+
+    foreground.resolve();
+    await visible;
+    expect(starts).toEqual(["background-1", "foreground"]);
+    firstBackground.resolve();
+    await first;
+    expect(starts).toEqual(["background-1", "foreground", "background-2"]);
+    secondBackground.resolve();
+    await second;
+  });
+
+  it("rate-limits background starts even when another background slot is free", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const scheduler = new PrioritizedRequestScheduler({
+      maxConcurrency: 2,
+      maxBackgroundConcurrency: 2,
+      minBackgroundStartIntervalMs: 100,
+    });
+    const firstWork = deferred<void>();
+    const secondWork = deferred<void>();
+    const starts: number[] = [];
+
+    const first = scheduler.schedule(
+      "background-1",
+      () => {
+        starts.push(Date.now());
+        return firstWork.promise;
+      },
+      { priority: "background" },
+    );
+    const second = scheduler.schedule(
+      "background-2",
+      () => {
+        starts.push(Date.now());
+        return secondWork.promise;
+      },
+      { priority: "background" },
+    );
+
+    expect(starts).toEqual([1_000]);
+    expect(scheduler.activeCount).toBe(1);
+    expect(scheduler.queuedCount).toBe(1);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(starts).toEqual([1_000]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(starts).toEqual([1_000, 1_100]);
+
+    firstWork.resolve();
+    secondWork.resolve();
+    await Promise.all([first, second]);
+  });
+
+  it("cancels subscribers independently and aborts shared work only after the last leaves", async () => {
+    const scheduler = new PrioritizedRequestScheduler();
+    const transport = deferred<string>();
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const sharedTransport: { signal?: AbortSignal } = {};
+    const task = (signal: AbortSignal) => {
+      sharedTransport.signal = signal;
+      return transport.promise;
+    };
+
+    const first = scheduler.schedule("candles", task, { signal: firstController.signal });
+    const second = scheduler.schedule("candles", task, { signal: secondController.signal });
+    const firstOutcome = first.then(
+      () => "resolved",
+      (error: unknown) => (error as Error).name,
+    );
+    const secondOutcome = second.then(
+      () => "resolved",
+      (error: unknown) => (error as Error).name,
+    );
+
+    firstController.abort();
+    expect(await firstOutcome).toBe("AbortError");
+    expect(sharedTransport.signal?.aborted).toBe(false);
+    expect(scheduler.activeCount).toBe(1);
+
+    secondController.abort();
+    expect(await secondOutcome).toBe("AbortError");
+    expect(sharedTransport.signal?.aborted).toBe(true);
+    // An abort-unaware transport still occupies its slot, but cannot resolve
+    // either cancelled subscriber when it eventually returns.
+    expect(scheduler.activeCount).toBe(1);
+    transport.resolve("late candles");
+    await Promise.resolve();
+    expect(scheduler.activeCount).toBe(0);
+  });
+});
+
+describe("LogicalViewportMemory", () => {
+  it("saves and restores independent ranges across timeframe keys", () => {
+    const memory = new LogicalViewportMemory<string>();
+
+    expect(memory.save("MNQ:1m", logicalRange(10.25, 40.75))).toBe(true);
+    expect(memory.save("MNQ:1H", logicalRange(100.5, 130.5))).toBe(true);
+    expect(memory.restore("MNQ:1m")).toEqual(logicalRange(10.25, 40.75));
+    expect(memory.restore("MNQ:1H")).toEqual(logicalRange(100.5, 130.5));
+    expect(memory.restore("MNQ:5m")).toBeNull();
+  });
+
+  it("ignores invalid ranges and protects saved ranges from caller mutation", () => {
+    const memory = new LogicalViewportMemory<string>();
+    const range = logicalRange(1, 3);
+    memory.save("5m", range);
+
+    range.from = 99 as Logical;
+    const restored = memory.restore("5m");
+    expect(restored).toEqual(logicalRange(1, 3));
+    if (restored) {
+      restored.to = 100 as Logical;
+    }
+    expect(memory.restore("5m")).toEqual(logicalRange(1, 3));
+    expect(memory.save("5m", logicalRange(4, 2))).toBe(false);
+    expect(memory.restore("5m")).toEqual(logicalRange(1, 3));
+
+    expect(memory.delete("5m")).toBe(true);
+    expect(memory.restore("5m")).toBeNull();
   });
 });
 

--- a/frontend/src/pages/bot/botChartLifecycle.test.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.test.ts
@@ -1,5 +1,5 @@
 import type { Logical, LogicalRange, UTCTimestamp } from "lightweight-charts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   LatestRequestCoordinator,
@@ -7,6 +7,7 @@ import {
   invalidateChartRequestLanes,
   isViewportAtLiveEdge,
   preserveLogicalViewport,
+  runChartContextLoadsInParallel,
 } from "./botChartLifecycle";
 
 function logicalRange(from: number, to: number): LogicalRange {
@@ -113,6 +114,36 @@ describe("LatestRequestCoordinator", () => {
     expect(live.accepts(liveRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(history.accepts(historyRequest, "bot-a:MNQ:5m")).toBe(false);
     expect(repair.accepts(repairRequest, "bot-a:MNQ:5m")).toBe(false);
+  });
+});
+
+describe("runChartContextLoadsInParallel", () => {
+  it("starts exactly one history and one live request together so live is not delayed by history", async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const delayed = (name: string, milliseconds: number) => () => {
+      events.push(`${name}:start`);
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          events.push(`${name}:end`);
+          resolve();
+        }, milliseconds);
+      });
+    };
+
+    try {
+      const load = runChartContextLoadsInParallel(delayed("history", 250), delayed("live", 100));
+      expect(events).toEqual(["history:start", "live:start"]);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(events).toEqual(["history:start", "live:start", "live:end"]);
+
+      await vi.advanceTimersByTimeAsync(150);
+      await load;
+      expect(events).toEqual(["history:start", "live:start", "live:end", "history:end"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/src/pages/bot/botChartLifecycle.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.ts
@@ -84,6 +84,14 @@ export function invalidateChartRequestLanes(lanes: readonly LatestRequestCoordin
   }
 }
 
+/** Start independent chart-history and live-price lanes without serial latency. */
+export async function runChartContextLoadsInParallel(
+  loadCandles: () => Promise<unknown>,
+  loadLivePrice: () => Promise<unknown>,
+): Promise<void> {
+  await Promise.allSettled([loadCandles(), loadLivePrice()]);
+}
+
 export type ChartViewportMutation = "refresh" | "pagination" | "live";
 
 export interface PreservedLogicalViewport {

--- a/frontend/src/pages/bot/botChartLifecycle.ts
+++ b/frontend/src/pages/bot/botChartLifecycle.ts
@@ -84,6 +84,364 @@ export function invalidateChartRequestLanes(lanes: readonly LatestRequestCoordin
   }
 }
 
+export type RequestPriority = "foreground" | "background";
+
+export interface PrioritizedRequestSchedulerOptions {
+  /** Maximum number of tasks that may be running at once. */
+  maxConcurrency?: number;
+  /** Maximum number of running tasks that started as background work. */
+  maxBackgroundConcurrency?: number;
+  /** Minimum elapsed time between the starts of two background tasks. */
+  minBackgroundStartIntervalMs?: number;
+}
+
+export interface ScheduledRequestOptions {
+  /** Foreground by default so user-visible work is never accidentally deprioritized. */
+  priority?: RequestPriority;
+  /** Cancels only this subscription to a shared task. */
+  signal?: AbortSignal;
+}
+
+export type ScheduledRequestTask<TResult> = (
+  signal: AbortSignal,
+) => PromiseLike<TResult> | TResult;
+
+type ScheduledEntryState = "queued" | "active" | "detached" | "settled";
+
+interface RequestSubscriber {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (reason?: unknown) => void;
+  readonly signal?: AbortSignal;
+  abortListener?: () => void;
+  settled: boolean;
+}
+
+interface ScheduledEntry<TKey> {
+  readonly key: TKey;
+  readonly task: ScheduledRequestTask<unknown>;
+  readonly controller: AbortController;
+  readonly subscribers: Set<RequestSubscriber>;
+  priority: RequestPriority;
+  state: ScheduledEntryState;
+  startedAsBackground: boolean;
+}
+
+/**
+ * Runs deduplicated async work with separate foreground and background limits.
+ *
+ * Every exact key has at most one live queued/running task. Later callers with
+ * the same key subscribe to the first task, so a key must identify all inputs
+ * that affect both the request and its result type. Subscriber abort signals
+ * are independent; the shared task is aborted only after its final subscriber
+ * leaves. A transport that ignores abort is harmless because detached
+ * subscribers have already been rejected and are never resolved later.
+ */
+export class PrioritizedRequestScheduler<TKey = string> {
+  private readonly maxConcurrency: number;
+  private readonly maxBackgroundConcurrency: number;
+  private readonly minBackgroundStartIntervalMs: number;
+  private readonly entriesByKey = new Map<TKey, ScheduledEntry<TKey>>();
+  private readonly queuedEntries: ScheduledEntry<TKey>[] = [];
+  private readonly activeEntries = new Set<ScheduledEntry<TKey>>();
+  private activeBackgroundTasks = 0;
+  private lastBackgroundStartTime: number | null = null;
+  private backgroundStartTimer: ReturnType<typeof setTimeout> | null = null;
+  private backgroundStartTimerDueAt: number | null = null;
+  private pumping = false;
+
+  constructor(options: PrioritizedRequestSchedulerOptions = {}) {
+    this.maxConcurrency = positiveInteger(options.maxConcurrency ?? 2, "maxConcurrency");
+    this.maxBackgroundConcurrency = nonNegativeInteger(
+      options.maxBackgroundConcurrency ?? 1,
+      "maxBackgroundConcurrency",
+    );
+    this.minBackgroundStartIntervalMs = nonNegativeFiniteNumber(
+      options.minBackgroundStartIntervalMs ?? 0,
+      "minBackgroundStartIntervalMs",
+    );
+  }
+
+  /**
+   * Subscribe to keyed work, creating the underlying task only for the first
+   * subscriber. A queued background task is upgraded when a foreground caller
+   * subscribes to the same key.
+   */
+  schedule<TResult>(
+    key: TKey,
+    task: ScheduledRequestTask<TResult>,
+    options: ScheduledRequestOptions = {},
+  ): Promise<TResult> {
+    const priority = options.priority ?? "foreground";
+    const subscriberSignal = options.signal;
+    if (subscriberSignal?.aborted) {
+      return Promise.reject(abortReason(subscriberSignal));
+    }
+
+    let entry = this.entriesByKey.get(key);
+    if (!entry) {
+      entry = {
+        key,
+        task: task as ScheduledRequestTask<unknown>,
+        controller: new AbortController(),
+        subscribers: new Set(),
+        priority,
+        state: "queued",
+        startedAsBackground: false,
+      };
+      this.entriesByKey.set(key, entry);
+      this.queuedEntries.push(entry);
+    } else if (entry.state === "queued" && priority === "foreground") {
+      entry.priority = "foreground";
+    }
+
+    const promise = new Promise<TResult>((resolve, reject) => {
+      const subscriber: RequestSubscriber = {
+        resolve: (value) => resolve(value as TResult),
+        reject,
+        signal: subscriberSignal,
+        settled: false,
+      };
+      entry.subscribers.add(subscriber);
+
+      if (subscriberSignal) {
+        const abortListener = () => {
+          this.abortSubscriber(entry, subscriber, abortReason(subscriberSignal));
+        };
+        subscriber.abortListener = abortListener;
+        subscriberSignal.addEventListener("abort", abortListener, { once: true });
+
+        // Close the small race between the initial check and listener setup.
+        if (subscriberSignal.aborted) {
+          abortListener();
+        }
+      }
+    });
+
+    this.pump();
+    return promise;
+  }
+
+  get activeCount(): number {
+    return this.activeEntries.size;
+  }
+
+  get queuedCount(): number {
+    return this.queuedEntries.length;
+  }
+
+  get activeBackgroundCount(): number {
+    return this.activeBackgroundTasks;
+  }
+
+  get queuedForegroundCount(): number {
+    return this.queuedEntries.reduce(
+      (count, entry) => count + (entry.priority === "foreground" ? 1 : 0),
+      0,
+    );
+  }
+
+  get queuedBackgroundCount(): number {
+    return this.queuedEntries.reduce(
+      (count, entry) => count + (entry.priority === "background" ? 1 : 0),
+      0,
+    );
+  }
+
+  private abortSubscriber(
+    entry: ScheduledEntry<TKey>,
+    subscriber: RequestSubscriber,
+    reason: unknown,
+  ): void {
+    if (subscriber.settled) {
+      return;
+    }
+
+    this.settleSubscriber(subscriber, "reject", reason);
+    entry.subscribers.delete(subscriber);
+    if (entry.subscribers.size > 0) {
+      return;
+    }
+
+    // Remove the key immediately so a later caller can start fresh rather than
+    // joining an abort-unaware transport whose shared signal is already dead.
+    if (this.entriesByKey.get(entry.key) === entry) {
+      this.entriesByKey.delete(entry.key);
+    }
+
+    if (entry.state === "queued") {
+      this.removeQueuedEntry(entry);
+      entry.state = "settled";
+      entry.controller.abort(reason);
+      this.pump();
+      return;
+    }
+
+    if (entry.state === "active") {
+      entry.state = "detached";
+      entry.controller.abort(reason);
+    }
+  }
+
+  private pump(): void {
+    if (this.pumping) {
+      return;
+    }
+
+    this.pumping = true;
+    try {
+      while (this.activeEntries.size < this.maxConcurrency) {
+        const entry = this.takeNextRunnableEntry();
+        if (!entry) {
+          break;
+        }
+        this.startEntry(entry);
+      }
+
+      if (!this.queuedEntries.some((entry) => entry.priority === "background")) {
+        this.clearBackgroundStartTimer();
+      }
+    } finally {
+      this.pumping = false;
+    }
+  }
+
+  private takeNextRunnableEntry(): ScheduledEntry<TKey> | null {
+    const foregroundIndex = this.queuedEntries.findIndex(
+      (entry) => entry.priority === "foreground",
+    );
+    if (foregroundIndex >= 0) {
+      return this.queuedEntries.splice(foregroundIndex, 1)[0] ?? null;
+    }
+
+    const backgroundIndex = this.queuedEntries.findIndex(
+      (entry) => entry.priority === "background",
+    );
+    if (
+      backgroundIndex < 0 ||
+      this.activeBackgroundTasks >= this.maxBackgroundConcurrency
+    ) {
+      return null;
+    }
+
+    const waitMs = this.backgroundStartWaitMs();
+    if (waitMs > 0) {
+      this.scheduleBackgroundStart(waitMs);
+      return null;
+    }
+
+    return this.queuedEntries.splice(backgroundIndex, 1)[0] ?? null;
+  }
+
+  private startEntry(entry: ScheduledEntry<TKey>): void {
+    entry.state = "active";
+    entry.startedAsBackground = entry.priority === "background";
+    this.activeEntries.add(entry);
+    if (entry.startedAsBackground) {
+      this.activeBackgroundTasks += 1;
+      this.lastBackgroundStartTime = Date.now();
+    }
+
+    let result: PromiseLike<unknown> | unknown;
+    try {
+      result = entry.task(entry.controller.signal);
+    } catch (error) {
+      this.finishEntry(entry, "reject", error);
+      return;
+    }
+
+    Promise.resolve(result).then(
+      (value) => this.finishEntry(entry, "resolve", value),
+      (error: unknown) => this.finishEntry(entry, "reject", error),
+    );
+  }
+
+  private finishEntry(
+    entry: ScheduledEntry<TKey>,
+    outcome: "resolve" | "reject",
+    value: unknown,
+  ): void {
+    if (entry.state !== "active" && entry.state !== "detached") {
+      return;
+    }
+
+    this.activeEntries.delete(entry);
+    if (entry.startedAsBackground) {
+      this.activeBackgroundTasks -= 1;
+    }
+    if (this.entriesByKey.get(entry.key) === entry) {
+      this.entriesByKey.delete(entry.key);
+    }
+    entry.state = "settled";
+
+    for (const subscriber of entry.subscribers) {
+      this.settleSubscriber(subscriber, outcome, value);
+    }
+    entry.subscribers.clear();
+    this.pump();
+  }
+
+  private settleSubscriber(
+    subscriber: RequestSubscriber,
+    outcome: "resolve" | "reject",
+    value: unknown,
+  ): void {
+    if (subscriber.settled) {
+      return;
+    }
+    subscriber.settled = true;
+    if (subscriber.signal && subscriber.abortListener) {
+      subscriber.signal.removeEventListener("abort", subscriber.abortListener);
+    }
+    if (outcome === "resolve") {
+      subscriber.resolve(value);
+    } else {
+      subscriber.reject(value);
+    }
+  }
+
+  private removeQueuedEntry(entry: ScheduledEntry<TKey>): void {
+    const index = this.queuedEntries.indexOf(entry);
+    if (index >= 0) {
+      this.queuedEntries.splice(index, 1);
+    }
+  }
+
+  private backgroundStartWaitMs(): number {
+    if (this.lastBackgroundStartTime === null) {
+      return 0;
+    }
+    const nextStartTime =
+      this.lastBackgroundStartTime + this.minBackgroundStartIntervalMs;
+    return Math.max(0, nextStartTime - Date.now());
+  }
+
+  private scheduleBackgroundStart(waitMs: number): void {
+    const dueAt = Date.now() + waitMs;
+    if (
+      this.backgroundStartTimer !== null &&
+      this.backgroundStartTimerDueAt !== null &&
+      this.backgroundStartTimerDueAt <= dueAt
+    ) {
+      return;
+    }
+    this.clearBackgroundStartTimer();
+    this.backgroundStartTimerDueAt = dueAt;
+    this.backgroundStartTimer = setTimeout(() => {
+      this.backgroundStartTimer = null;
+      this.backgroundStartTimerDueAt = null;
+      this.pump();
+    }, waitMs);
+  }
+
+  private clearBackgroundStartTimer(): void {
+    if (this.backgroundStartTimer !== null) {
+      clearTimeout(this.backgroundStartTimer);
+      this.backgroundStartTimer = null;
+      this.backgroundStartTimerDueAt = null;
+    }
+  }
+}
+
 export type ChartViewportMutation = "refresh" | "pagination" | "live";
 
 export interface PreservedLogicalViewport {
@@ -95,6 +453,34 @@ export interface PreservedLogicalViewport {
 interface ViewportRestoreOptions {
   /** Bars from the final candle that still count as following live data. */
   liveEdgeTolerance?: number;
+}
+
+/** Stores independent logical ranges for chart contexts such as timeframes. */
+export class LogicalViewportMemory<TKey = string> {
+  private readonly ranges = new Map<TKey, LogicalRange>();
+
+  /** Saves a defensive copy of a valid range; invalid transient ranges are ignored. */
+  save(key: TKey, range: LogicalRange | null): boolean {
+    if (!isValidLogicalRange(range)) {
+      return false;
+    }
+    this.ranges.set(key, cloneLogicalRange(range));
+    return true;
+  }
+
+  /** Returns a defensive copy so chart-library mutations cannot corrupt memory. */
+  restore(key: TKey): LogicalRange | null {
+    const range = this.ranges.get(key);
+    return range ? cloneLogicalRange(range) : null;
+  }
+
+  delete(key: TKey): boolean {
+    return this.ranges.delete(key);
+  }
+
+  clear(): void {
+    this.ranges.clear();
+  }
 }
 
 /**
@@ -223,6 +609,35 @@ function isValidLogicalRange(range: LogicalRange | null): range is LogicalRange 
   return Number.isFinite(from) && Number.isFinite(to) && from <= to;
 }
 
+function cloneLogicalRange(range: LogicalRange): LogicalRange {
+  return { from: range.from, to: range.to };
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
   return Math.min(maximum, Math.max(minimum, value));
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function nonNegativeFiniteNumber(value: number, name: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }

--- a/frontend/src/pages/bot/botDrawingStorage.test.ts
+++ b/frontend/src/pages/bot/botDrawingStorage.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./botDrawingStorage";
 
 const scope: BotDrawingStorageScope = {
+  userScope: "user:one",
   botId: 42,
   contractId: "CON.F.US.MNQ.U26",
   timeframe: "5m",
@@ -22,13 +23,15 @@ const scope: BotDrawingStorageScope = {
 describe("buildBotDrawingStorageKey", () => {
   it("normalizes casing but keeps bot, contract, and timeframe scopes isolated", () => {
     expect(buildBotDrawingStorageKey(scope)).toBe(
-      buildBotDrawingStorageKey({ botId: 42, contractId: " con.f.us.mnq.u26 ", timeframe: " 5M " }),
+      buildBotDrawingStorageKey({ userScope: "user:one", botId: 42, contractId: " con.f.us.mnq.u26 ", timeframe: " 5M " }),
     );
     expect(buildBotDrawingStorageKey({ ...scope, botId: 43 })).not.toBe(buildBotDrawingStorageKey(scope));
     expect(buildBotDrawingStorageKey({ ...scope, contractId: "CON.F.US.ES.U26" })).not.toBe(
       buildBotDrawingStorageKey(scope),
     );
     expect(buildBotDrawingStorageKey({ ...scope, timeframe: "15m" })).not.toBe(buildBotDrawingStorageKey(scope));
+    expect(buildBotDrawingStorageKey({ ...scope, userScope: "user:two" })).not.toBe(buildBotDrawingStorageKey(scope));
+    expect(buildBotDrawingStorageKey(scope)).toContain("topsignal:bot-chart-drawings:v2:");
   });
 });
 
@@ -45,6 +48,15 @@ describe("drawing persistence", () => {
 
     expect(clearBotDrawings(scope, storage)).toBe(true);
     expect(readBotDrawings(scope, storage)).toEqual([]);
+  });
+
+  it("invalidates an unscoped v1 payload instead of migrating it to a user", () => {
+    const storage = new MemoryStorage();
+    const legacyKey = "topsignal:bot-chart-drawings:v1:42%7CCON.F.US.MNQ.U26%7C5m";
+    storage.setItem(legacyKey, JSON.stringify({ version: 1, drawings: [drawing("legacy", "line")] }));
+
+    expect(readBotDrawings(scope, storage)).toEqual([]);
+    expect(storage.getItem(legacyKey)).toBeNull();
   });
 
   it("returns an empty collection for malformed JSON, unsupported versions, and invalid envelopes", () => {

--- a/frontend/src/pages/bot/botDrawingStorage.ts
+++ b/frontend/src/pages/bot/botDrawingStorage.ts
@@ -1,7 +1,8 @@
 import type { Logical, UTCTimestamp } from "lightweight-charts";
 
-export const BOT_DRAWING_STORAGE_VERSION = 1;
+export const BOT_DRAWING_STORAGE_VERSION = 2;
 export const BOT_DRAWING_STORAGE_KEY_PREFIX = `topsignal:bot-chart-drawings:v${BOT_DRAWING_STORAGE_VERSION}:`;
+const LEGACY_BOT_DRAWING_STORAGE_KEY_PREFIX = "topsignal:bot-chart-drawings:v1:";
 export const MAX_PERSISTED_BOT_DRAWINGS = 250;
 
 export type BotDrawingKind = "line" | "rectangle";
@@ -20,6 +21,8 @@ export interface BotDrawingShape {
 }
 
 export interface BotDrawingStorageScope {
+  /** Stable non-secret authenticated-user namespace. */
+  userScope: string;
   botId: number;
   contractId: string;
   /** Stable chart timeframe identifier, for example "5m" or "1h". */
@@ -38,10 +41,11 @@ interface BotDrawingStoragePayload {
 }
 
 export function buildBotDrawingStorageKey(scope: BotDrawingStorageScope): string {
+  const userScope = scope.userScope.trim();
   const botId = Number.isFinite(scope.botId) ? String(Math.trunc(scope.botId)) : "invalid";
   const contractId = scope.contractId.trim().toUpperCase();
   const timeframe = scope.timeframe.trim().toLowerCase();
-  return `${BOT_DRAWING_STORAGE_KEY_PREFIX}${encodeURIComponent(`${botId}|${contractId}|${timeframe}`)}`;
+  return `${BOT_DRAWING_STORAGE_KEY_PREFIX}${encodeURIComponent(`${userScope}|${botId}|${contractId}|${timeframe}`)}`;
 }
 
 export function readBotDrawings(
@@ -52,6 +56,7 @@ export function readBotDrawings(
     return [];
   }
   try {
+    removeLegacyBotDrawings(scope, storage);
     return parseBotDrawings(storage.getItem(buildBotDrawingStorageKey(scope)));
   } catch {
     return [];
@@ -66,6 +71,8 @@ export function writeBotDrawings(
   if (!storage) {
     return false;
   }
+
+  removeLegacyBotDrawings(scope, storage);
 
   const sanitizedDrawings = sanitizeDrawings(drawings);
   if (sanitizedDrawings.length === 0) {
@@ -92,6 +99,7 @@ export function clearBotDrawings(
     return false;
   }
   try {
+    removeLegacyBotDrawings(scope, storage);
     storage.removeItem(buildBotDrawingStorageKey(scope));
     return true;
   } catch {
@@ -169,4 +177,19 @@ function getBrowserStorage(): BotDrawingStorageAdapter | null {
   } catch {
     return null;
   }
+}
+
+function removeLegacyBotDrawings(scope: BotDrawingStorageScope, storage: BotDrawingStorageAdapter): void {
+  try {
+    storage.removeItem(buildLegacyBotDrawingStorageKey(scope));
+  } catch {
+    // Access failures are intentionally contained by the public operations.
+  }
+}
+
+function buildLegacyBotDrawingStorageKey(scope: BotDrawingStorageScope): string {
+  const botId = Number.isFinite(scope.botId) ? String(Math.trunc(scope.botId)) : "invalid";
+  const contractId = scope.contractId.trim().toUpperCase();
+  const timeframe = scope.timeframe.trim().toLowerCase();
+  return `${LEGACY_BOT_DRAWING_STORAGE_KEY_PREFIX}${encodeURIComponent(`${botId}|${contractId}|${timeframe}`)}`;
 }


### PR DESCRIPTION
## Summary

Integrates and reviews the completed Bot-page, candle, signal-chart, full-history, and backtest-engine performance work. The review focused on correctness, concurrency, caching, user isolation, and data integrity, and fixes the integration defects found along the way.

## Source provenance

- Base: `eb2b4333e575ab7ba96a998d24359126265b0fd1`
- Bot-page snapshot: `e5927b7833ba9dfd85dbcff71e71f527c5e76397`
- Automatic candle repair: `3f9455984fd576d6c7f63cb70275cdd62d5eff94`
- Signal-chart performance: `2eea5ebd9368c3c04433cb03293ead629025d3ff`
- Full-history backtests: `02a659cd61dce93d2a3c9ba74d9982cbafa76fd1`
- Backtest engine performance: `9610a9a79e78c3b9dd06e79cb6ff89eb17dd84cc`

## What changed

- Split critical Bot-page loading from secondary account/analysis work so startup warming never blocks the app.
- Scoped account, candle, drawing, request-scheduler, and in-flight caches to the authenticated user.
- Added stale-response rejection, cancellation, request prioritization, exact-key deduplication, and parallel history/live chart loading.
- Added bounded automatic candle-gap repair and product-aware CME equity halt/holiday handling in both backend and chart gap classification.
- Made candle writes closed-wins across same-batch, SQLite, PostgreSQL, and concurrent paths while still allowing partial bars to become closed.
- Added per-user single-flight provider retrieval to collapse identical concurrent candle requests.
- Removed silent full-history truncation and added exact cache coverage, boundary, overlap, and effectively-partial checks.
- Added an explicit 40-request provider budget, cumulative memory budget, and evaluator-work budget; failures roll back without persisting a partial backtest.
- Added projected candle loading, shared physical replay streams, stable incremental fingerprints, and a reproducible benchmark harness.
- Kept backtests deterministic and pure; authenticated backtest routes cannot submit provider orders.

## Validation

- Backend: `512 passed in 8.54s`
- Frontend: `355 passed in 2.47s`
- Focused safety/integration checks: `16 passed in 2.95s`
- ESLint: `0 errors` (one unrelated existing Dashboard hook warning remains)
- Production build: `4.02s`; BotPage `410.33 kB` / `109.77 kB gzip`

Performance and request-count checks:

- Startup lifespan: `<5ms`, zero provider/backtest calls.
- Eight identical concurrent candle requests: one upstream call in `0.05s`.
- Open-session gap repair: one provider request; weekend, holiday, and equity-halt closures: zero.
- Warm chart switch: zero requests; cold switch: one foreground plus one background request.
- Parallel chart context load: `250ms` critical path versus `350ms` if serialized in the lifecycle test.
- Two byte-identical 20,001-bar replays: `1.52s`, with no truncation.
- 20k-bar benchmark: SMA median `1.131s` / `13.94 MiB`; HOLD `0.609s` / `11.90 MiB`, with stable semantic hashes.
- 5k SQLite public path: `0.299s`, exactly four statements, three SELECTs, and one candle SELECT per run.

## Remaining risks

- ProjectX exposes no end-of-history marker, so the oldest boundary is inferred after 14 consecutive empty calendar days and fails explicitly at the request budget.
- Provider single-flight is process-local; multiple application workers can still duplicate an upstream request.
- CME holiday schedules are maintained in code and need periodic review when the exchange revises holiday hours.
- Very long backtests still return full equity/drawdown arrays, making response serialization and transfer the primary remaining scaling concern.
- No authenticated live-ProjectX browser E2E was run; unit/integration/build and local-server checks passed.
