### PR TITLE
Improve compact dashboard and Live account imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ A user can:
 - override the provider account name with a local display name
 - use the dashboard's `Live Account (CSV)` control to switch to a separate
   local Live account backed by manually imported Topstep trades
+- create Live accounts with a name and opening balance; TopSignal generates and
+  hides the internal routing key and derives current balance from imported net P&L
 - merge journal history from an older account into a replacement account
 - resolve the last trade timestamp from the provider when local data is stale or absent
 
@@ -438,10 +440,13 @@ Repeated or truncated provider pages keep the day marked `partial` rather than `
 #### Topstep Live file import
 
 The dashboard accepts Topstep `.csv` and `.xlsx` trade exports in two phases.
-Use `Add Live Account` to create a local, read-only account from the Topstep
-Live account number. The `Live Account (CSV)` control then selects that
-separate account; it never repurposes the selected Express account. Selecting a
-Live account turns off Copy Trade Mode and prevents paused Express accounts
+Use `Add Live Account` to create a local, read-only account from the account
+name and opening balance shown by Topstep. TopSignal adds imported all-time net
+P&L to that opening balance and generates a hidden internal routing key, so no
+account ID is requested or displayed for Live accounts. The `Live Account
+(CSV)` control then selects that separate account; it never repurposes the
+selected Express account. Selecting a Live account turns off Copy Trade Mode
+and prevents paused Express accounts
 from being auto-selected as copy followers.
 
 1. preview parses and validates the file, calculates new-row gross P&L,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1519,6 +1519,11 @@ def list_projectx_accounts(
         if account_id is not None
     ]
     last_trade_by_account_id = _load_last_trade_timestamps(db, user_id=user_id, account_ids=account_ids)
+    csv_import_current_balances = _load_csv_import_current_balances(
+        db,
+        user_id=user_id,
+        rows=visible_rows,
+    )
 
     payload: list[dict[str, object]] = []
     for row in visible_rows:
@@ -1546,6 +1551,7 @@ def list_projectx_accounts(
                 provider_sync_status=provider_sync_status,
                 provider_sync_error_code=provider_error_code,
                 provider_sync_error_message=provider_error_message,
+                csv_import_current_balance=csv_import_current_balances.get(account_id),
             )
         )
 
@@ -1597,24 +1603,17 @@ def create_topstep_live_import_target(
     db: Session = Depends(get_db),
 ):
     user_id = get_authenticated_user_id()
-    _validate_account_id(payload.account_id)
 
     try:
         with serialize_account_main_mutation(db, user_id=user_id):
             row = create_projectx_import_account(
                 db,
                 user_id=user_id,
-                account_id=payload.account_id,
                 name=payload.name,
+                starting_balance=payload.starting_balance,
             )
             db.commit()
             db.refresh(row)
-    except AccountTradeDataSourceConflictError as exc:
-        db.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=_trade_data_source_conflict_detail(exc),
-        ) from exc
     except ValueError as exc:
         db.rollback()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1626,30 +1625,26 @@ def create_topstep_live_import_target(
         ) from exc
     except IntegrityError as exc:
         db.rollback()
-        row = get_projectx_account_row(
-            db,
-            payload.account_id,
-            user_id=user_id,
-        )
-        if row is None:
-            raise HTTPException(
-                status_code=409,
-                detail=_retryable_main_account_conflict_detail(payload.account_id),
-            ) from exc
-        if row.trade_data_source != TRADE_DATA_SOURCE_CSV_IMPORT:
-            conflict = AccountTradeDataSourceConflictError(
-                account_id=payload.account_id,
-                current_trade_data_source=row.trade_data_source,
-                requested_trade_data_source=TRADE_DATA_SOURCE_CSV_IMPORT,
-            )
-            raise HTTPException(
-                status_code=409,
-                detail=_trade_data_source_conflict_detail(conflict),
-            ) from exc
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "live_account_create_conflict_retryable",
+                "message": (
+                    "Another Live account change completed at the same time. "
+                    "Reload accounts and retry."
+                ),
+                "retryable": True,
+            },
+        ) from exc
 
     account_id = account_id_from_external_id(row.external_id)
     if account_id is None:
         raise HTTPException(status_code=500, detail="invalid_stored_account_id")
+    csv_import_current_balances = _load_csv_import_current_balances(
+        db,
+        user_id=user_id,
+        rows=[row],
+    )
     return _serialize_projectx_account(
         row,
         account_id=account_id,
@@ -1657,6 +1652,7 @@ def create_topstep_live_import_target(
         provider_snapshot_freshness=_projectx_account_snapshot_freshness(
             row.last_seen_at,
         ),
+        csv_import_current_balance=csv_import_current_balances.get(account_id),
     )
 
 
@@ -1703,6 +1699,11 @@ def update_projectx_account_trade_data_source(
         row,
         account_id=account_id,
         last_trade_at=last_trade_at,
+        csv_import_current_balance=_load_csv_import_current_balances(
+            db,
+            user_id=user_id,
+            rows=[row],
+        ).get(account_id),
         # This mutation does not contact ProjectX, so preserve the cache age
         # established by the most recent successful account refresh.
         provider_snapshot_freshness=_projectx_account_snapshot_freshness(
@@ -4171,6 +4172,28 @@ def _load_last_trade_timestamps(db: Session, *, user_id: str, account_ids: list[
     return output
 
 
+def _load_csv_import_current_balances(
+    db: Session,
+    *,
+    user_id: str,
+    rows: list[Account],
+) -> dict[int, float]:
+    output: dict[int, float] = {}
+    for row in rows:
+        if row.trade_data_source != TRADE_DATA_SOURCE_CSV_IMPORT or row.balance is None:
+            continue
+        account_id = account_id_from_external_id(row.external_id)
+        if account_id is None:
+            continue
+        summary = summarize_trade_events(db, account_id, user_id=user_id)
+        net_pnl = Decimal(str(summary.get("net_pnl") or 0))
+        current_balance = Decimal(str(row.balance)) + net_pnl
+        output[account_id] = float(
+            current_balance.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        )
+    return output
+
+
 def _provider_account_payloads_by_external_id(
     provider_accounts: list[dict[str, object]],
 ) -> dict[str, dict[str, object]]:
@@ -4310,6 +4333,7 @@ def _serialize_projectx_account(
     provider_sync_status: str | None = None,
     provider_sync_error_code: str | None = None,
     provider_sync_error_message: str | None = None,
+    csv_import_current_balance: float | None = None,
 ) -> dict[str, object]:
     trade_data_source = (
         row.trade_data_source
@@ -4357,10 +4381,10 @@ def _serialize_projectx_account(
         "name": effective_name,
         "provider_name": provider_name,
         "custom_display_name": row.display_name,
-        # CSV exports do not carry a current balance or provider capability
-        # state. Preserve cached values in the database for a later switch back
-        # to ProjectX, but never present them as current in CSV mode.
-        "balance": None
+        # Local Live accounts use their stored opening balance plus all-time
+        # imported net P&L. Provider-backed accounts continue to prefer the
+        # provider's current balance.
+        "balance": csv_import_current_balance
         if is_csv_import
         else (
             float(provider_balance)

--- a/backend/app/projectx_schemas.py
+++ b/backend/app/projectx_schemas.py
@@ -38,8 +38,12 @@ class ProjectXAccountOut(BaseModel):
 
 
 class TopstepLiveAccountCreateIn(BaseModel):
-    account_id: int = Field(gt=0, le=9_223_372_036_854_775_807)
-    name: str | None = None
+    name: str
+    starting_balance: float | None = Field(
+        default=None,
+        gt=0,
+        le=1_000_000_000,
+    )
 
 
 class ProjectXAccountTradeDataSourceIn(BaseModel):

--- a/backend/app/services/projectx_accounts.py
+++ b/backend/app/services/projectx_accounts.py
@@ -27,7 +27,12 @@ TRADE_DATA_SOURCES = {
     TRADE_DATA_SOURCE_CSV_IMPORT,
 }
 ACCOUNT_DISPLAY_NAME_MAX_LENGTH = 120
-MAX_PROJECTX_ACCOUNT_ID = 9_223_372_036_854_775_807
+# Live CSV accounts still need a numeric key for authenticated API routes and
+# relational ownership, but that key is an application detail rather than a
+# provider identifier. Keep generated values inside JavaScript's safe integer
+# range so clients can route requests without ever asking the user for an ID.
+LOCAL_LIVE_ACCOUNT_ID_MIN = 8_000_000_000_000_000
+LOCAL_LIVE_ACCOUNT_ID_MAX = 9_007_199_254_740_991
 _ACCOUNT_MAIN_LOCK_STRIPES = tuple(RLock() for _ in range(256))
 
 
@@ -217,42 +222,54 @@ def get_projectx_account_row(
 def create_projectx_import_account(
     db: Session,
     *,
-    account_id: int,
-    name: str | None = None,
+    name: str,
+    starting_balance: float | None = None,
     user_id: str | None = None,
 ) -> Account:
     resolved_user_id = _resolve_user_id(user_id)
-    external_id = normalize_projectx_account_external_id(account_id)
-    if external_id is None:
-        raise ValueError("Account ID must be a positive integer.")
-    if int(external_id) > MAX_PROJECTX_ACCOUNT_ID:
-        raise ValueError("Account ID is outside the supported range.")
-
-    existing = get_projectx_account_row(
-        db,
-        int(external_id),
-        user_id=resolved_user_id,
-    )
-    if existing is not None:
-        if existing.trade_data_source == TRADE_DATA_SOURCE_CSV_IMPORT:
-            if existing.archived_at is not None:
-                raise LiveAccountArchivedError(account_id=int(external_id))
-            return existing
-        raise AccountTradeDataSourceConflictError(
-            account_id=int(external_id),
-            current_trade_data_source=existing.trade_data_source,
-            requested_trade_data_source=TRADE_DATA_SOURCE_CSV_IMPORT,
-        )
-
     normalized_name = _normalize_optional_text(name)
     if normalized_name is None:
-        normalized_name = f"Topstep Live {external_id}"
+        raise ValueError("Account name cannot be empty.")
     if len(normalized_name) > ACCOUNT_DISPLAY_NAME_MAX_LENGTH:
         raise ValueError(
             f"Account name must be {ACCOUNT_DISPLAY_NAME_MAX_LENGTH} characters or fewer."
         )
     if _has_control_character(normalized_name):
         raise ValueError("Account name cannot contain control characters.")
+    if starting_balance is not None and (
+        not math.isfinite(starting_balance)
+        or starting_balance <= 0
+        or starting_balance > 1_000_000_000
+    ):
+        raise ValueError("Starting balance must be between 0 and 1,000,000,000.")
+
+    # Treat a repeated name-only request as idempotent. The route serializes
+    # this lookup and creation per user, including across PostgreSQL workers.
+    existing_live_rows = (
+        db.query(Account)
+        .filter(Account.user_id == resolved_user_id)
+        .filter(Account.provider == ACCOUNT_PROVIDER)
+        .filter(Account.trade_data_source == TRADE_DATA_SOURCE_CSV_IMPORT)
+        .order_by(Account.created_at.asc(), Account.id.asc())
+        .all()
+    )
+    normalized_name_key = normalized_name.casefold()
+    for existing in existing_live_rows:
+        effective_name = _normalize_optional_text(existing.display_name) or _normalize_optional_text(
+            existing.name
+        )
+        if effective_name is None or effective_name.casefold() != normalized_name_key:
+            continue
+        existing_account_id = account_id_from_external_id(existing.external_id)
+        if existing_account_id is None:
+            continue
+        if existing.archived_at is not None:
+            raise LiveAccountArchivedError(account_id=existing_account_id)
+        if existing.balance is None and starting_balance is not None:
+            existing.balance = starting_balance
+        return existing
+
+    external_id = str(_next_local_live_account_id(db, user_id=resolved_user_id))
 
     has_main_account = (
         db.query(Account.id)
@@ -271,11 +288,35 @@ def create_projectx_import_account(
         account_state=ACCOUNT_STATE_ACTIVE,
         can_trade=None,
         is_visible=True,
+        # For a local Live account, balance is the user-supplied opening
+        # balance. The API adds the account's all-time net P&L when returning
+        # the current balance.
+        balance=starting_balance,
         is_main=not has_main_account,
     )
     db.add(row)
     db.flush()
     return row
+
+
+def _next_local_live_account_id(db: Session, *, user_id: str) -> int:
+    used_ids: set[int] = set()
+    for (external_id,) in (
+        db.query(Account.external_id)
+        .filter(Account.user_id == user_id)
+        .filter(Account.provider == ACCOUNT_PROVIDER)
+        .all()
+    ):
+        normalized = normalize_projectx_account_external_id(external_id)
+        if normalized is not None:
+            used_ids.add(int(normalized))
+
+    candidate = LOCAL_LIVE_ACCOUNT_ID_MIN
+    while candidate in used_ids and candidate <= LOCAL_LIVE_ACCOUNT_ID_MAX:
+        candidate += 1
+    if candidate > LOCAL_LIVE_ACCOUNT_ID_MAX:
+        raise ValueError("No internal Live account keys are available.")
+    return candidate
 
 
 def set_projectx_account_trade_data_source(

--- a/backend/tests/test_projectx_account_concurrency.py
+++ b/backend/tests/test_projectx_account_concurrency.py
@@ -11,6 +11,7 @@ from app.db import Base
 from app.main import create_topstep_live_import_target, set_projectx_main_account
 from app.models import Account
 from app.projectx_schemas import TopstepLiveAccountCreateIn
+from app.services.projectx_accounts import LOCAL_LIVE_ACCOUNT_ID_MIN
 
 
 USER_ID = "00000000-0000-0000-0000-000000000000"
@@ -30,27 +31,31 @@ def test_parallel_live_creation_serializes_first_main_assignment(tmp_path):
     engine, SessionLocal = _session_factory(tmp_path)
     start = Barrier(2)
 
-    def create(account_id: int) -> None:
+    def create(name: str) -> None:
         with SessionLocal() as db:
             start.wait(timeout=5)
             result = create_topstep_live_import_target(
-                TopstepLiveAccountCreateIn(
-                    account_id=account_id,
-                    name=f"Live {account_id}",
-                ),
+                TopstepLiveAccountCreateIn(name=name),
                 db=db,
             )
-            assert result["id"] == account_id
+            assert result["id"] in {
+                LOCAL_LIVE_ACCOUNT_ID_MIN,
+                LOCAL_LIVE_ACCOUNT_ID_MIN + 1,
+            }
 
     try:
         with ThreadPoolExecutor(max_workers=2) as executor:
-            futures = [executor.submit(create, account_id) for account_id in (88001, 88002)]
+            futures = [executor.submit(create, name) for name in ("Live Alpha", "Live Bravo")]
             for future in futures:
                 future.result(timeout=10)
 
         with SessionLocal() as db:
             rows = db.query(Account).order_by(Account.external_id.asc()).all()
-            assert [row.external_id for row in rows] == ["88001", "88002"]
+            assert [int(row.external_id) for row in rows] == [
+                LOCAL_LIVE_ACCOUNT_ID_MIN,
+                LOCAL_LIVE_ACCOUNT_ID_MIN + 1,
+            ]
+            assert {row.name for row in rows} == {"Live Alpha", "Live Bravo"}
             assert sum(bool(row.is_main) for row in rows) == 1
     finally:
         Base.metadata.drop_all(bind=engine, tables=[Account.__table__])

--- a/backend/tests/test_projectx_accounts_route.py
+++ b/backend/tests/test_projectx_accounts_route.py
@@ -37,6 +37,7 @@ from app.projectx_schemas import (
     ProjectXAccountTradeDataSourceIn,
     TopstepLiveAccountCreateIn,
 )
+from app.services.projectx_accounts import LOCAL_LIVE_ACCOUNT_ID_MIN
 
 
 @pytest.fixture()
@@ -252,16 +253,17 @@ def test_accounts_route_normalizes_provider_ids_when_attaching_provider_fields(d
 
 def test_create_live_import_target_is_local_missing_and_idempotent(db_session):
     payload = TopstepLiveAccountCreateIn(
-        account_id=88001,
         name="Topstep Live Funded",
+        starting_balance=10_000,
     )
 
     first = create_topstep_live_import_target(payload=payload, db=db_session)
     second = create_topstep_live_import_target(payload=payload, db=db_session)
 
     assert first == second
-    assert first["id"] == 88001
+    assert first["id"] == LOCAL_LIVE_ACCOUNT_ID_MIN
     assert first["name"] == "Topstep Live Funded"
+    assert first["balance"] == pytest.approx(10_000)
     assert first["account_state"] == "ACTIVE"
     assert first["can_trade"] is None
     assert first["is_main"] is True
@@ -271,7 +273,8 @@ def test_create_live_import_target_is_local_missing_and_idempotent(db_session):
     assert db_session.query(Account).count() == 1
 
     row = db_session.query(Account).one()
-    assert row.external_id == "88001"
+    assert row.external_id == str(LOCAL_LIVE_ACCOUNT_ID_MIN)
+    assert float(row.balance) == pytest.approx(10_000)
     assert row.last_seen_at is None
     assert row.last_missing_at is None
 
@@ -292,10 +295,7 @@ def test_create_live_import_target_keeps_existing_csv_account_unchanged(db_sessi
     db_session.commit()
 
     payload = create_topstep_live_import_target(
-        payload=TopstepLiveAccountCreateIn(
-            account_id=88003,
-            name="Replacement Name Must Not Win",
-        ),
+        payload=TopstepLiveAccountCreateIn(name="Topstep Live Existing"),
         db=db_session,
     )
 
@@ -307,11 +307,11 @@ def test_create_live_import_target_keeps_existing_csv_account_unchanged(db_sessi
     assert row.last_missing_at == last_missing_at.replace(tzinfo=None)
 
 
-def test_create_live_import_target_rejects_existing_projectx_account(db_session):
+def test_create_live_import_target_skips_internal_key_used_by_projectx_account(db_session):
     db_session.add(
         Account(
             provider="projectx",
-            external_id="88004",
+            external_id=str(LOCAL_LIVE_ACCOUNT_ID_MIN),
             name="EXPRESS-V2-DLL-192577-19008334",
             trade_data_source="projectx",
             account_state="ACTIVE",
@@ -320,38 +320,22 @@ def test_create_live_import_target_rejects_existing_projectx_account(db_session)
     )
     db_session.commit()
 
-    with pytest.raises(HTTPException) as exc_info:
-        create_topstep_live_import_target(
-            payload=TopstepLiveAccountCreateIn(
-                account_id=88004,
-                name="Topstep Live Funded",
-            ),
-            db=db_session,
-        )
+    payload = create_topstep_live_import_target(
+        payload=TopstepLiveAccountCreateIn(name="Topstep Live Funded"),
+        db=db_session,
+    )
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == {
-        "code": "account_trade_data_source_conflict",
-        "message": (
-            "Account 88004 already uses projectx; cross-source conversion to "
-            "csv_import is not allowed. ProjectX and Live CSV accounts must remain separate."
-        ),
-        "account_id": 88004,
-        "current_trade_data_source": "projectx",
-        "requested_trade_data_source": "csv_import",
-    }
-    row = db_session.query(Account).one()
-    assert row.name == "EXPRESS-V2-DLL-192577-19008334"
-    assert row.trade_data_source == "projectx"
+    assert payload["id"] == LOCAL_LIVE_ACCOUNT_ID_MIN + 1
+    assert payload["name"] == "Topstep Live Funded"
+    assert db_session.query(Account).count() == 2
+    live_row = db_session.query(Account).filter_by(trade_data_source="csv_import").one()
+    assert live_row.external_id == str(LOCAL_LIVE_ACCOUNT_ID_MIN + 1)
 
 
 def test_create_live_import_target_rejects_unsafe_name(db_session):
     with pytest.raises(HTTPException) as exc_info:
         create_topstep_live_import_target(
-            payload=TopstepLiveAccountCreateIn(
-                account_id=88002,
-                name="Unsafe\x00Name",
-            ),
+            payload=TopstepLiveAccountCreateIn(name="Unsafe\x00Name"),
             db=db_session,
         )
 
@@ -432,6 +416,53 @@ def test_accounts_route_explicit_refresh_contacts_projectx_with_only_csv_rows(
     assert [row["id"] for row in payload] == [88011]
     assert payload[0]["trade_data_source"] == "csv_import"
     assert payload[0]["provider_sync_status"] == "not_applicable"
+
+
+def test_live_account_balance_adds_all_time_net_pnl_to_starting_balance(
+    db_session,
+    monkeypatch,
+):
+    db_session.add_all(
+        [
+            Account(
+                provider="projectx",
+                external_id="88062",
+                name="Topstep Live Funded",
+                trade_data_source="csv_import",
+                balance=10_000,
+                account_state="ACTIVE",
+                is_main=True,
+            ),
+            ProjectXTradeEvent(
+                account_id=88062,
+                contract_id="NQU6",
+                symbol="NQU6",
+                side="SELL",
+                size=2,
+                price=27720.25,
+                trade_timestamp=datetime(2026, 7, 28, 13, 45, 17, tzinfo=timezone.utc),
+                trade_date=datetime(2026, 7, 28, tzinfo=timezone.utc).date(),
+                pnl=-3160,
+                fees=3.80,
+                commissions=0,
+                fee_scope="per_side",
+                order_id="2916446935",
+                source_trade_id="2916446935",
+            ),
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        main_module,
+        "_projectx_client_for_user",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("Local account snapshots must not load ProjectX credentials")
+        ),
+    )
+
+    payload = list_projectx_accounts(refresh_provider=False, db=db_session)
+
+    assert payload[0]["balance"] == pytest.approx(6832.40)
 
 
 def test_mixed_accounts_keep_normal_live_routes_entirely_local(db_session, monkeypatch):
@@ -683,7 +714,7 @@ def test_provider_sync_skips_csv_id_collision_and_missing_transition(
 
     assert db_session.query(Account).count() == 3
     assert by_id[88011]["name"] == "Local Live Name"
-    assert by_id[88011]["balance"] is None
+    assert by_id[88011]["balance"] == pytest.approx(43210)
     assert by_id[88011]["can_trade"] is None
     assert by_id[88011]["last_seen_at"] is None
     assert by_id[88011]["account_state"] == "ACTIVE"
@@ -1148,7 +1179,7 @@ def test_archived_live_account_cannot_be_set_main_or_recreated(db_session):
 
     with pytest.raises(HTTPException) as create_exc:
         create_topstep_live_import_target(
-            TopstepLiveAccountCreateIn(account_id=88041, name="Same"),
+            TopstepLiveAccountCreateIn(name="Archived Live"),
             db=db_session,
         )
     assert create_exc.value.status_code == 409

--- a/frontend/src/app/AppShell.compactMode.test.tsx
+++ b/frontend/src/app/AppShell.compactMode.test.tsx
@@ -70,6 +70,8 @@ describe("AppShell compact mode", () => {
   it("places a persisted live-updating dashboard switch immediately after Demo Mode", async () => {
     renderAppShell("/?account=10");
     const demoSwitch = await screen.findByRole("switch", { name: "Demo mode" });
+    expect(screen.getByRole("option", { name: "Test Account" })).not.toBeNull();
+    expect(screen.queryByRole("option", { name: /\b10\b/ })).toBeNull();
     const compactSwitch = screen.getByRole("switch", { name: "Compact Dashboard" });
     const headerContainer = screen.getByRole("banner").firstElementChild as HTMLElement;
     const main = screen.getByRole("main");

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -479,7 +479,7 @@ export function AppShell() {
                       <option key={account.id} value={account.id}>
                         {`${getDemoAccountLabel(account)}${
                           account.trade_data_source === "csv_import"
-                            ? " — Live CSV"
+                            ? ""
                             : account.provider_sync_status === "cached_fallback"
                               ? ` — cached after refresh failure (${formatProviderLastSeen(account.last_seen_at)})`
                               : account.provider_data_stale

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -387,8 +387,8 @@ describe("accountsApi", () => {
 
     await expect(
       accountsApi.createLiveImportAccount({
-        account_id: 88001,
         name: "Topstep Live Funded",
+        starting_balance: 10000,
       }),
     ).resolves.toEqual(account);
 
@@ -396,8 +396,8 @@ describe("accountsApi", () => {
     expect(url).toBe("http://127.0.0.1:8000/api/accounts/import-target");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual({
-      account_id: 88001,
       name: "Topstep Live Funded",
+      starting_balance: 10000,
     });
   });
 

--- a/frontend/src/lib/demoMode.test.ts
+++ b/frontend/src/lib/demoMode.test.ts
@@ -64,6 +64,18 @@ describe("demoMode", () => {
     expect(getDemoAccountLabel(account)).toBe("Demo Copy — Conservative (910002)");
   });
 
+  it("keeps internal routing ids out of Live account labels", () => {
+    setDemoModeEnabled(false);
+
+    expect(
+      getDemoAccountLabel({
+        id: 8_141,
+        name: "TOPX8141",
+        trade_data_source: "csv_import",
+      }),
+    ).toBe("TOPX8141");
+  });
+
   it("formats dummy money values instead of placeholders when enabled", () => {
     setDemoModeEnabled(true);
     const formatSignedCurrency = (value: number) => `${value > 0 ? "+" : value < 0 ? "-" : ""}$${Math.abs(value).toFixed(2)}`;

--- a/frontend/src/lib/demoMode.ts
+++ b/frontend/src/lib/demoMode.ts
@@ -224,8 +224,16 @@ export function getDemoAccountId(accountId: string | number | null | undefined) 
   return `ACCT-${demoOrdinal(accountId)}${stableHash(String(accountId ?? "demo")) % 100}`;
 }
 
-export function getDemoAccountLabel(account: { id: number; name: string; custom_display_name?: string | null }) {
-  return `${getDemoAccountName(account)} (${getDemoAccountId(account.id)})`;
+export function getDemoAccountLabel(account: {
+  id: number;
+  name: string;
+  custom_display_name?: string | null;
+  trade_data_source?: "projectx" | "csv_import";
+}) {
+  const accountName = getDemoAccountName(account);
+  return account.trade_data_source === "csv_import"
+    ? accountName
+    : `${accountName} (${getDemoAccountId(account.id)})`;
 }
 
 export function getDemoUserEmail(email: string | null | undefined) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -228,8 +228,8 @@ export interface AccountTradeRefreshResult {
 }
 
 export interface LiveImportAccountInput {
-  account_id: number;
-  name?: string;
+  name: string;
+  starting_balance: number;
 }
 
 export type TradeImportRowStatus = "new" | "duplicate" | "conflict";

--- a/frontend/src/pages/accounts/AccountsPage.test.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.test.tsx
@@ -79,7 +79,9 @@ describe("AccountsPage local-first management", () => {
 
     renderAccountsPage("/accounts?account=88001");
 
-    expect(await screen.findByRole("button", { name: "Select Live Funded account" })).not.toBeNull();
+    const liveSelection = await screen.findByRole("button", { name: "Select Live Funded account" });
+    expect(liveSelection).not.toBeNull();
+    expect(liveSelection.closest("tr")?.textContent).not.toContain("88001");
     expect(getAccounts).toHaveBeenCalledTimes(1);
     expect(getAccounts).toHaveBeenCalledWith({
       showInactive: true,

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -852,7 +852,9 @@ export function AccountsPage() {
                               <p className="mt-1 text-[11px] font-normal text-rose-300">{renameErrorMessage}</p>
                             ) : null}
                           </td>
-                          <td className="px-3 py-3 text-right text-slate-300">{getDemoAccountId(account.id)}</td>
+                          <td className="px-3 py-3 text-right text-slate-300">
+                            {account.trade_data_source === "csv_import" ? "—" : getDemoAccountId(account.id)}
+                          </td>
                           <td className="px-3 py-3 text-right font-mono text-slate-200">
                             <span className={availableBalance === null ? "font-sans text-amber-300" : undefined}>
                               {formatAccountBalance(account.balance)}

--- a/frontend/src/pages/accounts/components/MergeJournalCard.tsx
+++ b/frontend/src/pages/accounts/components/MergeJournalCard.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../..
 import { Input } from "../../../components/ui/Input";
 import { Select } from "../../../components/ui/Select";
 import { Toggle } from "../../../components/ui/Toggle";
-import { getDemoAccountId, getDemoAccountName } from "../../../lib/demoMode";
+import { getDemoAccountId, getDemoAccountLabel, getDemoAccountName } from "../../../lib/demoMode";
 import type {
   AccountInfo,
   JournalMergeConflictStrategy,
@@ -48,7 +48,9 @@ function formatAccountStateLabel(state: AccountInfo["account_state"]) {
 
 function formatMergeAccountLabel(account: AccountInfo) {
   const stateLabel = formatAccountStateLabel(account.account_state);
-  const accountLabel = `${getDemoAccountName(account)} (#${getDemoAccountId(account.id)})`;
+  const accountLabel = account.trade_data_source === "csv_import"
+    ? getDemoAccountLabel(account)
+    : `${getDemoAccountName(account)} (#${getDemoAccountId(account.id)})`;
   return account.account_state === "ACTIVE"
     ? accountLabel
     : `${accountLabel} - ${stateLabel}`;

--- a/frontend/src/pages/dashboard/components/CompactDashboardCalendar.test.tsx
+++ b/frontend/src/pages/dashboard/components/CompactDashboardCalendar.test.tsx
@@ -9,7 +9,16 @@ afterEach(cleanup);
 
 function props(overrides: Partial<CompactCalendarProps> = {}): CompactCalendarProps {
   return {
-    days: [{ date: "2026-07-01", trade_count: 1, gross_pnl: 25, fees: 0, net_pnl: 25 }],
+    days: [{
+      date: "2026-07-01",
+      trade_count: 1,
+      win_count: 1,
+      loss_count: 0,
+      breakeven_count: 0,
+      gross_pnl: 25,
+      fees: 0,
+      net_pnl: 25,
+    }],
     rangeStartDate: "2026-07-01",
     rangeEndDate: "2026-07-31",
     loading: false,
@@ -35,15 +44,87 @@ describe("CompactDashboardCalendar", () => {
       span.classList.contains("text-app-positive-text")
     ));
     expect(value).not.toBeNull();
-    expect(value?.textContent).toMatch(/^\+\$25(?:\.0+)?$/);
+    expect(value?.textContent).toContain("+$25");
     expect(value?.className).toContain("text-app-positive-text");
-    expect(july1.className).toContain("sm:min-h-12");
-    expect(july1.textContent).toContain("1t");
+    expect(july1.className).toContain("sm:min-h-[72px]");
+    expect(july1.className).toContain("lg:min-h-20");
+    expect(july1.textContent).not.toContain("1t");
+    expect(july1.textContent).not.toContain("1W");
+    expect(july1.textContent).not.toContain("0L");
+    expect(screen.getByText(/1 trade · 1 day/i)).not.toBeNull();
   });
 
   it("renders exactly 42 placeholders while the grid is loading", () => {
     render(<CompactDashboardCalendar {...props({ loading: true })} />);
     const calendar = screen.getByRole("heading", { name: "July 2026" }).closest("section");
-    expect(calendar?.querySelectorAll(".animate-pulse")).toHaveLength(42);
+    const placeholders = calendar?.querySelectorAll(".animate-pulse");
+    expect(placeholders).toHaveLength(42);
+    expect(placeholders?.[0]?.className).toContain("lg:min-h-20");
+  });
+
+  it("shows each row's range-aware weekly P&L on Saturday", () => {
+    render(
+      <CompactDashboardCalendar
+        {...props({
+          days: [
+            { date: "2026-07-01", trade_count: 2, gross_pnl: 100, fees: 0, net_pnl: 100 },
+            { date: "2026-07-02", trade_count: 16, gross_pnl: 6_100, fees: 0, net_pnl: 6_100 },
+            { date: "2026-07-03", trade_count: 1, gross_pnl: 439.2, fees: 0, net_pnl: 439.2 },
+          ],
+          rangeStartDate: "2026-07-02",
+        })}
+      />,
+    );
+
+    const saturday = screen.getByRole("button", {
+      name: /July 4, 2026, no daily P&L, no trades, weekly P&L \+\$6,539\.2 across 17 trades/i,
+    });
+    expect(saturday.textContent).toContain("W");
+    expect(saturday.textContent).toContain("+$6.5K");
+    expect(saturday.textContent).not.toContain("17t");
+  });
+
+  it("keeps Saturday's daily result when also showing its weekly total", () => {
+    render(
+      <CompactDashboardCalendar
+        {...props({
+          days: [
+            { date: "2026-07-02", trade_count: 1, gross_pnl: 100, fees: 0, net_pnl: 100 },
+            { date: "2026-07-04", trade_count: 2, gross_pnl: 25, fees: 0, net_pnl: 25 },
+          ],
+        })}
+      />,
+    );
+
+    const saturday = screen.getByRole("button", {
+      name: /July 4, 2026, \+\$25, 2 trades, weekly P&L \+\$125 across 3 trades/i,
+    });
+    expect(saturday.textContent).toContain("+$25");
+    expect(saturday.textContent).toContain("+$125");
+    expect(saturday.textContent).not.toContain("3t");
+  });
+
+  it("shows an in-range week total when Saturday falls outside the selected range", () => {
+    render(
+      <CompactDashboardCalendar
+        {...props({
+          days: [
+            { date: "2026-07-20", trade_count: 1, gross_pnl: -1_032.2, fees: 0, net_pnl: -1_032.2 },
+            { date: "2026-07-21", trade_count: 2, gross_pnl: -1_068, fees: 0, net_pnl: -1_068 },
+            { date: "2026-07-22", trade_count: 5, gross_pnl: 3_086.2, fees: 0, net_pnl: 3_086.2 },
+          ],
+          rangeStartDate: "2026-07-02",
+          rangeEndDate: "2026-07-22",
+        })}
+      />,
+    );
+
+    const saturday = screen.getByRole("gridcell", {
+      name: /July 25, 2026, outside selected range, weekly P&L \+\$986 across 8 trades/i,
+    });
+    expect(saturday.textContent).toContain("Week");
+    expect(saturday.textContent).toContain("+$986");
+    expect(saturday.textContent).not.toContain("8t");
+    expect(screen.queryByRole("button", { name: /July 25, 2026/i })).toBeNull();
   });
 });

--- a/frontend/src/pages/dashboard/components/CompactDashboardCalendar.tsx
+++ b/frontend/src/pages/dashboard/components/CompactDashboardCalendar.tsx
@@ -109,6 +109,11 @@ interface CalendarCell {
   point: AccountPnlCalendarDay | null;
 }
 
+interface WeeklySummary {
+  tradeCount: number;
+  netPnl: number;
+}
+
 export interface CompactCalendarProps {
   days: readonly AccountPnlCalendarDay[];
   rangeStartDate?: string;
@@ -242,6 +247,48 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
     }
     return rows;
   }, [cells]);
+  const weeklySummaries = useMemo<WeeklySummary[]>(() => (
+    weeks.map((week) => week.reduce<WeeklySummary>((summary, cell) => {
+      if (
+        !cell.date
+        || !cell.point
+        || (rangeStartDate && cell.date < rangeStartDate)
+        || (rangeEndDate && cell.date > rangeEndDate)
+      ) {
+        return summary;
+      }
+      return {
+        tradeCount: summary.tradeCount + cell.point.trade_count,
+        netPnl: summary.netPnl + cell.point.net_pnl,
+      };
+    }, { tradeCount: 0, netPnl: 0 }))
+  ), [rangeEndDate, rangeStartDate, weeks]);
+  const weeklySummaryBySaturday = useMemo(() => {
+    const summaries = new Map<string, WeeklySummary>();
+    weeks.forEach((week, weekIndex) => {
+      const saturday = week[6];
+      const summary = weeklySummaries[weekIndex];
+      if (saturday?.date && summary.tradeCount > 0) {
+        summaries.set(saturday.date, summary);
+      }
+    });
+    return summaries;
+  }, [weeklySummaries, weeks]);
+  const visibleSummary = useMemo(() => cells.reduce((summary, cell) => {
+    if (
+      !cell.date
+      || !cell.point
+      || (rangeStartDate && cell.date < rangeStartDate)
+      || (rangeEndDate && cell.date > rangeEndDate)
+    ) {
+      return summary;
+    }
+    return {
+      tradingDays: summary.tradingDays + 1,
+      tradeCount: summary.tradeCount + cell.point.trade_count,
+      netPnl: summary.netPnl + cell.point.net_pnl,
+    };
+  }, { tradingDays: 0, tradeCount: 0, netPnl: 0 }), [cells, rangeEndDate, rangeStartDate]);
   const visibleDates = useMemo(
     () => cells.flatMap((cell) => cell.date ? [cell.date] : []),
     [cells],
@@ -335,7 +382,12 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
   const agendaCells = cells.filter((cell) => (
     cell.date
     && isWithinSelectedRange(cell.date)
-    && (cell.point || journalDays.has(cell.date) || selectedDate === cell.date)
+    && (
+      cell.point
+      || weeklySummaryBySaturday.has(cell.date)
+      || journalDays.has(cell.date)
+      || selectedDate === cell.date
+    )
   ));
   const agendaDates = agendaCells.flatMap((cell) => cell.date ? [cell.date] : []);
   const agendaRovingDate = agendaDates.includes(rovingDate) ? rovingDate : (agendaDates[0] ?? "");
@@ -360,6 +412,11 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
   const selectedJournalDate = selectedDate && isSameUtcMonth(selectedDate, visibleMonth) && journalDays.has(selectedDate)
     ? selectedDate
     : null;
+  const showCalendarFooter = Boolean(
+    journalDaysError
+    || selectedJournalDate
+    || (visibleTradeDays === 0 && !journalDaysError),
+  );
   const today = formatIsoDay(new Date());
 
   return (
@@ -393,16 +450,21 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
         >
           ›
         </button>
-        <h2 id={titleId} className="ml-1 text-sm font-semibold text-app-text" aria-live="polite">
+        <h2 id={titleId} className="ml-1 text-sm font-semibold text-app-text sm:text-base" aria-live="polite">
           {monthFormatter.format(visibleMonth)}
         </h2>
-        <div className="ml-auto">
+        <p className="ml-auto hidden min-w-0 truncate text-xs text-app-muted-text sm:block">
+          <span className={cn("font-semibold", pnlTextClass(visibleSummary.netPnl))}>{formatPnl(visibleSummary.netPnl)}</span>
+          {" · "}{visibleSummary.tradeCount} trade{visibleSummary.tradeCount === 1 ? "" : "s"}
+          {" · "}{visibleSummary.tradingDays} day{visibleSummary.tradingDays === 1 ? "" : "s"}
+        </p>
+        <div className="ml-auto sm:ml-0">
           <InfoPopover
             triggerLabel="P&L calendar"
             align="end"
             label={journalDaysLoading
               ? "Journal markers are still loading."
-              : "Each cell shows net P&L and trade count. A dot marks a linked journal entry. Use arrow keys to move between days."}
+              : "Each cell shows daily net P&L. Saturdays also show the weekly total. A dot marks a linked journal entry. Use arrow keys to move between days."}
           />
         </div>
       </div>
@@ -419,12 +481,12 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
         ) : (
         <div className="min-h-[360px] p-2 sm:min-h-[416px] sm:p-4" role="status" aria-live="polite">
           <span className="sr-only">Loading P&amp;L calendar</span>
-          <div className="mb-1 grid grid-cols-7 gap-px sm:gap-1">
+          <div className="mb-1 grid grid-cols-7 gap-px sm:gap-1.5">
             {weekdayLabels.map((label) => <div key={label} className="py-2 text-center text-xs text-app-muted-text">{label.slice(0, 1)}</div>)}
           </div>
-          <div className="grid grid-cols-7 gap-px sm:gap-1">
+          <div className="grid grid-cols-7 gap-px sm:gap-1.5">
             {Array.from({ length: 42 }, (_, index) => (
-              <div key={index} className="min-h-14 animate-pulse rounded-md bg-app-border/35 motion-reduce:animate-none sm:min-h-12" />
+              <div key={index} className="min-h-16 animate-pulse rounded-md bg-app-border/35 motion-reduce:animate-none sm:min-h-[72px] lg:min-h-20" />
             ))}
           </div>
         </div>
@@ -442,12 +504,16 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
                   }
                   const cellDate = cell.date;
                   const point = cell.point;
+                  const weeklySummary = weeklySummaryBySaturday.get(cellDate) ?? null;
                   const hasJournal = journalDays.has(cellDate);
                   const isSelected = selectedDate === cellDate;
                   const tradeLabel = point
                     ? `${point.trade_count} trade${point.trade_count === 1 ? "" : "s"}`
                     : "no trades";
-                  const accessibleLabel = `${formatLongDate(cellDate)}, ${point ? formatPnl(point.net_pnl) : "no P&L"}, ${tradeLabel}${hasJournal ? ", journal entry" : ""}`;
+                  const weeklyLabel = weeklySummary
+                    ? `, weekly P&L ${formatPnl(weeklySummary.netPnl)} across ${weeklySummary.tradeCount} trade${weeklySummary.tradeCount === 1 ? "" : "s"}`
+                    : "";
+                  const accessibleLabel = `${formatLongDate(cellDate)}, ${point ? formatPnl(point.net_pnl) : "no daily P&L"}, ${tradeLabel}${weeklyLabel}${hasJournal ? ", journal entry" : ""}`;
                   return (
                     <li key={cellDate} className="py-1">
                       <button
@@ -484,11 +550,17 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
                           )}>
                             {point
                               ? formatCompactCurrency(point.net_pnl)
+                              : weeklySummary
+                                ? `Week ${formatCompactCurrency(weeklySummary.netPnl)}`
                               : hasJournal
                                 ? "Journal entry"
                                 : "No trading activity"}
                           </span>
-                          <span className="block truncate text-xs text-app-muted-text">{tradeLabel}</span>
+                          {point && weeklySummary ? (
+                            <span className="block truncate text-xs text-app-muted-text">
+                              Week {formatCompactCurrency(weeklySummary.netPnl)}
+                            </span>
+                          ) : null}
                         </span>
                         {hasJournal ? <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-app-accent" aria-hidden="true" /> : null}
                       </button>
@@ -513,13 +585,13 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
             aria-hidden={useAgendaLayout || undefined}
             className={cn("min-w-0", useAgendaLayout && "hidden")}
           >
-            <div role="row" className="mb-1 grid grid-cols-7 gap-px sm:gap-1">
+            <div role="row" className="mb-1 grid grid-cols-7 gap-px sm:gap-1.5">
               {weekdayLabels.map((label) => (
                 <div
                   key={label}
                   role="columnheader"
                   aria-label={label}
-                  className="py-1.5 text-center text-xs font-semibold uppercase text-app-muted-text"
+                  className="py-1.5 text-center text-xs font-semibold uppercase text-app-muted-text sm:text-sm"
                 >
                   <span className="sm:hidden" aria-hidden="true">{label.slice(0, 1)}</span>
                   <span className="hidden sm:inline" aria-hidden="true">{label}</span>
@@ -527,7 +599,7 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
               ))}
             </div>
             {weeks.map((week, weekIndex) => (
-              <div key={weekIndex} role="row" className="mb-px grid grid-cols-7 gap-px sm:mb-1 sm:gap-1">
+              <div key={weekIndex} role="row" className="mb-px grid grid-cols-7 gap-px sm:mb-1.5 sm:gap-1.5">
                 {week.map((cell, dayIndex) => {
                   if (!cell.date || cell.dayNumber === null) {
                     return (
@@ -535,28 +607,50 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
                         key={`empty-${weekIndex}-${dayIndex}`}
                         role="gridcell"
                         aria-label="Outside current month"
-                        className="min-h-14 rounded-md border border-app-border/25 bg-app-bg/10 sm:min-h-12"
+                        className="min-h-16 rounded-md border border-app-border/25 bg-app-bg/10 sm:min-h-[72px] lg:min-h-20"
                       />
                     );
                   }
                   const cellDate = cell.date;
                   const point = cell.point;
+                  const weeklySummary = dayIndex === 6 ? weeklySummaries[weekIndex] : null;
+                  const showWeeklySummary = weeklySummary !== null && weeklySummary.tradeCount > 0;
                   const isSelected = selectedDate === cellDate;
                   const hasJournal = journalDays.has(cellDate);
                   const tradeLabel = point
                     ? `${point.trade_count} trade${point.trade_count === 1 ? "" : "s"}`
                     : "no trades";
-                  const accessibleLabel = `${formatLongDate(cellDate)}, ${point ? formatPnl(point.net_pnl) : "no P&L"}, ${tradeLabel}${hasJournal ? ", journal entry" : ""}`;
+                  const weeklyLabel = showWeeklySummary
+                    ? `, weekly P&L ${formatPnl(weeklySummary.netPnl)} across ${weeklySummary.tradeCount} trade${weeklySummary.tradeCount === 1 ? "" : "s"}`
+                    : "";
+                  const accessibleLabel = `${formatLongDate(cellDate)}, ${point ? formatPnl(point.net_pnl) : "no daily P&L"}, ${tradeLabel}${weeklyLabel}${hasJournal ? ", journal entry" : ""}`;
                   if (!isWithinSelectedRange(cellDate)) {
                     return (
                       <div
                         key={cellDate}
                         role="gridcell"
                         aria-disabled="true"
-                        aria-label={`${formatLongDate(cellDate)}, outside selected range`}
-                        className="min-h-14 rounded-md border border-app-border/25 bg-app-bg/10 p-1 text-xs text-app-muted-text opacity-45 sm:min-h-12 sm:p-1.5"
+                        aria-label={`${formatLongDate(cellDate)}, outside selected range${weeklyLabel}`}
+                        className={cn(
+                          "flex h-full min-h-16 flex-col rounded-md border border-app-border/25 bg-app-bg/10 p-1.5 text-sm text-app-muted-text sm:min-h-[72px] sm:p-2 lg:min-h-20",
+                          !showWeeklySummary && "opacity-45",
+                        )}
                       >
-                        {cell.dayNumber}
+                        <span className={cn("font-medium", showWeeklySummary && "opacity-45")}>{cell.dayNumber}</span>
+                        {showWeeklySummary ? (
+                          <span className="mt-auto block w-full min-w-0 border-t border-app-border/45 pt-1">
+                            <span className="flex min-w-0 items-baseline gap-1">
+                              <span className="shrink-0 text-[9px] font-semibold uppercase text-app-muted-text sm:text-[10px]" aria-hidden="true">
+                                <span className="lg:hidden">W</span>
+                                <span className="hidden lg:inline">Week</span>
+                              </span>
+                              <span className={cn("min-w-0 truncate text-[11px] font-semibold lg:text-sm", pnlTextClass(weeklySummary.netPnl))}>
+                                <span className="lg:hidden">{formatCompactCurrency(weeklySummary.netPnl)}</span>
+                                <span className="hidden lg:inline">{formatPnl(weeklySummary.netPnl)}</span>
+                              </span>
+                            </span>
+                          </span>
+                        ) : null}
                       </div>
                     );
                   }
@@ -583,7 +677,7 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
                           onDaySelect(isSelected ? null : cellDate);
                         }}
                         className={cn(
-                          "relative flex min-h-14 w-full min-w-0 flex-col overflow-hidden rounded-md border p-1 text-left transition sm:min-h-12 sm:rounded-lg sm:p-1.5",
+                          "relative flex h-full min-h-16 w-full min-w-0 flex-col overflow-hidden rounded-md border p-1.5 text-left transition sm:min-h-[72px] sm:rounded-lg sm:p-2 lg:min-h-20",
                           dayTone(point),
                           isSelected
                             ? "border-app-focus ring-2 ring-app-focus/70"
@@ -591,23 +685,36 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
                           compactFocusRing,
                         )}
                       >
-                        <span className="flex w-full items-start justify-between gap-0.5 text-xs text-app-muted-text">
-                          <span>{cell.dayNumber}</span>
+                        <span className="flex w-full items-start justify-between gap-0.5 text-xs text-app-muted-text sm:text-sm">
+                          <span className="font-medium">{cell.dayNumber}</span>
                           {hasJournal ? (
                             <span className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-app-accent ring-1 ring-app-surface" aria-hidden="true" />
                           ) : null}
                         </span>
                         {point ? (
-                          <>
-                            <span className="mt-auto flex w-full min-w-0 items-center justify-between gap-1">
-                              <span className={cn("min-w-0 truncate text-xs font-semibold", pnlTextClass(point.net_pnl))}>
-                                {formatCompactCurrency(point.net_pnl)}
+                          <span className="mt-auto block w-full min-w-0">
+                            <span className={cn("min-w-0 truncate text-xs font-semibold lg:text-sm", pnlTextClass(point.net_pnl))}>
+                              <span className="lg:hidden">{formatCompactCurrency(point.net_pnl)}</span>
+                              <span className="hidden lg:inline">{formatPnl(point.net_pnl)}</span>
+                            </span>
+                          </span>
+                        ) : null}
+                        {showWeeklySummary ? (
+                          <span className={cn(
+                            "block w-full min-w-0 border-t border-app-border/45 pt-1",
+                            point ? "mt-1" : "mt-auto",
+                          )}>
+                            <span className="flex min-w-0 items-baseline gap-1">
+                              <span className="shrink-0 text-[9px] font-semibold uppercase text-app-muted-text sm:text-[10px]" aria-hidden="true">
+                                <span className="lg:hidden">W</span>
+                                <span className="hidden lg:inline">Week</span>
                               </span>
-                              <span className="hidden shrink-0 text-xs text-app-muted-text sm:inline" aria-hidden="true">
-                                {point.trade_count}t
+                              <span className={cn("min-w-0 truncate text-[11px] font-semibold lg:text-sm", pnlTextClass(weeklySummary.netPnl))}>
+                                <span className="lg:hidden">{formatCompactCurrency(weeklySummary.netPnl)}</span>
+                                <span className="hidden lg:inline">{formatPnl(weeklySummary.netPnl)}</span>
                               </span>
                             </span>
-                          </>
+                          </span>
                         ) : null}
                       </button>
                     </div>
@@ -617,33 +724,35 @@ export const CompactDashboardCalendar = memo(function CompactDashboardCalendar({
             ))}
           </div>
 
-          <div className="mt-3 flex min-h-11 items-center justify-center gap-2">
-            {journalDaysError ? (
-              <p
-                role="status"
-                aria-live="polite"
-                title={`Journal markers unavailable: ${journalDaysError}`}
-                className="inline-flex min-h-11 min-w-0 flex-1 items-center truncate rounded-xl border border-app-warning/35 bg-app-warning/10 px-3 py-2 text-xs text-app-text"
-              >
-                Journal markers unavailable: {journalDaysError}
-              </p>
-            ) : null}
-            {selectedJournalDate ? (
-              <button
-                type="button"
-                className={cn(
-                  "inline-flex min-h-11 min-w-0 flex-1 items-center justify-center rounded-xl border border-app-accent/40 bg-app-accent/10 px-2 text-center text-sm font-semibold text-app-text transition hover:bg-app-accent/15",
-                  compactFocusRing,
-                )}
-                aria-label={`Open journal for ${formatShortDate(selectedJournalDate)}`}
-                onClick={() => onJournalDayOpen(selectedJournalDate)}
-              >
-                Open {formatShortDate(selectedJournalDate)} journal
-              </button>
-            ) : visibleTradeDays === 0 && !journalDaysError ? (
-              <p role="status" className="text-center text-xs text-app-muted-text">No closed trades in this month.</p>
-            ) : null}
-          </div>
+          {showCalendarFooter ? (
+            <div className="mt-3 flex min-h-11 items-center justify-center gap-2">
+              {journalDaysError ? (
+                <p
+                  role="status"
+                  aria-live="polite"
+                  title={`Journal markers unavailable: ${journalDaysError}`}
+                  className="inline-flex min-h-11 min-w-0 flex-1 items-center truncate rounded-xl border border-app-warning/35 bg-app-warning/10 px-3 py-2 text-xs text-app-text"
+                >
+                  Journal markers unavailable: {journalDaysError}
+                </p>
+              ) : null}
+              {selectedJournalDate ? (
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex min-h-11 min-w-0 flex-1 items-center justify-center rounded-xl border border-app-accent/40 bg-app-accent/10 px-2 text-center text-sm font-semibold text-app-text transition hover:bg-app-accent/15",
+                    compactFocusRing,
+                  )}
+                  aria-label={`Open journal for ${formatShortDate(selectedJournalDate)}`}
+                  onClick={() => onJournalDayOpen(selectedJournalDate)}
+                >
+                  Open {formatShortDate(selectedJournalDate)} journal
+                </button>
+              ) : visibleTradeDays === 0 && !journalDaysError ? (
+                <p role="status" className="text-center text-xs text-app-muted-text">No closed trades in this month.</p>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       )}
     </Card>

--- a/frontend/src/pages/dashboard/components/CompactDashboardView.test.tsx
+++ b/frontend/src/pages/dashboard/components/CompactDashboardView.test.tsx
@@ -140,7 +140,7 @@ describe("CompactDashboardView", () => {
     expect(screen.getAllByText("Primary").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Follower").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: /daily/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Daily" }));
     expect(screen.getByRole("img", { name: /Daily P&L chart/i })).toBeTruthy();
     expect(screen.getByText("Daily P&L data")).toBeTruthy();
 
@@ -368,8 +368,11 @@ describe("CompactDashboardView", () => {
     expect(screen.queryByRole("grid")).toBeNull();
     const agenda = screen.getByRole("list", { name: "July 2026 P&L agenda" });
     const agendaButtons = agenda.querySelectorAll("button");
-    expect(agendaButtons).toHaveLength(2);
+    expect(agendaButtons).toHaveLength(3);
     agendaButtons.forEach((button) => expect(button.className).toContain("min-h-11"));
+    expect(within(agenda).getByRole("button", {
+      name: /July 4, 2026.*weekly P&L \+\$70 across 3 trades/i,
+    })).toBeTruthy();
   });
 
   it("marks a single-point cumulative series and provides its value as table data", () => {

--- a/frontend/src/pages/dashboard/components/TradeImportPanel.test.tsx
+++ b/frontend/src/pages/dashboard/components/TradeImportPanel.test.tsx
@@ -260,7 +260,7 @@ describe("TradeImportPanel", () => {
 
     expect(markup).toContain("Loading account...");
     expect(markup).not.toContain("Topstep Live account ID");
-    expect(markup).not.toContain("Account name (optional)");
+    expect(markup).not.toContain("Account name");
     expect(markup).not.toContain("Add Import Account");
     expect(markup).not.toContain("Add or select the Live account before choosing a trade file.");
     expect(markup).not.toContain("Add Live Account");
@@ -269,9 +269,12 @@ describe("TradeImportPanel", () => {
   it("offers manual Live-account onboarding when ProjectX has no account to select", () => {
     const markup = renderToStaticMarkup(<TradeImportPanel accountId={null} />);
 
-    expect(markup).toContain("Topstep Live account ID");
+    expect(markup).not.toContain("Topstep Live account ID");
+    expect(markup).toContain("Account name");
+    expect(markup).toContain("Starting balance");
+    expect(markup).toContain("TOPX8141");
     expect(markup).toContain("Add Import Account");
-    expect(markup).toContain("stay separate from your Express account");
+    expect(markup).toContain("adds imported net P&amp;L to that balance automatically");
     expect(markup).toContain("Add or select the Live account");
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).toMatch(/aria-controls="[^"]+-account-setup"/);
@@ -331,6 +334,8 @@ describe("TradeImportPanel", () => {
     expect(openMarkup).toContain("Existing Live CSV accounts");
     expect(openMarkup).toContain("Live Funded A");
     expect(openMarkup).toContain("Live Funded B");
+    expect(openMarkup).not.toContain("ID 88001");
+    expect(openMarkup).not.toContain("ID 88002");
     expect(openMarkup).not.toContain("Topstep Live account ID");
     expect(openMarkup).not.toContain("Add Import Account");
   });
@@ -343,9 +348,27 @@ describe("TradeImportPanel", () => {
     disclosure.focus();
     await user.keyboard("{Enter}");
     expect(disclosure.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByText("Topstep Live account ID")).not.toBeNull();
+    expect(screen.getByText("Account name")).not.toBeNull();
+    expect(screen.queryByText("Topstep Live account ID")).toBeNull();
     await user.keyboard(" ");
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("creates a Live account from its name without asking for or sending an account ID", async () => {
+    const user = userEvent.setup();
+    const created = liveAccount(8_000_000_000_000_000, "TOPX8141");
+    const create = vi.spyOn(accountsApi, "createLiveImportAccount").mockResolvedValue(created);
+    const onAccountCreated = vi.fn();
+    render(<TradeImportPanel accountId={null} onAccountCreated={onAccountCreated} />);
+
+    await user.type(screen.getByLabelText("Account name"), "TOPX8141");
+    await user.click(screen.getByRole("button", { name: "Add Import Account" }));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith({ name: "TOPX8141", starting_balance: 10000 }),
+    );
+    expect(onAccountCreated).toHaveBeenCalledWith(created);
+    expect(screen.queryByText("Topstep Live account ID")).toBeNull();
   });
 
   it("delegates to the native picker and clears its value for same-file reselection", () => {
@@ -669,20 +692,18 @@ describe("getTradeImportErrorMessage", () => {
     );
   });
 
-  it("explains that a ProjectX account ID cannot be reused for Live CSV", () => {
+  it("explains a retryable name-only Live account creation conflict", () => {
     const error = new ApiError(
       "conflict",
       409,
       null,
       {
-        code: "account_trade_data_source_conflict",
-        current_trade_data_source: "projectx",
-        requested_trade_data_source: "csv_import",
+        code: "live_account_create_conflict_retryable",
       },
     );
 
     expect(getTradeImportErrorMessage(error)).toBe(
-      "That account ID already belongs to an Express/ProjectX account. Enter the separate Topstep Live account ID.",
+      "Another Live account change completed at the same time. Reload accounts and retry.",
     );
   });
 

--- a/frontend/src/pages/dashboard/components/TradeImportPanel.tsx
+++ b/frontend/src/pages/dashboard/components/TradeImportPanel.tsx
@@ -4,7 +4,7 @@ import { Badge } from "../../../components/ui/Badge";
 import { Button } from "../../../components/ui/Button";
 import { Input } from "../../../components/ui/Input";
 import { accountsApi, isApiError } from "../../../lib/api";
-import { getDemoAccountId, getDemoAccountName } from "../../../lib/demoMode";
+import { getDemoAccountName } from "../../../lib/demoMode";
 import { TRADE_IMPORT_FILE_PICKER_REQUESTED_EVENT } from "../../../lib/tradeImportEvents";
 import type {
   AccountInfo,
@@ -434,8 +434,8 @@ export function TradeImportPanel({
   const [creatingAccount, setCreatingAccount] = useState(false);
   const [selectingAccountId, setSelectingAccountId] = useState<number | null>(null);
   const [showAccountForm, setShowAccountForm] = useState(!accountsLoading && accountId === null);
-  const [liveAccountId, setLiveAccountId] = useState("");
   const [liveAccountName, setLiveAccountName] = useState("");
+  const [liveStartingBalance, setLiveStartingBalance] = useState("10000");
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<TradeImportConfirmResult | null>(null);
   const canImport = accountId !== null && tradeDataSource === "csv_import";
@@ -465,7 +465,6 @@ export function TradeImportPanel({
     setRecoveryToken(null);
     setCreatingAccount(false);
     setShowAccountForm(!accountsLoading && accountId === null);
-    setLiveAccountId("");
     setLiveAccountName("");
     setError(null);
     setResult(null);
@@ -493,7 +492,6 @@ export function TradeImportPanel({
       setShowAccountForm(false);
     } else if (accountId !== null && tradeDataSource === "csv_import") {
       setShowAccountForm(false);
-      setLiveAccountId("");
       setLiveAccountName("");
     } else if (accountId === null && !hasLiveAccount) {
       setShowAccountForm(true);
@@ -799,15 +797,18 @@ export function TradeImportPanel({
 
   async function handleCreateLiveAccount(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const normalizedId = liveAccountId.trim();
-    const accountIdValue = Number(normalizedId);
-    if (!/^\d+$/.test(normalizedId) || !Number.isSafeInteger(accountIdValue) || accountIdValue <= 0) {
-      setError("Enter the positive numeric account ID shown by Topstep.");
+    const normalizedName = liveAccountName.trim();
+    if (!normalizedName) {
+      setError("Enter the Live account name.");
       return;
     }
-    const normalizedName = liveAccountName.trim();
     if (normalizedName.length > 120) {
       setError("Live account name must be 120 characters or fewer.");
+      return;
+    }
+    const startingBalance = Number(liveStartingBalance);
+    if (!Number.isFinite(startingBalance) || startingBalance <= 0 || startingBalance > 1_000_000_000) {
+      setError("Enter a starting balance between $0.01 and $1,000,000,000.");
       return;
     }
 
@@ -815,12 +816,12 @@ export function TradeImportPanel({
     setError(null);
     try {
       const account = await accountsApi.createLiveImportAccount({
-        account_id: accountIdValue,
-        ...(normalizedName ? { name: normalizedName } : {}),
+        name: normalizedName,
+        starting_balance: startingBalance,
       });
       await onAccountCreated?.(account);
-      setLiveAccountId("");
       setLiveAccountName("");
+      setLiveStartingBalance("10000");
       setShowAccountForm(false);
     } catch (nextError) {
       setError(getTradeImportErrorMessage(nextError));
@@ -980,7 +981,7 @@ export function TradeImportPanel({
                         ? "Selecting..."
                         : selected
                           ? `${getDemoAccountName(account)} · Selected`
-                          : `${getDemoAccountName(account)} · ID ${getDemoAccountId(account.id)}`}
+                          : getDemoAccountName(account)}
                     </Button>
                   );
                 })}
@@ -990,41 +991,42 @@ export function TradeImportPanel({
 
           {!hasLiveAccount ? (
             <form
-              className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto] md:items-end"
+              className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,0.65fr)_auto] md:items-end"
               onSubmit={(event) => void handleCreateLiveAccount(event)}
             >
               <label className="space-y-1">
                 <span className="block text-[10px] font-medium uppercase tracking-[0.12em] text-app-muted">
-                  Topstep Live account ID
-                </span>
-                <Input
-                  value={liveAccountId}
-                  inputMode="numeric"
-                  autoComplete="off"
-                  placeholder="e.g. 88001"
-                  disabled={creatingAccount}
-                  onChange={(event) => setLiveAccountId(event.target.value)}
-                />
-              </label>
-              <label className="space-y-1">
-                <span className="block text-[10px] font-medium uppercase tracking-[0.12em] text-app-muted">
-                  Account name (optional)
+                  Account name
                 </span>
                 <Input
                   value={liveAccountName}
                   maxLength={120}
                   autoComplete="off"
-                  placeholder="Topstep Live Funded"
+                  placeholder="TOPX8141"
                   disabled={creatingAccount}
                   onChange={(event) => setLiveAccountName(event.target.value)}
                 />
               </label>
-              <Button type="submit" size="sm" disabled={creatingAccount || !liveAccountId.trim()}>
+              <label className="space-y-1">
+                <span className="block text-[10px] font-medium uppercase tracking-[0.12em] text-app-muted">
+                  Starting balance
+                </span>
+                <Input
+                  type="number"
+                  min="0.01"
+                  max="1000000000"
+                  step="0.01"
+                  value={liveStartingBalance}
+                  inputMode="decimal"
+                  disabled={creatingAccount}
+                  onChange={(event) => setLiveStartingBalance(event.target.value)}
+                />
+              </label>
+              <Button type="submit" size="sm" disabled={creatingAccount || !liveAccountName.trim()}>
                 {creatingAccount ? "Adding..." : "Add Import Account"}
               </Button>
               <p className="text-[10px] text-app-muted-strong md:col-span-3">
-                Topstep exports do not include an account ID. Enter the Live account number so imported trades stay separate
-                from your Express account.
+                Enter the account name and opening balance shown by Topstep. TopSignal adds imported net P&amp;L to that balance automatically.
               </p>
             </form>
           ) : null}

--- a/frontend/src/pages/dashboard/components/tradeImportErrors.ts
+++ b/frontend/src/pages/dashboard/components/tradeImportErrors.ts
@@ -32,8 +32,8 @@ function getDetailMessage(detail: unknown): string | null {
   }
 
   const record = detail as Record<string, unknown>;
-  if (record.code === "account_trade_data_source_conflict") {
-    return "That account ID already belongs to an Express/ProjectX account. Enter the separate Topstep Live account ID.";
+  if (record.code === "live_account_create_conflict_retryable") {
+    return "Another Live account change completed at the same time. Reload accounts and retry.";
   }
   const missingColumns = record.missing_columns;
   if (Array.isArray(missingColumns)) {


### PR DESCRIPTION
## Summary
- improve the compact dashboard calendar and responsive agenda presentation
- simplify Live CSV account creation with generated internal IDs and opening balances
- calculate Live account balances from imported net P&L
- preserve the latest ProjectX freshness and error-state hardening from `main`

## Verification
- `python -m pytest` — 867 passed
- `npm test -- --run` — 708 passed
- `npm run build`
- `npm run lint`
- `npm run test:dev-scripts` — 2 passed