### PR TITLE
Optimize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,17 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  verify:
+  database:
+    name: Database migrations
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -28,25 +35,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: backend/requirements.txt
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          npm --prefix frontend ci
-          python -m pip install -r backend/requirements.txt
+      - name: Install backend dependencies
+        run: python -m pip install --disable-pip-version-check -r backend/requirements.txt
 
       - name: Validate fresh PostgreSQL schema and migrations
         env:
@@ -157,14 +153,64 @@ jobs:
             --adopt-current --acknowledge-populated-database
           DATABASE_URL="$ADOPT_DATABASE_URL" python backend/tools/migrate_db.py --check
 
-      - name: Backend tests
+  backend_tests:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    env:
+      AUTH_REQUIRED: "true"
+      TOPSIGNAL_DB_SCHEMA_INIT: skip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: python -m pip install --disable-pip-version-check -r backend/requirements.txt
+
+      - name: Run backend tests
         working-directory: backend
         env:
           DATABASE_URL: "sqlite+pysqlite:///:memory:"
         run: python -m pytest -q
 
-      - name: Frontend tests
+  frontend_tests:
+    name: Frontend tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm --prefix frontend ci --no-audit --fund=false
+
+      - name: Run frontend tests
         run: npm --prefix frontend test
+
+  frontend_quality:
+    name: Frontend quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm --prefix frontend ci --no-audit --fund=false
 
       - name: Frontend lint
         run: npm --prefix frontend run lint -- --max-warnings=0
@@ -176,3 +222,20 @@ jobs:
         run: |
           npm audit
           node scripts/audit-frontend.cjs
+
+  verify:
+    name: verify
+    if: ${{ always() }}
+    needs:
+      - database
+      - backend_tests
+      - frontend_tests
+      - frontend_quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all CI lanes passed
+        run: |
+          test "${{ needs.database.result }}" = "success"
+          test "${{ needs.backend_tests.result }}" = "success"
+          test "${{ needs.frontend_tests.result }}" = "success"
+          test "${{ needs.frontend_quality.result }}" = "success"


### PR DESCRIPTION
## What changed

- Restrict push-triggered CI runs to `main` while continuing to verify pull requests targeting `main`.
- Cancel superseded runs for the same PR or branch.
- Split database migrations, backend tests, frontend tests, and frontend quality checks into parallel jobs.
- Preserve a final `verify` gate for a single required-check target.
- Avoid redundant install-time audits while retaining explicit dependency audit steps.

## Why

The previous workflow ran every check sequentially in one job and triggered duplicate workflows for both a feature-branch push and its pull request. A successful run took roughly two and a half minutes and consumed duplicate runner time.

## Impact

The same validation coverage now runs in parallel, with expected wall-clock time around 60–90 seconds. Outdated runs are canceled automatically.

## Validation

- Workflow YAML syntax and job structure validated locally.
- Backend suite: 830 tests passed.
- Frontend lint and production build passed.
- The two timing-sensitive frontend integration tests that timed out in the full Windows suite passed independently; the latest Ubuntu CI run on `main` passed the complete frontend suite.